### PR TITLE
Rename float trait to WGSL and impl vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Spawners can be reset with `Spawner::reset`. This gives control over when to spawn a burst of particles.
   - Spawners can be activated or deactivated with `Spawner::set_active`.
   - `ParticleEffectBundle`s can be initialized with a spawner with `ParticleEffectBundle::with_spawner`.
+- Implemented `ToWgslFloat` for `Vec2` / `Vec3` / `Vec4`.
+
+### Changed
+
+- Renamed the `ToWgslFloat` trait into `ToWgslString`, and its `to_float_string()` method into `to_wgsl_string()`. Also made the trait public.
 
 ### Fixed
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -33,7 +33,7 @@ use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::{borrow::Cow, cmp::Ordering, num::NonZeroU64, ops::Range};
 
-use crate::{asset::EffectAsset, Gradient, ParticleEffect, ToWgslFloat};
+use crate::{asset::EffectAsset, Gradient, ParticleEffect, ToWgslString};
 
 mod compute_cache;
 mod effect_cache;
@@ -90,11 +90,10 @@ impl ShaderCode for Gradient<Vec2> {
             .enumerate()
             .map(|(index, key)| {
                 format!(
-                    "let t{0} = {1};\nlet v{0} = vec2<f32>({2}, {3});",
+                    "let t{0} = {1};\nlet v{0} = {2};",
                     index,
-                    key.ratio().to_float_string(),
-                    key.value.x.to_float_string(),
-                    key.value.y.to_float_string()
+                    key.ratio().to_wgsl_string(),
+                    key.value.to_wgsl_string()
                 )
             })
             .fold("// Gradient\n".into(), |s, key| s + &key + "\n");
@@ -133,13 +132,10 @@ impl ShaderCode for Gradient<Vec4> {
             .enumerate()
             .map(|(index, key)| {
                 format!(
-                    "let t{0} = {1};\nlet c{0} = vec4<f32>({2}, {3}, {4}, {5});",
+                    "let t{0} = {1};\nlet c{0} = {2};",
                     index,
-                    key.ratio().to_float_string(),
-                    key.value.x.to_float_string(),
-                    key.value.y.to_float_string(),
-                    key.value.z.to_float_string(),
-                    key.value.w.to_float_string()
+                    key.ratio().to_wgsl_string(),
+                    key.value.to_wgsl_string()
                 )
             })
             .fold("// Gradient\n".into(), |s, key| s + &key + "\n");


### PR DESCRIPTION
Rename the `ToWgslFloat` trait into `ToWgslString` to make it more
generic, and implement it for `Vec2` / `Vec3` / `Vec4` to make it easier
to format vectors. Also rename the `to_float_string()` trait method into
`to_wgsl_string()` for consistency.