### PR TITLE
Align spawner params with GPU constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix missing `derive` feature in `bytemuck` dependency occasionally causing build errors.
+- Fix a bug in spawner parameters alignment making the library crash on some GPUs. The spawner parameters are now properly aligned according to the device-dependent constraints queried at runtime. (#26)
 
 ## [0.1.2] 2022-04-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = [ "2d", "3d" ]
 
 [dependencies]
 bytemuck = { version = "1.5", features = ["derive"] }
+copyless = "0.1"
 rand = "0.8"
 rand_pcg = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -1,6 +1,10 @@
 use bevy::{
     prelude::*,
-    render::{mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{
+        mesh::shape::Cube,
+        render_resource::WgpuFeatures,
+        settings::{WgpuLimits, WgpuSettings},
+    },
 };
 //use bevy_inspector_egui::WorldInspectorPlugin;
 
@@ -11,6 +15,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     options
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
+
+    // Optional; test that a stronger constraint is handled correctly.
+    // On macOS the alignment is commonly 256 bytes, whereas on Desktop GPUs
+    // it can be much smaller, like 16 bytes only. Force 256 bytes here for
+    // the sake of exercising a bit that codepath, and as an example of how
+    // to force a particular limit.
+    let limits = WgpuLimits {
+        min_storage_buffer_offset_alignment: 256,
+        ..Default::default()
+    };
+    options.constrained_limits = Some(limits);
+
     // options
     //     .features
     //     .set(WgpuFeatures::MAPPABLE_PRIMARY_BUFFERS, false);

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -1,0 +1,200 @@
+use bevy::{
+    core::{cast_slice, Pod},
+    log::trace,
+    render::{
+        render_resource::{Buffer, BufferAddress, BufferDescriptor, BufferUsages},
+        renderer::{RenderDevice, RenderQueue},
+    },
+};
+use bytemuck::cast_slice_mut;
+use copyless::VecHelper;
+
+// TODO - filler for usize.next_multiple_of()
+fn next_multiple_of(value: usize, align: usize) -> usize {
+    let count = (value + align - 1) / align;
+    count * align
+}
+
+/// Like Bevy's [`BufferVec`], but with an explicit item alignment.
+///
+/// This is a helper to ensure the data is properly aligned when copied to GPU, depending
+/// on the device constraints. Generally the alignment is one of the [`wgpu::Limits`].
+pub struct AlignedBufferVec<T: Pod> {
+    values: Vec<T>,
+    buffer: Option<Buffer>,
+    capacity: usize,
+    item_size: usize,
+    aligned_size: usize,
+    buffer_usage: BufferUsages,
+    label: Option<String>,
+}
+
+impl<T: Pod> Default for AlignedBufferVec<T> {
+    fn default() -> Self {
+        Self {
+            values: Vec::new(),
+            buffer: None,
+            capacity: 0,
+            buffer_usage: BufferUsages::all(),
+            item_size: std::mem::size_of::<T>(),
+            aligned_size: std::mem::size_of::<T>(),
+            label: None,
+        }
+    }
+}
+
+impl<T: Pod> AlignedBufferVec<T> {
+    pub fn new(buffer_usage: BufferUsages, item_align: usize, label: Option<String>) -> Self {
+        let item_size = std::mem::size_of::<T>();
+        //let aligned_size = item_size.next_multiple_of(item_align);
+        let aligned_size = next_multiple_of(item_size, item_align);
+        assert!(aligned_size >= item_size);
+        assert!(aligned_size % item_align == 0);
+        Self {
+            buffer_usage,
+            aligned_size,
+            label,
+            ..Default::default()
+        }
+    }
+
+    #[inline]
+    pub fn buffer(&self) -> Option<&Buffer> {
+        self.buffer.as_ref()
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    pub fn aligned_size(&self) -> usize {
+        self.aligned_size
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn push(&mut self, value: T) -> usize {
+        let index = self.values.len();
+        self.values.alloc().init(value);
+        index
+    }
+
+    pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
+        if capacity > self.capacity {
+            self.capacity = capacity;
+            let size = self.aligned_size * capacity;
+            self.buffer = Some(device.create_buffer(&BufferDescriptor {
+                label: self.label.as_ref().map(|s| &s[..]),
+                size: size as BufferAddress,
+                usage: BufferUsages::COPY_DST | self.buffer_usage,
+                mapped_at_creation: false,
+            }));
+        }
+    }
+
+    pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
+        if self.values.is_empty() {
+            return;
+        }
+        trace!(
+            "write_buffer: values.len={} item_size={} aligned_size={}",
+            self.values.len(),
+            self.item_size,
+            self.aligned_size
+        );
+        self.reserve(self.values.len(), device);
+        if let Some(buffer) = &self.buffer {
+            let aligned_size = self.aligned_size * self.values.len();
+            trace!("aligned_buffer: size={}", aligned_size);
+            let mut aligned_buffer: Vec<u8> = Vec::with_capacity(aligned_size);
+            aligned_buffer.resize(aligned_size, 0);
+            for i in 0..self.values.len() {
+                let src: &[u8] = cast_slice(std::slice::from_ref(&self.values[i]));
+                let dst_offset = i * self.aligned_size;
+                let dst_range = dst_offset..dst_offset + self.item_size;
+                trace!("+ copy: src={:?} dst={:?}", src.as_ptr(), dst_range);
+                let dst = &mut aligned_buffer[dst_range];
+                dst.copy_from_slice(src);
+            }
+            let bytes: &[u8] = cast_slice(&aligned_buffer);
+            queue.write_buffer(buffer, 0, bytes);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.values.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INTS: &[usize] = &[1, 2, 4, 8, 9, 15, 16, 17, 23, 24, 31, 32, 33];
+
+    /// Same as `INTS`, rounded up to 16
+    const INTS16: &[usize] = &[16, 16, 16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 48];
+
+    #[test]
+    fn next_multiple() {
+        // align-1 is no-op
+        for &size in INTS {
+            assert_eq!(size, next_multiple_of(size, 1));
+        }
+
+        // zero-sized is always aligned
+        for &align in INTS {
+            assert_eq!(0, next_multiple_of(0, align));
+        }
+
+        // size < align : rounds up to align
+        for &size in INTS {
+            assert_eq!(256, next_multiple_of(size, 256));
+        }
+
+        // size > align : actually aligns
+        for (&size, &aligned_size) in INTS.iter().zip(INTS16) {
+            assert_eq!(aligned_size, next_multiple_of(size, 16));
+        }
+    }
+
+    #[test]
+    fn abv_align() {
+        for &align in INTS {
+            let abv = AlignedBufferVec::<u8>::new(BufferUsages::STORAGE, align, None);
+            assert_eq!(abv.aligned_size(), align);
+        }
+
+        for &align in INTS {
+            let abv = AlignedBufferVec::<u32>::new(BufferUsages::STORAGE, align, None);
+            assert_eq!(abv.aligned_size(), next_multiple_of(4, align));
+        }
+
+        for &align in INTS {
+            let abv = AlignedBufferVec::<[u8; 27]>::new(BufferUsages::STORAGE, align, None);
+            assert_eq!(abv.aligned_size(), next_multiple_of(27, align));
+        }
+    }
+
+    #[test]
+    fn abv_push() {
+        const SIZE: usize = 27;
+        const ALIGN: usize = 32;
+        let mut abv = AlignedBufferVec::<[u8; SIZE]>::new(BufferUsages::STORAGE, ALIGN, None);
+        assert_eq!(abv.aligned_size(), next_multiple_of(SIZE, ALIGN));
+        assert!(abv.is_empty());
+        abv.push([9; SIZE]);
+        assert!(!abv.is_empty());
+        assert_eq!(abv.len(), 1);
+    }
+}


### PR DESCRIPTION
Ensure the spawner parameters are aligned based on actual GPU
constraints of the host, to enable binding the data block without error.

Bug: #26