### PR TITLE
Reorganize all modifiers into modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `PositionCone3dModifier` to spawn particles inside a truncated 3D cone.
 - All GPU profiling markers are now prefixed with `hanabi:` to make it easier to find Hanabi-related GPU resources.
 
+### Changed
+
+- Moved all modifiers into a top-level `modifier` module, and further into some `init`, `update`, and `render` sub-modules.
+- Added a `bevy_hanabi::prelude` containing most public types, to be used preferably over `use bevy_hanabi::*`.
+- Renamed `ForceFieldParam` to `ForceFieldSource`.
+- Renamed the `FFNUM` constant to `ForceFieldSource::MAX_SOURCES`.
+- Renamed `ForceFieldModifier::force_field` to `ForceFieldModifier::sources`.
+
 ### Fixed
 
 - The orientation of the `Entity` of the `ParticleEffect` is now taken into account for spawning. (#42)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See also [Features](#features) below for the list of supported features.
 Add the `HanabiPlugin` to your app:
 
 ```rust
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 App::default()
     .add_plugins(DefaultPlugins)

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -11,7 +11,7 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -5,9 +5,9 @@ use bevy::{
     prelude::*,
     render::{camera::Projection, render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-
-use bevy_hanabi::*;
 use bevy_inspector_egui::WorldInspectorPlugin;
+
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -5,9 +5,9 @@ use bevy::{
     prelude::*,
     render::{render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-
-use bevy_hanabi::*;
 use bevy_inspector_egui::WorldInspectorPlugin;
+
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -8,7 +8,8 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
+
 // use smooth_bevy_cameras::{
 //     controllers::orbit::{OrbitCameraBundle, OrbitCameraController,
 // OrbitCameraPlugin},     LookTransformPlugin,
@@ -122,8 +123,8 @@ fn setup(
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })
-        .update(bevy_hanabi::ForceFieldModifier::new(vec![
-            ForceFieldParam {
+        .update(ForceFieldModifier::new(vec![
+            ForceFieldSource {
                 position: attractor2_position,
                 max_radius: 1000000.0,
                 min_radius: BALL_RADIUS * 6.0,
@@ -133,7 +134,7 @@ fn setup(
                 force_exponent: 1.0,
                 conform_to_sphere: true,
             },
-            ForceFieldParam {
+            ForceFieldSource {
                 position: attractor1_position,
                 max_radius: 1000000.0,
                 min_radius: BALL_RADIUS * 6.0,

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -5,7 +5,7 @@ use bevy::{
 use bevy_inspector_egui::WorldInspectorPlugin;
 use std::f32::consts::PI;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -7,7 +7,7 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -8,7 +8,7 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -11,7 +11,7 @@ use bevy::{
 };
 use bevy_inspector_egui::WorldInspectorPlugin;
 
-use bevy_hanabi::*;
+use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = WgpuSettings::default();

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -9,8 +9,12 @@ use bevy::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    modifiers::{ForceFieldParam, FFNUM},
-    Gradient, InitModifier, RenderModifier, Spawner, UpdateModifier,
+    modifier::{
+        init::InitModifier,
+        render::RenderModifier,
+        update::{ForceFieldSource, UpdateModifier},
+    },
+    Gradient, Spawner,
 };
 
 /// Struct containing snippets of WSGL code that can be used
@@ -29,12 +33,12 @@ pub struct InitLayout {
 /// to update the particles every frame on the GPU.
 #[derive(Default, Clone, Copy)]
 pub struct UpdateLayout {
-    /// Constant accelereation to apply to all particles.
+    /// Constant acceleration to apply to all particles.
     /// Generally used to simulate some kind of gravity.
     pub accel: Vec3,
     /// Array of force field components with a maximum number of components
-    /// determined by [`FFNUM`].
-    pub force_field: [ForceFieldParam; FFNUM],
+    /// determined by [`ForceFieldSource::MAX_SOURCES`].
+    pub force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
 }
 
 /// Struct containing data and snippets of WSGL code that can be used

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -1,0 +1,48 @@
+//! Building blocks to create a visual effect.
+//!
+//! A **modifier** is a building block used to create effects. Particles effects
+//! are composed of multiple modifiers, which put together and configured
+//! produce the desired visual effect. Each modifier changes a specific part of
+//! the behavior of an effect. Modifiers are grouped in three categories:
+//!
+//! - **Init modifiers** influence the initializing of particles when they
+//!   spawn. They typically configure the initial position and/or velocity of
+//!   particles. Init modifiers are grouped under the [`init`] module, and
+//!   implement the [`InitModifier`] trait.
+//! - **Update modifiers** influence the particle update loop each frame. For
+//!   example, an update modifier can apply a gravity force to all particles.
+//!   Update modifiers are grouped under the [`update`] module, and implement
+//!   the [`UpdateModifier`] trait.
+//! - **Render modifiers** influence the rendering of each particle. They can
+//!   change the particle's color, or orient it to face the camera. Render
+//!   modifiers are grouped under the [`render`] module, and implement the
+//!   [`RenderModifier`] trait.
+//!
+//! [`InitModifier`]: crate::modifier::init::InitModifier
+//! [`UpdateModifier`]: crate::modifier::update::UpdateModifier
+//! [`RenderModifier`]: crate::modifier::render::RenderModifier
+
+pub mod init;
+pub mod render;
+pub mod update;
+
+pub use init::*;
+pub use render::*;
+pub use update::*;
+
+/// The dimension of a shape to consider.
+///
+/// The exact meaning depends on the context where this enum is used.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ShapeDimension {
+    /// Consider the surface of the shape only.
+    Surface,
+    /// Consider the entire shape volume.
+    Volume,
+}
+
+impl Default for ShapeDimension {
+    fn default() -> Self {
+        ShapeDimension::Surface
+    }
+}

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -1,0 +1,62 @@
+//! Modifiers to influence the rendering of each particle.
+
+use bevy::prelude::*;
+
+use crate::{Gradient, RenderLayout};
+
+/// Trait to customize the rendering of alive particles each frame.
+pub trait RenderModifier {
+    /// Apply the modifier to the render layout of the effect instance.
+    fn apply(&self, render_layout: &mut RenderLayout);
+}
+
+/// A modifier modulating each particle's color by sampling a texture.
+#[derive(Default, Clone)]
+pub struct ParticleTextureModifier {
+    /// The texture image to modulate the particle color with.
+    pub texture: Handle<Image>,
+}
+
+impl RenderModifier for ParticleTextureModifier {
+    fn apply(&self, render_layout: &mut RenderLayout) {
+        render_layout.particle_texture = Some(self.texture.clone());
+    }
+}
+
+/// A modifier modulating each particle's color over its lifetime with a
+/// gradient curve.
+#[derive(Default, Clone)]
+pub struct ColorOverLifetimeModifier {
+    /// The color gradient defining the particle color based on its lifetime.
+    pub gradient: Gradient<Vec4>,
+}
+
+impl RenderModifier for ColorOverLifetimeModifier {
+    fn apply(&self, render_layout: &mut RenderLayout) {
+        render_layout.lifetime_color_gradient = Some(self.gradient.clone());
+    }
+}
+
+/// A modifier modulating each particle's size over its lifetime with a gradient
+/// curve.
+#[derive(Default, Clone)]
+pub struct SizeOverLifetimeModifier {
+    /// The size gradient defining the particle size based on its lifetime.
+    pub gradient: Gradient<Vec2>,
+}
+
+impl RenderModifier for SizeOverLifetimeModifier {
+    fn apply(&self, render_layout: &mut RenderLayout) {
+        render_layout.size_color_gradient = Some(self.gradient.clone());
+    }
+}
+
+/// Reorients the vertices to always face the camera when rendering.
+#[derive(Default, Clone, Copy)]
+pub struct BillboardModifier;
+
+impl RenderModifier for BillboardModifier {
+    fn apply(&self, render_layout: &mut RenderLayout) {
+        render_layout.billboard = true;
+    }
+}

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -1,0 +1,145 @@
+//! Modifiers to influence the update behavior of particle each frame.
+//!
+//! The update modifiers control how particles are updated each frame by the
+//! update compute shader.
+
+use bevy::prelude::*;
+
+use crate::UpdateLayout;
+
+/// Trait to customize the updating of existing particles each frame.
+pub trait UpdateModifier {
+    /// Apply the modifier to the update layout of the effect instance.
+    fn apply(&self, update_layout: &mut UpdateLayout);
+}
+
+/// A modifier to apply a constant acceleration to all particles each frame.
+/// Used to simulate gravity.
+#[derive(Default, Clone, Copy)]
+pub struct AccelModifier {
+    /// The constant acceleration to apply to all particles in the effect each
+    /// frame.
+    pub accel: Vec3,
+}
+
+impl UpdateModifier for AccelModifier {
+    fn apply(&self, layout: &mut UpdateLayout) {
+        layout.accel = self.accel;
+    }
+}
+
+/// A single attraction or repulsion source of a [`ForceFieldModifier`].
+///
+/// The source applies a radial force field to all particles around its
+/// position, with a decreasing intensity the further away from the source the
+/// particle is. This force is added to the one(s) of all the other active
+/// sources of a [`ForceFieldModifier`].
+#[derive(Debug, Clone, Copy)]
+pub struct ForceFieldSource {
+    /// Position of the source.
+    pub position: Vec3,
+    /// Maximum radius of the sphere of influence, outside of which
+    /// the contribution of this source to the force field is null.
+    pub max_radius: f32,
+    /// Minimum radius of the sphere of influence, inside of which
+    /// the contribution of this source to the force field is null, avoiding the
+    /// singularity at the source position.
+    pub min_radius: f32,
+    /// The intensity of the force of the source is proportional to its mass.
+    /// Note that the update shader will ignore all subsequent force field
+    /// sources after it encountered a source with a mass of zero. To change
+    /// the force from an attracting one to a repulsive one, simply
+    /// set the mass to a negative value.
+    pub mass: f32,
+    /// The source force is proportional to `1 / distance^force_exponent`.
+    pub force_exponent: f32,
+    /// If `true`, the particles which attempt to come closer than
+    /// [`min_radius`] from the source position will conform to a sphere of
+    /// radius [`min_radius`] around the source position, appearing like a
+    /// recharging effect.
+    ///
+    /// [`min_radius`]: ForceFieldSource::min_radius
+    pub conform_to_sphere: bool,
+}
+
+impl Default for ForceFieldSource {
+    fn default() -> Self {
+        // defaults to no force field (a mass of 0)
+        ForceFieldSource {
+            position: Vec3::new(0., 0., 0.),
+            min_radius: 0.1,
+            max_radius: 0.0,
+            mass: 0.,
+            force_exponent: 0.0,
+            conform_to_sphere: false,
+        }
+    }
+}
+
+impl ForceFieldSource {
+    /// Maximum number of sources in the force field.
+    pub const MAX_SOURCES: usize = 16;
+}
+
+/// A modifier to apply a force field to all particles each frame. The force
+/// field is made up of [`ForceFieldSource`]s.
+///
+/// The maximum number of sources is [`ForceFieldSource::MAX_SOURCES`].
+#[derive(Default, Clone, Copy)]
+pub struct ForceFieldModifier {
+    /// Array of force field sources.
+    ///
+    /// A source can be disabled by setting its [`mass`] to zero. In that case,
+    /// all other sources located after it in the array are automatically
+    /// disabled too.
+    ///
+    /// [`mass`]: ForceFieldSource::mass
+    pub sources: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
+}
+
+impl ForceFieldModifier {
+    /// Instantiate a [`ForceFieldModifier`] with a set of sources.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of sources exceeds [`MAX_SOURCES`].
+    ///
+    /// [`MAX_SOURCES`]: ForceFieldSource::MAX_SOURCES
+    pub fn new<T>(sources: T) -> Self
+    where
+        T: IntoIterator<Item = ForceFieldSource>,
+    {
+        let mut source_array = [ForceFieldSource::default(); ForceFieldSource::MAX_SOURCES];
+
+        for (index, p_attractor) in sources.into_iter().enumerate() {
+            if index > ForceFieldSource::MAX_SOURCES {
+                panic!(
+                    "Force field source count exceeded maximum of {}",
+                    ForceFieldSource::MAX_SOURCES
+                );
+            }
+            source_array[index] = p_attractor;
+        }
+
+        Self {
+            sources: source_array,
+        }
+    }
+
+    /// Overwrite the source at the given index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than or equal to [`MAX_SOURCES`].
+    ///
+    /// [`MAX_SOURCES`]: ForceFieldSource::MAX_SOURCES
+    pub fn add_or_replace(&mut self, source: ForceFieldSource, index: usize) {
+        self.sources[index] = source;
+    }
+}
+
+impl UpdateModifier for ForceFieldModifier {
+    fn apply(&self, layout: &mut UpdateLayout) {
+        layout.force_field = self.sources;
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -39,7 +39,7 @@ use bevy::core_pipeline::core_3d::Transparent3d;
 
 use crate::{
     asset::EffectAsset,
-    modifiers::{ForceFieldParam, FFNUM},
+    modifier::update::ForceFieldSource,
     spawn::{new_rng, Random},
     Gradient, ParticleEffect, RemovedEffectsEvent, ToWgslString,
 };
@@ -138,8 +138,8 @@ pub struct ForceFieldStd430 {
     pub conform_to_sphere: f32,
 }
 
-impl From<ForceFieldParam> for ForceFieldStd430 {
-    fn from(param: ForceFieldParam) -> Self {
+impl From<ForceFieldSource> for ForceFieldStd430 {
+    fn from(param: ForceFieldSource) -> Self {
         ForceFieldStd430 {
             position_or_direction: param.position,
             max_radius: param.max_radius,
@@ -167,7 +167,7 @@ struct SpawnerParams {
     /// Number of particles to spawn this frame.
     spawn: i32,
     /// Force field components. One PullingForceFieldParam takes up 32 bytes.
-    force_field: [ForceFieldStd430; FFNUM],
+    force_field: [ForceFieldStd430; ForceFieldSource::MAX_SOURCES],
     /// Spawn seed, for randomized modifiers.
     seed: u32,
     /// Current number of used particles.
@@ -553,7 +553,7 @@ pub struct ExtractedEffect {
     /// Constant acceleration applied to all particles.
     pub accel: Vec3,
     /// Force field applied to all particles in the "update" phase.
-    force_field: [ForceFieldParam; FFNUM],
+    force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
     /// Particles tint to modulate with the texture image.
     pub color: Color,
     pub rect: MinMaxRect,
@@ -1192,7 +1192,8 @@ pub(crate) fn prepare_effects(
 
         // extract the force field and turn it into a struct that is compliant with
         // Std430, namely ForceFieldStd430
-        let mut extracted_force_field = [ForceFieldStd430::default(); FFNUM];
+        let mut extracted_force_field =
+            [ForceFieldStd430::default(); ForceFieldSource::MAX_SOURCES];
         for (i, ff) in extracted_effect.force_field.iter().enumerate() {
             extracted_force_field[i] = (*ff).into();
         }

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -14,7 +14,7 @@ struct SimParams {
     time: f32,
 };
 
-struct ForceFieldParam {
+struct ForceFieldSource {
     position: vec3<f32>,
     max_radius: f32,
     min_radius: f32,
@@ -27,7 +27,7 @@ struct Spawner {
     transform: mat3x4<f32>, // transposed (row-major)
     accel: vec3<f32>,
     spawn: atomic<i32>,
-    force_field: array<ForceFieldParam, 16>,
+    force_field: array<ForceFieldSource, 16>,
     seed: u32,
     count: atomic<i32>,
 };


### PR DESCRIPTION
Move all the modifiers under a top-level `modifier` module, and further group them based on the phase they modify under three sub-modules `init`, `update`, and `render`.

Clean-up the `ForceFieldModifier` with various renames for clarity and consistency, and added documentation.