### PR TITLE
Arbitrary rotation with speed vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ fn setup(mut effects: ResMut<Assets<EffectAsset>>) {
             radius: 2.,
             dimension: ShapeDimension::Surface,
             speed: 6.0.into(),
+            ..default()
         })
         // Every frame, add a gravity-like acceleration downward
         .update(AccelModifier {

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -94,7 +94,7 @@ fn setup(
         }
         .init(PositionSphereModifier {
             radius: 0.05,
-            speed: 0.1.into(),
+            speed: SpeedVector::Radial(0.1.into()),
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -63,9 +63,9 @@ fn setup(
         }
         .init(PositionCircleModifier {
             center: Vec3::Y * 0.1,
-            axis: Vec3::Y,
+            rotation: Quat::IDENTITY,
             radius: 0.4,
-            speed: Value::Uniform((1.0, 1.5)),
+            speed: SpeedVector::Radial(Value::Uniform((1.0, 1.5))),
             dimension: ShapeDimension::Surface,
         })
         .render(ParticleTextureModifier {

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -118,7 +118,7 @@ fn setup(
         }
         .init(PositionSphereModifier {
             radius: BALL_RADIUS,
-            speed: Value::Uniform((0.1, 0.3)),
+            speed: SpeedVector::Radial(Value::Uniform((0.1, 0.3))),
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -73,7 +73,8 @@ fn setup(
             center: Vec3::ZERO,
             radius: 5.,
             dimension: ShapeDimension::Volume,
-            speed: 2.0.into(),
+            speed: SpeedVector::Radial(2.0.into()),
+            ..default()
         })
         .update(AccelModifier {
             accel: Vec3::new(0., 5., 0.),

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -94,7 +94,8 @@ fn setup(
             center: Vec3::ZERO,
             radius: 2.,
             dimension: ShapeDimension::Surface,
-            speed: 6.0.into(),
+            speed: SpeedVector::Radial(6.0.into()),
+            ..default()
         })
         .update(AccelModifier {
             accel: Vec3::new(0., -3., 0.),
@@ -176,7 +177,8 @@ fn setup(
             center: Vec3::ZERO,
             radius: 5.,
             dimension: ShapeDimension::Volume,
-            speed: 2.0.into(),
+            speed: SpeedVector::Radial(2.0.into()),
+            ..default()
         })
         .update(AccelModifier {
             accel: Vec3::new(0., 5., 0.),

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -99,7 +99,7 @@ fn setup(
         }
         .init(PositionSphereModifier {
             radius: BALL_RADIUS,
-            speed: 0.2.into(),
+            speed: SpeedVector::Radial(0.2.into()),
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub use gradient::{Gradient, GradientKey};
 pub use modifiers::{
     AccelModifier, ColorOverLifetimeModifier, ForceFieldModifier, ForceFieldParam, InitModifier,
     ParticleTextureModifier, PositionCircleModifier, PositionSphereModifier, RenderModifier,
-    ShapeDimension, SizeOverLifetimeModifier, UpdateModifier, FFNUM,
+    ShapeDimension, SizeOverLifetimeModifier, SpeedVector, UpdateModifier, FFNUM,
 };
 pub use plugin::HanabiPlugin;
 pub use render::EffectCacheId;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,9 @@
 //!     .init(PositionSphereModifier {
 //!         center: Vec3::ZERO,
 //!         radius: 2.,
+//!         rotation: Quat::IDENTITY,
 //!         dimension: ShapeDimension::Surface,
-//!         speed: 6.0.into(),
+//!         speed: SpeedVector::Radial(6.0.into()),
 //!     })
 //!     // Every frame, add a gravity-like acceleration downward
 //!     .update(AccelModifier {

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -42,6 +42,25 @@ impl Default for ShapeDimension {
     }
 }
 
+/// The direction and intensity of the speed vector for particles
+#[derive(Clone, Copy, PartialEq)]
+pub enum SpeedVector {
+    /// The particle will get ejected along the face normal
+    Normal(Value<f32>),
+    /// The particle will get ejected away from the shape's center
+    Radial(Value<f32>),
+    /// The particle will get ejected in the given (x, y, z) direction (local space)
+    Local(Value<f32>, Value<f32>, Value<f32>),
+    /// The particle will get ejected in the given (x, y, z) direction (world space)
+    World(Value<f32>, Value<f32>, Value<f32>),
+}
+
+impl Default for SpeedVector {
+    fn default() -> Self {
+        Self::Radial(Value::Single(1.0))
+    }
+}
+
 /// An initialization modifier spawning particles on a circle/disc.
 #[derive(Clone, Copy)]
 pub struct PositionCircleModifier {

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -104,6 +104,27 @@ fn rand4(input: u32) -> vec4<f32> {
     return vec4<f32>(x, y, z, w);
 }
 
+// From https://www.geeks3d.com/20141201/how-to-rotate-a-vertex-by-a-quaternion-in-glsl/
+fn quat_conj(q: vec4<f32>) -> vec4<f32> {
+    return vec4<f32>(-q.x, -q.y, -q.z, q.w);
+}
+
+fn quat_mult(q1: vec4<f32>, q2: vec4<f32>) -> vec4<f32> {
+    var qr: vec4<f32>;
+    qr.x = (q1.w * q2.x) + (q1.x * q2.w) + (q1.y * q2.z) - (q1.z * q2.y);
+    qr.y = (q1.w * q2.y) - (q1.x * q2.z) + (q1.y * q2.w) + (q1.z * q2.x);
+    qr.z = (q1.w * q2.z) + (q1.x * q2.y) - (q1.y * q2.x) + (q1.z * q2.w);
+    qr.w = (q1.w * q2.w) - (q1.x * q2.x) - (q1.y * q2.y) - (q1.z * q2.z);
+    return qr;
+}
+
+fn rotate_point(position: vec3<f32>, q: vec4<f32>) -> vec3<f32> {
+    var q_conj = quat_conj(q);
+    var q_pos = vec4<f32>(position.x, position.y, position.z, 0.);
+    q_pos = quat_mult(quat_mult(q, q_pos), q_conj);
+    return q_pos.xyz;
+}
+
 struct PosVel {
     pos: vec3<f32>;
     vel: vec3<f32>;


### PR DESCRIPTION
In the process of providing more PositionModifier primitives like Cube, Cone & Plane, I noticed it could be nice to have more ways to express the initial velocity of particles emitted on those primitives. In the case of Sphere and Circle, it's straightforward and reasonably enough to only provide radial speed. However,

1. Circle doesn't support arbitrary rotations, only axis-aligned
2. In the context of a Cube emitter (see [this fork's branch](https://github.com/dtaralla/bevy_hanabi/tree/more_position_over_shape) last [commit](https://github.com/dtaralla/bevy_hanabi/commit/10c328e5286d8c55e737001d2aa949f8f40d9a4c)), what if you want particles emitted not radially but along the normals of its faces?
3.  What if you want to author the velocity direction from user code directly, instead of relying on a force field? In this case, you might want to describe this velocity as a world vector or a local vector in the primitive's space.

This PR adds a new `SpeedVector` enum to describe `Radial`, `Normal`, `Local` & `World` velocities. It allows (1) by supporting a quaternion instead of an axis, that is required anyway to support (3). `Normal` will allow for (2).

I offer this PR as a draft, because a review wouldn't hurt it; I'm pretty new to WGSL and shader code in general, and I'm unsure that my quaternion things are done the correct way without adding too much overhead.

Thoughts? 😊