### PR TITLE
Fix bugs in `EffectCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Respect user-defined MSAA setting by reading the value of `Msaa::samples` when building the render pipeline. (#59)
 - Fixed a bug in the effect cache causing a panic sometimes when effects are removed. (#60)
+- Fixed a bug where an effect instance would be allocated overwriting another existing instance.
+- Fixed a bug in the calculation of some GPU buffer binding causing a panic under some combination of effect capacity and spawn count. (#68)
 
 ## [0.4.0] 2022-10-11
 


### PR DESCRIPTION
- Fix indirect buffer binding calculation, which results in panic when the capacity is small compared to the spawn count.
- Fix `pop_free_slice()` to prevent allocating over a range too small, and to split free slices in case the new requested size is strictly smaller than the best free slice, so that no space is wasted.

Fixes #68