### PR TITLE
Fix item alignment for GPU in `AlignedBufferVec`

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -861,7 +861,7 @@ impl EffectsMeta {
             });
         }
 
-        let item_align = device.limits().min_storage_buffer_offset_alignment as usize;
+        let item_align = device.limits().min_storage_buffer_offset_alignment as u64;
 
         Self {
             entity_map: HashMap::default(),
@@ -873,7 +873,7 @@ impl EffectsMeta {
             sim_params_uniforms: UniformBuffer::default(),
             spawner_buffer: AlignedBufferVec::new(
                 BufferUsages::STORAGE,
-                item_align,
+                NonZeroU64::new(item_align),
                 Some("hanabi:spawner_buffer".to_string()),
             ),
             vertices,


### PR DESCRIPTION
Ensure that `AlignedBufferVec` items are properly aligned according to the WGSL language rules.

Fixes #55