### PR TITLE
Prefix all profiling GPU markers with `hanabi:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `PositionCone3dModifier` to spawn particles inside a truncated 3D cone.
+- All GPU profiling markers are now prefixed with `hanabi:` to make it easier to find Hanabi-related GPU resources.
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,9 @@ pub use render::{EffectCacheId, PipelineRegistry};
 pub use spawn::{Random, Spawner, Value};
 
 #[cfg(not(any(feature = "2d", feature = "3d")))]
-compile_error!("You need to enable at least one of the '2d' or '3d' features for anything to happen.");
+compile_error!(
+    "You need to enable at least one of the '2d' or '3d' features for anything to happen."
+);
 
 /// Extension trait to write a floating point scalar or vector constant in a
 /// format matching the WGSL grammar.

--- a/src/material.rs
+++ b/src/material.rs
@@ -160,7 +160,7 @@ impl RenderAsset for EffectMaterial {
         let value_std140 = value.as_std140();
 
         let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
-            label: Some("effect_material_uniform_buffer"),
+            label: Some("hanabi:effect_material_uniform_buffer"),
             usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
             contents: value_std140.as_bytes(),
         });
@@ -179,7 +179,7 @@ impl RenderAsset for EffectMaterial {
                     resource: BindingResource::Sampler(base_color_sampler),
                 },
             ],
-            label: Some("effect_material_bind_group"),
+            label: Some("hanabi:effect_material_bind_group"),
             layout: &pbr_pipeline.material_layout,
         });
 

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -174,18 +174,18 @@ impl InitModifier for PositionSphereModifier {
     }
 }
 
-
 /// An initialization modifier spawning particles inside a truncated 3D cone.
 ///
-/// The 3D cone is oriented along the Y axis, with its origin at the center of the top
-/// circle truncating the cone. The center of the base circle of the cone is located at
-/// a positive Y.
+/// The 3D cone is oriented along the Y axis, with its origin at the center of
+/// the top circle truncating the cone. The center of the base circle of the
+/// cone is located at a positive Y.
 ///
-/// Particles are spawned somewhere inside the volume or on the surface of a truncated
-/// 3D cone defined by its base radius, its top radius, and the height of the cone section.
+/// Particles are spawned somewhere inside the volume or on the surface of a
+/// truncated 3D cone defined by its base radius, its top radius, and the height
+/// of the cone section.
 ///
-/// The particle velocity is initialized to a random speed along the direction going from
-/// the cone apex to the particle position.
+/// The particle velocity is initialized to a random speed along the direction
+/// going from the cone apex to the particle position.
 #[derive(Default, Clone, Copy)]
 pub struct PositionCone3dModifier {
     /// The cone height along its axis, between the base and top radii.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -53,10 +53,6 @@ impl Plugin for HanabiPlugin {
                     .after(VisibilitySystems::CheckVisibility),
             );
 
-        // Register the spawn and update systems
-        // app.add_system(hanabi_spawn.system())
-        //     .add_system(hanabi_update.system());
-
         // Register the particles shaders
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         let update_shader = Shader::from_wgsl(include_str!("render/particles_update.wgsl"));


### PR DESCRIPTION
Ensure all profiling GPU markers have a name starting with the `hanabi:` prefix, to group them in _e.g._ RenderDoc and make it easier to find Hanabi-related GPU resources.