### PR TITLE
Make `GradientKey::ratio` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `SizeOverLifetimeModifier`.
 - Add `PositionCircleModifier` to allow spawning from a circle or disc.
 - Revamped spawning system:
-    - `SpawnMode` is gone; `Spawner`s are constructed with associated functions `new`, `once`, `rate`, and `burst`.
-    - Spawners can be reset with `Spawner::reset`. This gives control over when to spawn a burst of particles.
-    - Spawners can be activated or deactivated with `Spawner::set_active`.
-    - `ParticleEffectBundle`s can be initialized with a spawner with `ParticleEffectBundle::with_spawner`.
+  - `SpawnMode` is gone; `Spawner`s are constructed with associated functions `new`, `once`, `rate`, and `burst`.
+  - Spawners can be reset with `Spawner::reset`. This gives control over when to spawn a burst of particles.
+  - Spawners can be activated or deactivated with `Spawner::set_active`.
+  - `ParticleEffectBundle`s can be initialized with a spawner with `ParticleEffectBundle::with_spawner`.
 
 ### Fixed
 
 - Fixed depth sorting of particles relative to opaque objects. Particles are now correctly hidden when behind opaque objects.
 - Fixed truncation in compute workgroup count preventing update of some particles, and in degenerate cases (`capacity < 64`) completely disabling update.
+- Made the `GradientKey<T>::ratio` field private to avoid any modification via `Gradient<T>::keys_mut()` which would corrupt the internal sorting of keys.
 
 ## [0.1.1] 2022-02-15
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -92,7 +92,7 @@ impl ShaderCode for Gradient<Vec2> {
                 format!(
                     "let t{0} = {1};\nlet v{0} = vec2<f32>({2}, {3});",
                     index,
-                    key.ratio.to_float_string(),
+                    key.ratio().to_float_string(),
                     key.value.x.to_float_string(),
                     key.value.y.to_float_string()
                 )
@@ -135,7 +135,7 @@ impl ShaderCode for Gradient<Vec4> {
                 format!(
                     "let t{0} = {1};\nlet c{0} = vec4<f32>({2}, {3}, {4}, {5});",
                     index,
-                    key.ratio.to_float_string(),
+                    key.ratio().to_float_string(),
                     key.value.x.to_float_string(),
                     key.value.y.to_float_string(),
                     key.value.z.to_float_string(),


### PR DESCRIPTION
Make the `GradientKey::ratio` field private, and add a `ratio()` read-only
accessor, to prevent the user from modifying the ratio of a key already
inserted into a `Gradient` and break the internal sorting.