### PR TITLE
Single bind group for particles and indirection

### DIFF
--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -38,8 +38,8 @@ struct IndirectBuffer {
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
+@group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner;
-@group(3) @binding(0) var<storage, read_write> indirect_buffer : IndirectBuffer;
 
 var<private> seed : u32 = 0u;
 


### PR DESCRIPTION
Use a single common bind group for both the particle buffer containing the actual per-particle data, and the indirect buffer containing the index of the particles to render in sorted order. This frees up a bind group for other uses in the update compute shader, while keeping their number under the wgpu default limit of 4.