### PR TITLE
Enable setting the Z layer for 2D particles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `EffectAsset::z_layer_2d` and `ParticleEffect::z_layer_2d` to control the Z layer at which particles are rendered in 2D mode. Note that effects with different Z values cannot be batched together, which may negatively affect performance.
+
 ## [0.3.0] 2022-06-08
 
 ### Changed

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,7 +1,8 @@
 use bevy::{
     asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
+    ecs::reflect::ReflectResource,
     math::{Vec2, Vec3, Vec4},
-    reflect::TypeUuid,
+    reflect::{Reflect, TypeUuid},
     render::texture::Image,
     utils::BoxedFuture,
 };
@@ -58,7 +59,8 @@ pub struct RenderLayout {
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
-#[derive(Default, Serialize, Deserialize, TypeUuid)]
+#[derive(Default, Clone, Serialize, Deserialize, Reflect, TypeUuid)]
+#[reflect(Resource)]
 #[uuid = "249aefa4-9b8e-48d3-b167-3adf6c081c34"]
 pub struct EffectAsset {
     /// Display name of the effect.
@@ -69,17 +71,28 @@ pub struct EffectAsset {
     pub spawner: Spawner,
     /// Layout describing the particle initialize code.
     #[serde(skip)] // TODO
+    #[reflect(ignore)] // TODO?
     pub init_layout: InitLayout,
     /// Layout describing the particle update code.
     #[serde(skip)] // TODO
+    #[reflect(ignore)] // TODO?
     pub update_layout: UpdateLayout,
     /// Layout describing the particle rendering code.
     #[serde(skip)] // TODO
+    #[reflect(ignore)] // TODO?
     pub render_layout: RenderLayout,
+    /// For 2D rendering, the Z coordinate used as the sort key.
+    ///
+    /// This value is passed to the render pipeline and used when sorting
+    /// transparent items to render, to order them. As a result, effects
+    /// with different Z values cannot be batched together, which may
+    /// negatively affect performance.
+    ///
+    /// Ignored for 3D rendering.
+    pub z_layer_2d: f32,
+    //#[serde(skip)] // TODO
+    //modifiers: Vec<Box<dyn Modifier + Send + Sync + 'static>>,
 }
-///
-//#[serde(skip)] // TODO
-//modifiers: Vec<Box<dyn Modifier + Send + Sync + 'static>>,
 
 impl EffectAsset {
     /// Add an initialization modifier to the effect.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -21,7 +21,7 @@ use crate::{
         PARTICLES_UPDATE_SHADER_HANDLE,
     },
     spawn::{self, Random},
-    tick_spawners,
+    tick_spawners, ParticleEffect,
 };
 
 pub mod draw_graph {
@@ -63,7 +63,8 @@ impl Plugin for HanabiPlugin {
         shaders.set_untracked(PARTICLES_RENDER_SHADER_HANDLE, render_shader);
 
         // Register the component reflection
-        //app.register_type::<ParticleEffect>();
+        app.register_type::<EffectAsset>();
+        app.register_type::<ParticleEffect>();
 
         let render_device = app.world.get_resource::<RenderDevice>().unwrap();
         let effects_meta = EffectsMeta::new(render_device.clone());
@@ -180,20 +181,3 @@ impl Plugin for HanabiPlugin {
         }
     }
 }
-
-// pub fn hanabi_spawn(
-//     time: Res<Time>,
-//     mut query: Query<(&mut ParticleEffect, &mut SpawnState, &mut
-// UpdateState)>, ) {
-//     for (ref mut effect, ref mut spawn_state, ref mut state) in
-// query.iter_mut() {         effect
-//             .spawner
-//             .spawn(spawn_state, state, time.delta_seconds());
-//     }
-// }
-
-// pub fn hanabi_update(time: Res<Time>, mut query: Query<(&mut ParticleEffect,
-// &mut UpdateState)>) {     for (ref mut effect, ref mut motion) in
-// query.iter_mut() {         effect.updater.update(motion,
-// time.delta_seconds());     }
-// }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,3 +1,4 @@
+use bevy::reflect::Reflect;
 use rand::{
     distributions::{uniform::SampleUniform, Distribution, Uniform},
     SeedableRng,
@@ -65,17 +66,20 @@ impl<T: Copy> From<T> for Value<T> {
 }
 
 /// Spawner defining how new particles are created.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Reflect)]
 pub struct Spawner {
     /// Number of particles to spawn over `spawn_time`
+    #[reflect(ignore)] // TODO
     num_particles: Value<f32>,
 
     /// Time over which to spawn `num_particles`, in seconds
+    #[reflect(ignore)] // TODO
     spawn_time: Value<f32>,
 
     /// Time between bursts of the particle system, in seconds.
     /// If this is infinity, there's only one burst.
     /// If this is `spawn_time`, the system spawns a steady stream of particles.
+    #[reflect(ignore)] // TODO
     period: Value<f32>,
 
     /// Time since last spawn.


### PR DESCRIPTION
Add a new field `EffectAsset::z_layer_2d` holding the Z coordinate of
the layer at which particles are rendered in 2D mode. Also add a new
field `ParticleEffect::z_layer_2d` to override this value on a
per-instance basis.

Reflect both `EffectAsset` and `ParticleEffect`, allowing to tweak the
`z_layer_2d` value on a per-instance basis with the egui inspector in
the `2d.rs` example, to show the effect of this Z layer feature.

Bug: #28