### PR TITLE
Made the InitLayout and UpdateLayout public

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -16,8 +16,11 @@ use crate::{
 /// to define the initial conditions of particles on the GPU.
 #[derive(Default, Clone)]
 pub struct InitLayout {
+    /// Code to define the initial position of particles.
     pub position_code: String,
+    /// WSGL code to initialize interactions with force fields. (Unused?)
     pub force_field_code: String,
+    /// WSGL code to set the initial lifetime of the particle.
     pub lifetime_code: String,
 }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -12,6 +12,8 @@ use crate::{
     Gradient, InitModifier, RenderModifier, Spawner, UpdateModifier,
 };
 
+/// Struct containing snippets of WSGL code that can be used
+/// to define the initial conditions of particles on the GPU.
 #[derive(Default, Clone)]
 pub struct InitLayout {
     pub position_code: String,
@@ -19,6 +21,8 @@ pub struct InitLayout {
     pub lifetime_code: String,
 }
 
+/// Struct containing snippets of WSGL code that can be used
+/// to update the particles every frame on the GPU.
 #[derive(Default, Clone, Copy)]
 pub struct UpdateLayout {
     /// Constant accelereation to apply to all particles.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,11 @@ mod spawn;
 #[cfg(test)]
 mod test_utils;
 
-pub use asset::EffectAsset;
+pub use asset::{
+    EffectAsset,
+    InitLayout,
+    UpdateLayout
+};
 pub use bundle::ParticleEffectBundle;
 pub use gradient::{Gradient, GradientKey};
 pub use modifiers::{


### PR DESCRIPTION
The `InitModifier` and `UpdateModifier` traits were impossible to implement because the `InitLayout` and `UpdateLayout` struct were private.

This PR makes these structs publicly available. Shouldn't break any existing code that I'm aware of.