### PR TITLE
Switch to additive `2d`/`3d` features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        dimensions: [2d, 3d]
+        dimensions: [2d, 3d, all]
         toolchain: [stable, nightly]
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -46,15 +46,21 @@ jobs:
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
         if: runner.os == 'linux'
       - name: Build & run tests
-        run: cargo test --features ${{ matrix.dimensions }}
+        run: cargo test --no-default-features --features ${{ matrix.dimensions }}
         env:
           CARGO_INCREMENTAL: 0
+        if: matrix.dimensions != 'all'
+      - name: Build & run tests
+        run: cargo test --all-features
+        env:
+          CARGO_INCREMENTAL: 0
+        if: matrix.dimensions == 'all'
 
   coverage:
     name: Coverage
     strategy:
       matrix:
-        dimensions: [2d, 3d]
+        dimensions: [2d, 3d, all]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -91,8 +97,14 @@ jobs:
           RUST_BACKTRACE=1 cargo install --version 0.19.1 cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace --features ${{ matrix.dimensions }}
+          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace --no-default-features --features ${{ matrix.dimensions }}
           ls -la
+        if: matrix.dimensions != 'all'
+      - name: Generate code coverage
+        run: |
+          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace --all--features
+          ls -la
+        if: matrix.dimensions == 'all'
       - name: Upload code coverage
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,6 @@ jobs:
 
   coverage:
     name: Coverage
-    strategy:
-      matrix:
-        dimensions: [2d, 3d, all]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -77,7 +74,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-build-${{ matrix.dimensions }}-stable-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-build-all-stable-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -97,14 +94,8 @@ jobs:
           RUST_BACKTRACE=1 cargo install --version 0.19.1 cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace --no-default-features --features ${{ matrix.dimensions }}
+          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace --all-features
           ls -la
-        if: matrix.dimensions != 'all'
-      - name: Generate code coverage
-        run: |
-          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace --all--features
-          ls -la
-        if: matrix.dimensions == 'all'
       - name: Upload code coverage
         uses: coverallsapp/github-action@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Switch to Bevy v0.7.
+- Changed features `2d` and `3d` to be purely additive. They are now both active by default, allowing to render through both 2D and 3D cameras at the same time. Users can optionally select either of those exclusively via the `--no-default-features --features='2d'` options (or similar for 3D), as an optimization for applications using only one of the two codepaths.
 - Tighter set of dependencies, removing the general `bevy/render` and instead depending on `bevy/bevy_core_pipeline` and `bevy/bevy_render` only.
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ readme = "README.md"
 exclude = ["examples/*.gif", ".github"]
 
 [features]
-3d = []
+default = [ "2d", "3d" ]
 2d = []
+3d = []
 
 [dependencies]
 bytemuck = { version = "1.5", features = ["derive"] }
@@ -31,8 +32,7 @@ default-features = false
 features = [ "bevy_core_pipeline", "bevy_render" ]
 
 [package.metadata.docs.rs]
-# Document only 3D by default. There's no public API difference anyway.
-features = [ "3d" ]
+all-features = true
 
 #[dev-dependencies]
 #bevy-inspector-egui = "0.8"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Hanabi particle system is a modern GPU-based particle system for the Bevy ga
 
 ## Usage
 
