### PR TITLE
Clean-up GPU resources on `ParticleEffect` despawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The orientation of the `Entity` of the `ParticleEffect` is now taken into account for spawning. (#42)
+- Ensure all GPU resources are deallocated when a `ParticleEffect` component is despawned. (#45)
 
 ## [0.3.1] 2022-08-19
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,6 @@ pub struct ParticleEffect {
     #[reflect(ignore)]
     effect: EffectCacheId,
     /// Particle spawning descriptor.
-    #[reflect(ignore)]
     spawner: Option<Spawner>,
     /// Handle to the configured compute shader for his effect instance, if
     /// configured.
@@ -578,6 +577,20 @@ fn tick_spawners(
             effect.force_field_code = force_field_code;
             effect.lifetime_code = lifetime_code;
         }
+    }
+}
+
+struct RemovedEffectsEvent {
+    entities: Vec<Entity>,
+}
+
+fn gather_removed_effects(
+    removed_effects: RemovedComponents<ParticleEffect>,
+    mut removed_effects_event_writer: EventWriter<RemovedEffectsEvent>,
+) {
+    let entities: Vec<Entity> = removed_effects.iter().collect();
+    if !entities.is_empty() {
+        removed_effects_event_writer.send(RemovedEffectsEvent { entities });
     }
 }
 

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -118,6 +118,12 @@ struct BestRange {
     index: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferState {
+    Used,
+    Free,
+}
+
 impl EffectBuffer {
     /// Minimum buffer capacity to allocate, in number of particles.
     pub const MIN_CAPACITY: u32 = 65536; // at least 64k particles
@@ -184,7 +190,7 @@ impl EffectBuffer {
 
     /// Return a binding for the entire buffer.
     pub fn max_binding(&self) -> BindingResource {
-        let capacity_bytes = self.capacity as u64 * self.item_size as u64;
+        let capacity_bytes = self.to_byte_size(self.capacity);
         BindingResource::Buffer(BufferBinding {
             buffer: &self.particle_buffer,
             offset: 0,
@@ -205,12 +211,17 @@ impl EffectBuffer {
     /// Return a binding for the entire indirect buffer associated with the
     /// current effect buffer.
     pub fn indirect_max_binding(&self) -> BindingResource {
-        let capacity_bytes = self.capacity as u64 * std::mem::size_of::<u32>() as u64;
+        let capacity_bytes = self.to_byte_size(std::mem::size_of::<u32>() as u32);
         BindingResource::Buffer(BufferBinding {
             buffer: &self.indirect_buffer,
             offset: 0,
             size: Some(NonZeroU64::new(capacity_bytes).unwrap()),
         })
+    }
+
+    #[inline]
+    fn to_byte_size(&self, count: u32) -> u64 {
+        count as u64 * self.item_size as u64
     }
 
     fn pop_free_slice(&mut self, size: u32) -> Option<Range<u32>> {
@@ -236,7 +247,7 @@ impl EffectBuffer {
                 };
             }
         }
-        self.free_slices.swap_remove(result.index);
+        self.free_slices.remove(result.index);
         Some(result.range)
     }
 
@@ -249,9 +260,9 @@ impl EffectBuffer {
             item_size
         );
 
-        let byte_size = capacity
-            .checked_mul(item_size)
-            .expect("Effect slice size overflow");
+        if capacity > self.capacity {
+            return None;
+        }
 
         let range = if let Some(range) = self.pop_free_slice(capacity) {
             range
@@ -263,7 +274,10 @@ impl EffectBuffer {
                 range
             } else {
                 if self.used_size == 0 {
-                    warn!("Cannot allocate slice of size {} ({} B) in effect cache buffer of capacity {}.", capacity, byte_size, self.capacity);
+                    warn!(
+                        "Cannot allocate slice of size {} in effect cache buffer of capacity {}.",
+                        capacity, self.capacity
+                    );
                 }
                 return None;
             }
@@ -272,11 +286,49 @@ impl EffectBuffer {
         Some(SliceRef { range, item_size })
     }
 
-    // pub fn write_slice(&mut self, slice: &SliceRef, data: &[u8], queue:
-    // &RenderQueue) {     assert!(data.len() <= slice.byte_size());
-    //     let bytes: &[u8] = cast_slice(data);
-    //     queue.write_buffer(buffer, slice.range.begin, &bytes[slice.range]);
-    // }
+    /// Free an allocated slice, and if this was the last allocated slice also
+    /// free the buffer.
+    pub fn free_slice(&mut self, slice: SliceRef) -> BufferState {
+        // If slice is at the end of the buffer, reduce total used size
+        if slice.range.end == self.used_size {
+            self.used_size = slice.range.start;
+            // Check other free slices to further reduce used size and drain the free slice
+            // list
+            while let Some(free_slice) = self.free_slices.last() {
+                if free_slice.end == self.used_size {
+                    self.used_size = free_slice.start;
+                    self.free_slices.pop();
+                } else {
+                    break;
+                }
+            }
+            if self.used_size == 0 {
+                assert!(self.free_slices.is_empty());
+                // The buffer is not used anymore, free it too
+                BufferState::Free
+            } else {
+                // There are still some slices used, the last one of which ends at
+                // self.used_size
+                BufferState::Used
+            }
+        } else {
+            // Free slice is not at end; insert it in free list
+            let range = slice.range;
+            match self.free_slices.binary_search_by(|s| {
+                if s.end <= range.start {
+                    Ordering::Less
+                } else if s.start >= range.end {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            }) {
+                Ok(_) => warn!("Range {:?} already present in free list!", range),
+                Err(index) => self.free_slices.insert(index, range),
+            }
+            BufferState::Used
+        }
+    }
 
     pub fn is_compatible(&self, handle: &Handle<EffectAsset>) -> bool {
         // TODO - replace with check particle layout is compatible to allow tighter
@@ -304,8 +356,10 @@ impl EffectCacheId {
 pub struct EffectCache {
     /// Render device the GPU resources (buffers) are allocated from.
     device: RenderDevice,
-    /// Collection of effect buffers managed by this cache.
-    buffers: Vec<EffectBuffer>,
+    /// Collection of effect buffers managed by this cache. Some buffers might
+    /// be `None` if the entry is not used. Since the buffers are referenced
+    /// by index, we cannot move them once they're allocated.
+    buffers: Vec<Option<EffectBuffer>>,
     /// Map from an effect cache ID to the index of the buffer and the slice
     /// into that buffer.
     effects: HashMap<EffectCacheId, (usize, SliceRef)>,
@@ -320,8 +374,12 @@ impl EffectCache {
         }
     }
 
-    pub fn buffers(&self) -> &[EffectBuffer] {
+    pub fn buffers(&self) -> &[Option<EffectBuffer>] {
         &self.buffers
+    }
+
+    pub fn buffers_mut(&mut self) -> &mut [Option<EffectBuffer>] {
+        &mut self.buffers
     }
 
     pub fn insert(
@@ -337,20 +395,24 @@ impl EffectCache {
             .iter_mut()
             .enumerate()
             .find_map(|(buffer_index, buffer)| {
-                // The buffer must be compatible with the effect layout, to allow the update pass
-                // to update all particles at once from all compatible effects in a single dispatch.
-                if !buffer.is_compatible(&asset) {
-                    return None;
-                }
+                if let Some(buffer) = buffer {
+                    // The buffer must be compatible with the effect layout, to allow the update pass
+                    // to update all particles at once from all compatible effects in a single dispatch.
+                    if !buffer.is_compatible(&asset) {
+                        return None;
+                    }
 
-                // Try to allocate a slice into the buffer
-                buffer
-                    .allocate_slice(capacity, item_size)
-                    .map(|slice| (buffer_index, slice))
+                    // Try to allocate a slice into the buffer
+                    buffer
+                        .allocate_slice(capacity, item_size)
+                        .map(|slice| (buffer_index, slice))
+                } else {
+                    None
+                }
             })
             .or_else(|| {
                 // Cannot find any suitable buffer; allocate a new one
-                let buffer_index = self.buffers.len();
+                let buffer_index = self.buffers.iter().position(|buf| buf.is_none()).unwrap_or(self.buffers.len());
                 let byte_size = capacity.checked_mul(item_size).unwrap_or_else(|| panic!(
                     "Effect size overflow: capacity={} item_size={}",
                     capacity, item_size
@@ -363,19 +425,21 @@ impl EffectCache {
                     item_size,
                     byte_size
                 );
-                self.buffers.push(EffectBuffer::new(
+                let mut buffer = EffectBuffer::new(
                     asset,
                     capacity,
                     item_size,
                     //pipeline,
                     &self.device,
                     Some(&format!("hanabi:effect_buffer{}", buffer_index)),
-                ));
-                let buffer = self.buffers.last_mut().unwrap();
-                Some((
-                    buffer_index,
-                    buffer.allocate_slice(capacity, item_size).unwrap(),
-                ))
+                );
+                let slice_ref = buffer.allocate_slice(capacity, item_size).unwrap();
+                self.buffers.insert(buffer_index, Some(buffer));
+                // Newly-allocated buffers are not cleared to zero, and currently we eagerly render the entire buffer
+                // since we don't have an indirection buffer to tell us how many particles are alive. So clear the buffer
+                // to zero to mark all particles as invalid and prevent rendering them.
+                //queue.cle
+                Some((buffer_index, slice_ref))
             })
             .unwrap();
         let id = EffectCacheId::new();
@@ -399,5 +463,93 @@ impl EffectCache {
                 item_size: slice_ref.item_size,
             })
             .unwrap()
+    }
+
+    /// Remove an effect from the cache. If this was the last effect, drop the
+    /// underlying buffer and return the index of the dropped buffer.
+    pub fn remove(&mut self, id: EffectCacheId) -> Option<u32> {
+        if let Some((buffer_index, slice)) = self.effects.remove(&id) {
+            if let Some(buffer) = &mut self.buffers[buffer_index] {
+                if buffer.free_slice(slice) == BufferState::Free {
+                    self.buffers[buffer_index] = None;
+                    return Some(buffer_index as u32);
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod gpu_tests {
+    use super::*;
+    use crate::test_utils::MockRenderer;
+    use bevy::asset::HandleId;
+
+    use super::*;
+
+    #[test]
+    fn effect_buffer() {
+        let renderer = MockRenderer::new();
+        let render_device = renderer.device();
+        //let render_queue = renderer.queue();
+
+        let asset = Handle::weak(HandleId::random::<EffectAsset>());
+        let capacity = 4096;
+        let item_size = 64;
+        let mut buffer = EffectBuffer::new(
+            asset,
+            capacity,
+            item_size,
+            &render_device,
+            Some("my_buffer"),
+        );
+
+        assert_eq!(EffectBuffer::MIN_CAPACITY, buffer.capacity);
+        assert_eq!(64, buffer.item_size);
+        assert_eq!(0, buffer.used_size);
+        assert!(buffer.free_slices.is_empty());
+        assert!(buffer.slice_from_entity.is_empty());
+
+        assert_eq!(None, buffer.allocate_slice(buffer.capacity + 1, 64));
+
+        let mut offset = 0;
+        let mut slices = vec![];
+        for size in [32, 128, 55, 148, 1, 2048, 42] {
+            let slice = buffer.allocate_slice(size, 64);
+            assert!(slice.is_some());
+            let slice = slice.unwrap();
+            assert_eq!(64, slice.item_size);
+            assert_eq!(offset..offset + size, slice.range);
+            slices.push(slice);
+            offset += size;
+        }
+        assert_eq!(offset, buffer.used_size);
+
+        assert_eq!(BufferState::Used, buffer.free_slice(slices[2].clone()));
+        assert_eq!(1, buffer.free_slices.len());
+        let free_slice = &buffer.free_slices[0];
+        assert_eq!(160..215, *free_slice);
+        assert_eq!(offset, buffer.used_size); // didn't move
+
+        assert_eq!(BufferState::Used, buffer.free_slice(slices[3].clone()));
+        assert_eq!(BufferState::Used, buffer.free_slice(slices[4].clone()));
+        assert_eq!(BufferState::Used, buffer.free_slice(slices[5].clone()));
+        assert_eq!(4, buffer.free_slices.len());
+        assert_eq!(offset, buffer.used_size); // didn't move
+
+        // this will collapse all the way to slices[1], the highest allocated
+        assert_eq!(BufferState::Used, buffer.free_slice(slices[6].clone()));
+        assert_eq!(0, buffer.free_slices.len()); // collapsed
+        assert_eq!(160, buffer.used_size); // collapsed
+
+        assert_eq!(BufferState::Used, buffer.free_slice(slices[0].clone()));
+        assert_eq!(1, buffer.free_slices.len());
+        assert_eq!(160, buffer.used_size); // didn't move
+
+        // collapse all, and free buffer
+        assert_eq!(BufferState::Free, buffer.free_slice(slices[1].clone()));
+        assert_eq!(0, buffer.free_slices.len());
+        assert_eq!(0, buffer.used_size); // collapsed and empty
     }
 }


### PR DESCRIPTION
Ensure all GPU resources associated with a `ParticleEffect` instance are cleared when that component instance is despawned. This fixes a bug where buffers are reused for a different instance, possibly giving the impression that the effect continues to simulate even though it's despawned.

Fixes #45