### PR TITLE
Make `EffectCacheId` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The orientation of the `Entity` of the `ParticleEffect` is now taken into account for spawning. (#42)
 - Ensure all GPU resources are deallocated when a `ParticleEffect` component is despawned. (#45)
 
+### Removed
+
+- `EffectCacheId` is now private. It was exposed publicly by error, and cannot be used for anything in the public API anyway.
+
 ## [0.3.1] 2022-08-19
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,12 +126,14 @@ mod spawn;
 #[cfg(test)]
 mod test_utils;
 
+use render::EffectCacheId;
+
 pub use asset::{EffectAsset, InitLayout, RenderLayout, UpdateLayout};
 pub use bundle::ParticleEffectBundle;
 pub use gradient::{Gradient, GradientKey};
 pub use modifier::*;
 pub use plugin::HanabiPlugin;
-pub use render::{EffectCacheId, PipelineRegistry};
+pub use render::PipelineRegistry;
 pub use spawn::{Random, Spawner, Value};
 
 #[allow(missing_docs)]

--- a/src/material.rs
+++ b/src/material.rs
@@ -16,23 +16,36 @@ use bevy_render::{
 };
 use wgpu::{BindGroupDescriptor, BindGroupEntry, BindingResource};
 
-/// A material for a [`ParticleEffect`]
+/// A material for a [`ParticleEffect`].
 ///
 /// May be created directly from a [`Color`] or an [`Image`].
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "1ebefa44-80b6-46bc-939d-5bf39ff15f53"]
 pub struct EffectMaterial {
+    /// The bsae color of the particles.
+    ///
+    /// This is multiplied by the sampling of the [`base_color_texture`], if any.
+    ///
+    /// [`base_color_texture`]: EffectMaterial::base_color_texture
     pub base_color: Color,
+    /// The bsae color texture of the particles.
+    ///
+    /// This is multiplied by the scalar [`base_color`].
+    ///
+    /// [`base_color`]: EffectMaterial::base_color
     pub base_color_texture: Option<Handle<Image>>,
+    /// Enable double-sided rendering.
     pub double_sided: bool,
+    /// Disable lighting in rendering, use a full-bright model.
     pub unlit: bool,
+    /// Alpha blending mode for rendering the particles.
     pub alpha_mode: AlphaMode,
 }
 
 impl Default for EffectMaterial {
     fn default() -> Self {
         EffectMaterial {
-            base_color: Color::rgb(1.0, 1.0, 1.0),
+            base_color: Color::WHITE,
             base_color_texture: None,
             double_sided: false,
             unlit: false,
@@ -92,7 +105,7 @@ impl Plugin for EffectMaterialPlugin {
     }
 }
 
-/// The GPU representation of a [`EffectMaterial`].
+/// The GPU representation of an [`EffectMaterial`].
 #[derive(Debug, Clone)]
 pub struct GpuEffectMaterial {
     /// A buffer containing the [`EffectMaterialUniformData`] of the material.

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -339,7 +339,7 @@ impl EffectBuffer {
 
 /// Identifier referencing an effect cached in an internal effect cache.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct EffectCacheId(u64);
+pub(crate) struct EffectCacheId(u64);
 
 impl EffectCacheId {
     /// An invalid handle, corresponding to nothing.
@@ -353,7 +353,7 @@ impl EffectCacheId {
 }
 
 /// Cache for effect instances sharing common GPU data structures.
-pub struct EffectCache {
+pub(crate) struct EffectCache {
     /// Render device the GPU resources (buffers) are allocated from.
     device: RenderDevice,
     /// Collection of effect buffers managed by this cache. Some buffers might


### PR DESCRIPTION
Hide the `EffectCacheId` type, which is only used internally and has no value to the API user.