### PR TITLE
Fix missing `bytemuck` derive feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tighter set of dependencies, removing the general `bevy/render` and instead depending on `bevy/bevy_core_pipeline` and `bevy/bevy_render` only.
 
+### Fixed
+
+- Fix missing `derive` feature in `bytemuck` dependency occasionally causing build errors.
+
 ## [0.1.2] 2022-04-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["examples/*.gif", ".github"]
 2d = []
 
 [dependencies]
-bytemuck = "1.5"
+bytemuck = { version = "1.5", features = ["derive"] }
 rand = "0.8"
 rand_pcg = "0.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Add the `derive` feature to the `bytemuck` dependency, which used to
build without but is having troubles now and confuses the Rust compiler
unless explicitly added, for some reason. Since this looks more correct,
and probably shouldn't have worked before, add the feature.