-The 🎆 Bevy Hanabi plugin is compatible with Bevy >= v0.6; see the list of compatible versions below.
+The 🎆 Bevy Hanabi plugin is compatible with Bevy >= v0.6; see [Compatible Bevy versions](#compatible-bevy-versions).
 
 ### Add the dependency
 
@@ -25,10 +25,10 @@ Add the `bevy_hanabi` dependency to `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy_hanabi = { version = "0.2", features = ["3d"] }
+bevy_hanabi = "0.2"
 ```
 
-If you're using a 2D camera, add the `2d` feature instead.
+See also [Features](#features) below for the list of supported features.
 
 ### System setup
 
@@ -227,19 +227,38 @@ cargo run --example random --features="bevy/bevy_winit bevy/bevy_pbr 3d"
   - [ ] Face camera
   - [ ] Face constant direction
 - Render
-  - [x] Quad (sprite)
+  - [x] Quad
     - [x] Textured
   - [ ] Generic 3D mesh
   - [ ] Deformation
     - [ ] Velocity (trail)
-  - [x] 3D camera support
-  - [x] 2D camera support
+  - [x] Camera support
+    - [x] 2D cameras ([`Camera2d`](https://docs.rs/bevy/0.7.0/bevy/render/camera/struct.Camera2d.html)) only
+    - [x] 3D cameras ([`Camera3d`](https://docs.rs/bevy/0.7.0/bevy/render/camera/struct.Camera3d.html)) only
+    - [x] Simultaneous dual 2D/3D cameras
 - Debug
   - [x] GPU debug labels / groups
   - [ ] Debug visualization
     - [ ] Position magnitude
     - [ ] Velocity magnitude
     - [ ] Age / lifetime
+
+## Features
+
+🎆 Bevy Hanabi supports the following features:
+
+| Feature | Default | Description |
+|---|:-:|---|
+| `2d` | ✔ | Enable rendering through 2D cameras ([`Camera2d`](https://docs.rs/bevy/0.7.0/bevy/render/camera/struct.Camera2d.html)) |
+| `3d` | ✔ | Enable rendering through 3D cameras ([`Camera3d`](https://docs.rs/bevy/0.7.0/bevy/render/camera/struct.Camera3d.html)) |
+
+For optimization purpose, users of a single type of camera can disable the other type by skipping default features in their `Cargo.toml`. For example to use only the 3D mode:
+
+```toml
+bevy_hanabi = { version = "0.2", default-features = false, features = [ "3d" ] }
+```
+
+There is currently no support for `CameraUi`. If you feel you need this feature, please [open a GitHub issue](https://github.com/djeedai/bevy_hanabi/issues/new) explaining your use case and why the `Camera2d` and `Camera3d` options cannot be used.
 
 ## Compatible Bevy versions
 

--- a/release.md
+++ b/release.md
@@ -4,11 +4,14 @@
 - Update `Cargo.toml` with version
 - Update `README.md` and other images to point to github raw content at commit SHA1 of current HEAD
 - `cargo fmt --all`
-- `cargo build --features="2d"`
-- `cargo build --features="3d"`
-- `cargo clippy --workspace --all-targets --features="2d" -- -D warnings`
-- `cargo clippy --workspace --all-targets --features="3d" -- -D warnings`
-- `cargo test --features="2d"`
-- `cargo test --features="3d"`
-- `cargo +nightly doc --no-deps --features="3d"` (for `docs.rs`)
-- `cargo +nightly build --features="3d"` (for `docs.rs`)
+- `cargo build`
+- `cargo build --no-default-features --features="2d"`
+- `cargo build --no-default-features --features="3d"`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo clippy --workspace --all-targets --no-default-features --features="2d" -- -D warnings`
+- `cargo clippy --workspace --all-targets --no-default-features --features="3d" -- -D warnings`
+- `cargo test`
+- `cargo test --no-default-features --features="2d"`
+- `cargo test --no-default-features --features="3d"`
+- `cargo +nightly doc --no-deps --all-features` (for `docs.rs`)
+- `cargo +nightly build --all-features` (for `docs.rs`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,6 @@ pub use spawn::{Spawner, Value};
 
 #[cfg(not(any(feature = "2d", feature = "3d")))]
 compile_error!("Enable either the '2d' or '3d' feature.");
-#[cfg(all(feature = "2d", feature = "3d"))]
-compile_error!("Disable either the '2d' or '3d' feature. Both at the same time is not supported.");
 
 /// Extension trait to write a floating point scalar or vector constant in a format
 /// matching the WGSL grammar.

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -1,12 +1,3 @@
-use rand::Rng;
-use std::{borrow::Cow, cmp::Ordering, num::NonZeroU64, ops::Range};
-
-use crate::{asset::EffectAsset, render::Particle, ParticleEffect};
-
-#[cfg(feature = "2d")]
-use bevy::core_pipeline::Transparent2d as Transparent;
-#[cfg(feature = "3d")]
-use bevy::core_pipeline::Transparent3d as Transparent;
 use bevy::{
     asset::{AssetEvent, Assets, Handle, HandleUntyped},
     core::{cast_slice, FloatOrd, Time},
@@ -32,7 +23,16 @@ use bevy::{
     utils::{HashMap, HashSet},
 };
 use bytemuck::cast_slice_mut;
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use rand::Rng;
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    num::NonZeroU64,
+    ops::Range,
+    sync::atomic::{AtomicU64, Ordering as AtomicOrdering},
+};
+
+use crate::{asset::EffectAsset, render::Particle, ParticleEffect};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EffectSlice {


### PR DESCRIPTION
Make the `2d` and `3d` features purely additive, allowing for both to be
selected at once, to enable rendering through both 2D and 3D cameras.
Aside from being more versatile, this avoids a series of issues with
`docs.rs` and `cargo publish` where `--all-features` was previously
forbidden, making it difficult/impossible to use them correctly. This
also follows the official Rust guidelines on features, which state all
features must be strictly additive.