### PR TITLE
Added support for random velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Spawners can be activated or deactivated with `Spawner::set_active`.
   - `ParticleEffectBundle`s can be initialized with a spawner with `ParticleEffectBundle::with_spawner`.
 - Implemented `ToWgslFloat` for `Vec2` / `Vec3` / `Vec4`.
+- Implemented `ToWgslFloat` for `Value<f32>`.
 
 ### Changed
 
 - Renamed the `ToWgslFloat` trait into `ToWgslString`, and its `to_float_string()` method into `to_wgsl_string()`. Also made the trait public.
+- Position modifiers now use `Value<f32>` for velocity to allow for random velocity.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ cargo run --example spawn --features="bevy/bevy_winit"
     - [ ] generic mesh / point cloud (?)
   - [ ] Random position offset
   - [x] Constant velocity
-  - [ ] Random velocity
+  - [x] Random velocity
   - [ ] Constant color
   - [ ] Random color
 - Update

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -1,5 +1,5 @@
-//! A circle bounces around in a box and spawns particles
-//! when it hits the wall.
+//! A circle bobs up and down in the water,
+//! spawning square bubbles when in the water.
 //!
 use bevy::{
     prelude::*,

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -90,7 +90,7 @@ fn setup(
         }
         .init(PositionSphereModifier {
             radius: 0.05,
-            speed: 0.1,
+            speed: 0.1.into(),
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,4 +1,4 @@
-//! Example of using the circle spawner.
+//! Example of using the circle spawner with random velocity.
 //! A sphere spawns dust in a circle.
 
 use bevy::{
@@ -64,7 +64,7 @@ fn setup(
             center: Vec3::Y * 0.1,
             axis: Vec3::Y,
             radius: 0.4,
-            speed: 1.0,
+            speed: Value::Uniform((1.0, 1.5)),
             dimension: ShapeDimension::Surface,
         })
         .render(ParticleTextureModifier {

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -77,7 +77,7 @@ fn setup(
             center: Vec3::ZERO,
             radius: 2.,
             dimension: ShapeDimension::Surface,
-            speed: 6.,
+            speed: 6.0.into(),
         })
         .update(AccelModifier {
             accel: Vec3::new(0., -3., 0.),
@@ -155,7 +155,7 @@ fn setup(
             center: Vec3::ZERO,
             radius: 5.,
             dimension: ShapeDimension::Volume,
-            speed: 2.,
+            speed: 2.0.into(),
         })
         .update(AccelModifier {
             accel: Vec3::new(0., 5., 0.),

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -95,7 +95,7 @@ fn setup(
         }
         .init(PositionSphereModifier {
             radius: BALL_RADIUS,
-            speed: 0.2,
+            speed: 0.2.into(),
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,4 +276,12 @@ mod tests {
         let s = Vec4::new(1., 2., -1., 2.).to_wgsl_string();
         assert_eq!(s, "vec4<f32>(1., 2., -1., 2.)");
     }
+
+    #[test]
+    fn to_wgsl_value_f32() {
+        let s = Value::Single(1.0_f32).to_wgsl_string();
+        assert_eq!(s, "1.");
+        let s = Value::Uniform((1.0_f32, 2.0_f32)).to_wgsl_string();
+        assert_eq!(s, "rand() * (2. - 1.) + 1.");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,9 @@ impl ToWgslString for Value<f32> {
             Self::Single(x) => x.to_wgsl_string(),
             Self::Uniform((a, b)) => format!(
                 "rand() * ({1} - {0}) + {0}",
-                a,
-                b
-            )
+                a.to_wgsl_string(),
+                b.to_wgsl_string(),
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //!         center: Vec3::ZERO,
 //!         radius: 2.,
 //!         dimension: ShapeDimension::Surface,
-//!         speed: 6.,
+//!         speed: 6.0.into(),
 //!     })
 //!     // Every frame, add a gravity-like acceleration downward
 //!     .update(AccelModifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,19 @@ impl ToWgslString for Vec4 {
     }
 }
 
+impl ToWgslString for Value<f32> {
+    fn to_wgsl_string(&self) -> String {
+        match self {
+            Self::Single(x) => x.to_wgsl_string(),
+            Self::Uniform((a, b)) => format!(
+                "rand() * ({1} - {0}) + {0}",
+                a,
+                b
+            )
+        }
+    }
+}
+
 /// Visual effect made of particles.
 ///
 /// The particle effect component represent a single instance of a visual effect. The

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use crate::{
     asset::{InitLayout, RenderLayout, UpdateLayout},
     gradient::Gradient,
-    ToWgslString,
+    ToWgslString, Value,
 };
 
 /// Trait to customize the initializing of newly spawned particles.
@@ -50,7 +50,7 @@ pub struct PositionCircleModifier {
     /// The circle radius.
     pub radius: f32,
     /// The radial speed of the particles on spawn.
-    pub speed: f32,
+    pub speed: Value<f32>,
     /// The shape dimension to spawn from.
     pub dimension: ShapeDimension,
 }
@@ -121,7 +121,7 @@ pub struct PositionSphereModifier {
     /// The sphere radius.
     pub radius: f32,
     /// The radial speed of the particles on spawn.
-    pub speed: f32,
+    pub speed: Value<f32>,
     /// The shape dimension to spawn from.
     pub dimension: ShapeDimension,
 }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -9,6 +9,12 @@ pub enum Value<T: Copy> {
     Uniform((T, T)),
 }
 
+impl<T: Copy + Default> Default for Value<T> {
+    fn default() -> Self {
+        Self::Single(T::default())
+    }
+}
+
 impl<T: Copy> Value<T> {
     /// Sample the value.
     pub fn sample(&self) -> T {


### PR DESCRIPTION
Particles can now start with a random velocity in the radial direction. I separated this from randomness of spawner parameters because that would require an RNG to maintained and passed around in the CPU, while this just needed a small shader modification.