### PR TITLE
Tighter Bevy dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Tighter set of dependencies, removing the general `bevy/render` and instead depending on `bevy/bevy_core_pipeline` and `bevy/bevy_render` only.
+
 ## [0.1.2] 2022-04-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "1.3"
 [dependencies.bevy]
 version = "0.6"
 default-features = false
-features = [ "render" ]
+features = [ "bevy_core_pipeline", "bevy_render" ]
 
 [dev-dependencies]
 bevy-inspector-egui = "0.8"
@@ -36,37 +36,35 @@ smooth-bevy-cameras = "0.2"
 
 [[example]]
 name = "spawn"
-required-features = [ "bevy/bevy_winit", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "random"
-required-features = [ "bevy/bevy_winit", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "gradient"
-required-features = [ "bevy/bevy_winit", "bevy/png", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "circle"
-required-features = [ "bevy/bevy_winit", "bevy/png", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "spawn_on_command"
-required-features = [ "bevy/bevy_winit", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "activate"
-required-features = [ "bevy/bevy_winit", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "force_field"
-required-features = [ "bevy/bevy_winit", "3d" ]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "2d"
-required-features = [ "bevy/bevy_winit", "2d" ]
-
-# [[example]]
+required-features = [ "bevy/bevy_winit", "bevy/bevy_sprite", "2d" ]
 
 [workspace]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See the [`examples/`](https://github.com/djeedai/bevy_hanabi/examples) folder.
 Animate an emitter by moving its `Transform` component, and emit textured quad particles with a `ColorOverLifetimeModifier`.
 
 ```shell
-cargo run --example gradient --features="bevy/bevy_winit bevy/png"
+cargo run --example gradient --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
 ```
 
 ![gradient](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/gradient.gif)
@@ -118,17 +118,25 @@ cargo run --example gradient --features="bevy/bevy_winit bevy/png"
 This example demonstrates the force field modifier `ForceFieldModifier`, which allows creating some attraction and repulsion sources affecting the motion of the particles.
 
 ```shell
-cargo run --example force_field --features="bevy/bevy_winit"
+cargo run --example force_field --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 ```
 
 ![force_field](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/force_field.gif)
+
+### 2D
+
+This example shows how to use 🎆 Hanabi with a 2D camera.
+
+```shell
+cargo run --example 2d --features="bevy/bevy_winit bevy/bevy_sprite 2d"
+```
 
 ### Activate
 
 This example demonstrates manual activation and deactivation of a spawner, from code (CPU). The circle bobs up and down in the water, spawning square bubbles when in the water only.
 
 ```shell
-cargo run --example activate --features="bevy/bevy_winit"
+cargo run --example activate --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 ```
 
 ![activate](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/activate.gif)
@@ -144,7 +152,7 @@ This example demonstrates three spawn modes:
 It also shows the applying of constant force (downward gravity-like, or upward smoke-style).
 
 ```shell
-cargo run --example spawn --features="bevy/bevy_winit"
+cargo run --example spawn --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 ```
 
 ![spawn](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/spawn.gif)
@@ -154,7 +162,7 @@ cargo run --example spawn --features="bevy/bevy_winit"
 This example demonstrates how to emit a burst of particles when an event occurs. This gives total control of the spawning to the user code.
 
 ```shell
-cargo run --example spawn_on_command --features="bevy/bevy_winit"
+cargo run --example spawn_on_command --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 ```
 
 ![spawn](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/spawn_on_command.gif)
@@ -164,7 +172,7 @@ cargo run --example spawn_on_command --features="bevy/bevy_winit"
 This example demonstrates the `circle` spawner type, which emits particles along a circle perimeter or a disk surface. This allows for example simulating a dust ring around an object colliding with the ground.
 
 ```shell
-cargo run --example circle --features="bevy/bevy_winit bevy/png"
+cargo run --example circle --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
 ```
 
 ![circle](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/circle.gif)
@@ -174,7 +182,7 @@ cargo run --example circle --features="bevy/bevy_winit bevy/png"
 This example spawns particles with randomized parameters.
 
 ```shell
-cargo run --example random --features="bevy/bevy_winit"
+cargo run --example random --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 ```
 
 ![spawn](https://raw.githubusercontent.com/djeedai/bevy_hanabi/471669f735f202d3877969e25c488e5d74fc3393/examples/random.gif)

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -15,7 +15,7 @@ use bevy::{
         system::{lifetimeless::*, SystemState},
     },
     log::{trace, warn},
-    math::{const_vec3, Mat4, Vec2, Vec3, Vec4Swizzles},
+    math::{const_vec3, Mat4, Rect, Vec2, Vec3, Vec4Swizzles},
     reflect::TypeUuid,
     render::{
         color::Color,
@@ -28,7 +28,6 @@ use bevy::{
         view::{ComputedVisibility, ExtractedView, ViewUniform, ViewUniformOffset, ViewUniforms},
         RenderWorld,
     },
-    sprite::Rect,
     transform::components::GlobalTransform,
     utils::{HashMap, HashSet},
 };

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,6 +4,7 @@
 use bevy::core_pipeline::Transparent2d as Transparent;
 #[cfg(feature = "3d")]
 use bevy::core_pipeline::Transparent3d as Transparent;
+
 use bevy::{
     asset::{AssetEvent, Assets, Handle, HandleId, HandleUntyped},
     core::{cast_slice, FloatOrd, Pod, Time, Zeroable},
@@ -12,7 +13,7 @@ use bevy::{
         system::{lifetimeless::*, SystemState},
     },
     log::trace,
-    math::{const_vec3, Mat4, Vec2, Vec3, Vec4, Vec4Swizzles},
+    math::{const_vec3, Mat4, Rect, Vec2, Vec3, Vec4, Vec4Swizzles},
     reflect::TypeUuid,
     render::{
         color::Color,
@@ -25,7 +26,6 @@ use bevy::{
         view::{ComputedVisibility, ExtractedView, ViewUniform, ViewUniformOffset, ViewUniforms},
         RenderWorld,
     },
-    sprite::Rect,
     transform::components::GlobalTransform,
     utils::{HashMap, HashSet},
 };
@@ -641,7 +641,7 @@ pub struct ExtractedEffect {
     force_field: [ForceFieldParam; FFNUM],
     /// Particles tint to modulate with the texture image.
     pub color: Color,
-    pub rect: Rect,
+    pub rect: Rect<f32>,
     // Texture to use for the sprites of the particles of this effect.
     //pub image: Handle<Image>,
     pub has_image: bool, // TODO -> use flags
@@ -853,10 +853,12 @@ pub(crate) fn extract_effects(
                     accel,
                     force_field,
                     rect: Rect {
-                        min: Vec2::ZERO,
-                        max: Vec2::new(0.2, 0.2), // effect
-                                                  //.custom_size
-                                                  //.unwrap_or_else(|| Vec2::new(size.width as f32, size.height as f32)),
+                        left: -0.1,
+                        top: -0.1,
+                        right: 0.1,
+                        bottom: 0.1, // effect
+                                     //.custom_size
+                                     //.unwrap_or_else(|| Vec2::new(size.width as f32, size.height as f32)),
                     },
                     has_image: asset.render_layout.particle_texture.is_some(),
                     image_handle_id: asset


### PR DESCRIPTION
Update the library to use tighter Bevy depedencies, removing the general
`bevy/render` and instead depending on `bevy/bevy_core_pipeline` and
`bevy/bevy_render` only.