### PR TITLE
Fix workgroup calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `SizeOverLifetimeModifier`.
 
+### Fixed
+
+- Fixed depth sorting of particles relative to opaque objects. Particles are now correctly hidden when behind opaque objects.
+- Fixed truncation in compute workgroup count preventing update of some particles, and in degenerate cases (`capacity < 64`) completely disabling update.
+
 ## [0.1.1] 2022-02-15
 
 ### Fixed

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1700,7 +1700,7 @@ impl Node for ParticleUpdateNode {
 
                         let item_size = batch.item_size;
                         let item_count = batch.slice.end - batch.slice.start;
-                        let workgroup_count = item_count / 64;
+                        let workgroup_count = (item_count + 63) / 64;
 
                         let spawner_base = batch.spawner_base;
                         let buffer_offset = batch.slice.start;


### PR DESCRIPTION
Ensure enough workgroups are dispatched to process all particles,
rounding up to the number of particles to avoid truncating the last few
ones.