### PR TITLE
Respect user-defined MSAA setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Respect user-defined MSAA setting by reading the value of `Msaa::samples` when building the render pipeline. (#59)
+
 ## [0.4.0] 2022-10-11
 
 ### Added


### PR DESCRIPTION
Ensure the render pipeline reads the `Msaa::samples` value defined by the user instead of assuming a value.

Fixes #59