### PR TITLE
[DRAFT] - Updated to work with bevy 0.9-dev breaking API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ ron = "0.7"
 bitflags = "1.3"
 
 [dependencies.bevy]
-version = "0.8"
+#bevy = "0.8.0"
+git = "https://github.com/bevyengine/bevy.git"
+branch = "main"
 default-features = false
 features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.4.1"
+version = "0.5.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Hanabi GPU particle system for the Bevy game engine"
@@ -32,7 +32,6 @@ ron = "0.7"
 bitflags = "1.3"
 
 [dependencies.bevy]
-#bevy = "0.8.0"
 git = "https://github.com/bevyengine/bevy.git"
 branch = "main"
 default-features = false

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -2,6 +2,7 @@ use bevy::{
     asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
     ecs::reflect::ReflectResource,
     math::{Vec2, Vec3, Vec4},
+    prelude::Resource,
     reflect::{Reflect, TypeUuid},
     render::texture::Image,
     utils::BoxedFuture,
@@ -66,7 +67,7 @@ pub struct RenderLayout {
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
-#[derive(Default, Clone, Serialize, Deserialize, Reflect, TypeUuid)]
+#[derive(Default, Clone, Serialize, Deserialize, Resource, Reflect, TypeUuid)]
 #[reflect(Resource)]
 #[uuid = "249aefa4-9b8e-48d3-b167-3adf6c081c34"]
 pub struct EffectAsset {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -785,7 +785,7 @@ pub(crate) fn extract_effects(
                         .render_layout
                         .particle_texture
                         .clone()
-                        .map_or(HandleId::default::<Image>(), |handle| handle.id()),
+                        .map_or(HandleId::default::<Image>(), |handle| handle.id), // FIXME: might be handle.id() in bevy 0.9
                     compute_shader: compute_shader.clone(),
                     render_shader: render_shader.clone(),
                     position_code,

--- a/src/render/pipeline_template.rs
+++ b/src/render/pipeline_template.rs
@@ -2,12 +2,12 @@ use bevy::{
     asset::{Assets, Handle},
     log::debug,
     render::render_resource::Shader,
-    utils::HashMap,
+    utils::HashMap, prelude::Resource,
 };
 use std::hash::Hash;
 
 ///
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct PipelineRegistry {
     cache: HashMap<String, Handle<Shader>>,
 }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,4 +1,4 @@
-use bevy::reflect::Reflect;
+use bevy::{reflect::{Reflect, FromReflect}, prelude::Resource};
 use rand::{
     distributions::{uniform::SampleUniform, Distribution, Uniform},
     SeedableRng,
@@ -15,6 +15,7 @@ pub(crate) fn new_rng() -> Pcg32 {
 }
 
 /// An RNG resource
+#[derive(Resource)]
 pub struct Random(pub Pcg32);
 
 /// A constant or random value.
@@ -66,7 +67,7 @@ impl<T: Copy> From<T> for Value<T> {
 }
 
 /// Spawner defining how new particles are created.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Reflect)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Reflect, FromReflect)]
 pub struct Spawner {
     /// Number of particles to spawn over `spawn_time`
     #[reflect(ignore)] // TODO


### PR DESCRIPTION
The upcoming bevy 0.9 comes with a slew of breaking api changes.
They were substantial enough that I went forward with updating my `bevy_hanabi` branch to work with 0.9

Since 0.9 is a ways away, I'm leaving this as a DRAFT PR for the day when 0.9 lands.