### PR TITLE
Add `PositionCone3dModifier` for directional emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `PositionCone3dModifier` to spawn particles inside a truncated 3D cone.
+
 ### Fixed
 
 - The orientation of the `Entity` of the `ParticleEffect` is now taken into account for spawning. (#42)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The image on the left has the `BillboardModifier` enabled.
     - [ ] cube
     - [x] circle
     - [x] sphere
-    - [ ] cone
+    - [x] cone / truncated cone (3D)
     - [ ] plane
     - [ ] generic mesh / point cloud (?)
   - [ ] Random position offset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,15 +100,15 @@ pub use gradient::{Gradient, GradientKey};
 pub use modifiers::{
     AccelModifier, BillboardModifier, ColorOverLifetimeModifier, ForceFieldModifier,
     ForceFieldParam, InitModifier, ParticleLifetimeModifier, ParticleTextureModifier,
-    PositionCircleModifier, PositionSphereModifier, RenderModifier, ShapeDimension,
-    SizeOverLifetimeModifier, UpdateModifier, FFNUM,
+    PositionCircleModifier, PositionCone3dModifier, PositionSphereModifier, RenderModifier,
+    ShapeDimension, SizeOverLifetimeModifier, UpdateModifier, FFNUM,
 };
 pub use plugin::HanabiPlugin;
 pub use render::{EffectCacheId, PipelineRegistry};
 pub use spawn::{Random, Spawner, Value};
 
 #[cfg(not(any(feature = "2d", feature = "3d")))]
-compile_error!("Enable either the '2d' or '3d' feature.");
+compile_error!("You need to enable at least one of the '2d' or '3d' features for anything to happen.");
 
 /// Extension trait to write a floating point scalar or vector constant in a
 /// format matching the WGSL grammar.

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -156,7 +156,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
             // Initialize new particle
             var posVel = init_pos_vel(index, transform);
-            vPos = posVel.pos + transform[3].xyz; // global space simulation
+            vPos = posVel.pos;
             vVel = posVel.vel;
             vAge = 0.0;
             vLifetime = init_lifetime();


### PR DESCRIPTION
Add a new position modifier `PositionCone3dModifier` which spawns
particle inside a truncated 3D cone, with a velocity directed from the
apex toward the base.

Change the `particles_update.wgsl` code and all other modifiers to take
into account the transform of the emitter `Entity` directly in the
`init_pos_vel()` method, so they can apply it most efficiently.