### PR TITLE
Handle rotation of emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The orientation of the `Entity` of the `ParticleEffect` is now taken into account for spawning. (#42)
+
 ## [0.3.1] 2022-08-19
 
 ### Added


### PR DESCRIPTION
Take into account the `GlobalTransform` of the `Entity` holding the
`ParticleEffect` to emit particles.

Fixes #42