### PR TITLE
Add GPU test for `AlignedBufferVec<T>`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,13 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
         if: matrix.dimensions != 'all'
+      - name: Build & run GPU tests
+        run: cargo test --no-default-features --features ${{ matrix.dimensions }} --features gpu_tests
+        env:
+          CARGO_INCREMENTAL: 0
+        if: runner.os == 'linux' && matrix.dimensions != 'all'
       - name: Build & run tests
-        run: cargo test --all-features
+        run: cargo test --no-default-features --features="2d 3d"
         env:
           CARGO_INCREMENTAL: 0
         if: matrix.dimensions == 'all'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added test-only feature `gpu_tests` active by default to enable tests requiring a working graphic adapter (GPU). This is disabled in most CI tests, except on Linux where the CPU-based Vulkan emulator `lavapipe` is used.
+
 ### Changed
 
 - Switch to Bevy v0.7.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,12 @@ features = [ "bevy_core_pipeline", "bevy_render" ]
 [package.metadata.docs.rs]
 all-features = true
 
-#[dev-dependencies]
+[dev-dependencies]
+# Same version as Bevy 0.7
+wgpu = "0.12"
+# Same version as wgpu 0.12
+pollster = "0.2"
+
 #bevy-inspector-egui = "0.8"
 #smooth-bevy-cameras = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,13 @@ readme = "README.md"
 exclude = ["examples/*.gif", ".github"]
 
 [features]
-default = [ "2d", "3d" ]
+default = [ "2d", "3d", "gpu_tests" ]
 2d = []
 3d = []
+
+# Special feature to enable GPU-based tests, which otherwise fail
+# on a CI machine without a graphic adapter or without proper drivers.
+gpu_tests = []
 
 [dependencies]
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ mod plugin;
 mod render;
 mod spawn;
 
+#[cfg(test)]
+mod test_utils;
+
 pub use asset::EffectAsset;
 pub use bundle::ParticleEffectBundle;
 pub use gradient::{Gradient, GradientKey};

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -199,6 +199,7 @@ mod tests {
         assert_eq!(abv.len(), 1);
     }
 
+    #[cfg(gpu_tests)]
     #[test]
     fn abv_write() {
         let renderer = MockRenderer::new();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,51 @@
+use bevy::render::renderer::{RenderDevice, RenderQueue};
+
+pub(crate) struct MockRenderer {
+    instance: wgpu::Instance,
+    adapter: wgpu::Adapter,
+    device: RenderDevice,
+    queue: RenderQueue,
+}
+
+impl MockRenderer {
+    pub fn new() -> Self {
+        // Create the WGPU adapter
+        let instance = wgpu::Instance::new(wgpu::Backends::all());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::default(),
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("Failed to find an appropriate adapter");
+
+        // Create the logical device and command queue
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: None,
+                features: wgpu::Features::empty(),
+                limits: wgpu::Limits::downlevel_defaults(),
+            },
+            None,
+        ))
+        .expect("Failed to create device");
+
+        // Turn into Bevy objects
+        let device = RenderDevice::from(std::sync::Arc::new(device));
+        let queue = std::sync::Arc::new(queue);
+
+        MockRenderer {
+            instance,
+            adapter,
+            device,
+            queue,
+        }
+    }
+
+    pub fn device(&self) -> RenderDevice {
+        self.device.clone()
+    }
+
+    pub fn queue(&self) -> RenderQueue {
+        self.queue.clone()
+    }
+}


### PR DESCRIPTION
Add a test for `AlignedBufferVec<T>` to ensure the data is properly
written to the GPU, by reading it back to compare locally. This mocks a
Bevy render device and queue backed by a real physical WGPU device.