### PR TITLE
Split init/update phases + indirect dispatch/render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Disabled broken effect batching until #73 is fixed, to prevent triggering batching which breaks rendering.
+- Switched to a new internal architecture, splitting the initializing of newly spawned particles from the updating of all alive particles, to achieve more consistent workload on the update compute. Added GPU-driven compute dispatch and rendering, which slighly improves performance and reduces CPU dependency/synchronization. This is mostly an internal change, but with the potential to unblock or facilitate several other issues. (#19)
 
 ## [0.4.1] 2022-10-28
 

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -2,7 +2,6 @@ use bevy::{
     prelude::*,
     render::{
         mesh::shape::Cube,
-        render_resource::WgpuFeatures,
         settings::{WgpuLimits, WgpuSettings},
     },
 };
@@ -11,26 +10,15 @@ use bevy_inspector_egui::WorldInspectorPlugin;
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     // Optional; test that a stronger constraint is handled correctly.
-    // On macOS the alignment is commonly 256 bytes, whereas on Desktop GPUs
-    // it can be much smaller, like 16 bytes only. Force 256 bytes here for
-    // the sake of exercising a bit that codepath, and as an example of how
-    // to force a particular limit.
-    let limits = WgpuLimits {
-        min_storage_buffer_offset_alignment: 256,
-        ..Default::default()
-    };
+    // For example, on macOS the alignment for storage buffer offsets is commonly
+    // 256 bytes, whereas on Desktop GPUs it can be much smaller, like 16 bytes
+    // only. Force the downlevel limits here, and as an example of how
+    // to force a particular limit, and to show Hanabi works with those settings.
+    let mut options = WgpuSettings::default();
+    let limits = WgpuLimits::downlevel_defaults();
     options.constrained_limits = Some(limits);
 
-    // options
-    //     .features
-    //     .set(WgpuFeatures::MAPPABLE_PRIMARY_BUFFERS, false);
-    // println!("wgpu options: {:?}", options.features);
     App::default()
         .insert_resource(options)
         .insert_resource(bevy::log::LogSettings {
@@ -161,6 +149,8 @@ fn setup(
                 .insert(Name::new("source"));
         });
 
+    // Note: same as gradient2, will yield shared render shader between effects #2
+    // and #3
     let mut gradient3 = Gradient::new();
     gradient3.add_key(0.0, Vec4::new(0.0, 0.0, 1.0, 1.0));
     gradient3.add_key(1.0, Vec4::splat(0.0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,10 @@ fn tick_spawners(
 
         // Lazily configure shaders on first use (or after some changes occurred)
         // TODO - Reconfigure only the shader that changed, not both
-        if effect.configured_init_shader.is_none() || effect.configured_update_shader.is_none() || effect.configured_render_shader.is_none() {
+        if effect.configured_init_shader.is_none()
+            || effect.configured_update_shader.is_none()
+            || effect.configured_render_shader.is_none()
+        {
             let asset = effects.get(&effect.handle).unwrap(); // must succeed since it did above
 
             // Extract the acceleration
@@ -582,8 +585,7 @@ fn tick_spawners(
             // asset exists
             let mut init_shader_source =
                 PARTICLES_INIT_SHADER_TEMPLATE.replace("{{INIT_POS_VEL}}", &position_code);
-            init_shader_source =
-                init_shader_source.replace("{{INIT_LIFETIME}}", &lifetime_code);
+            init_shader_source = init_shader_source.replace("{{INIT_LIFETIME}}", &lifetime_code);
             let init_shader = pipeline_registry.configure(&init_shader_source, &mut shaders);
 
             // Configure the update shader template, and make sure a corresponding shader

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,8 @@ impl ShaderCode for Gradient<Vec4> {
 /// visibility system has updated the [`ComputedVisibility`] of each effect
 /// instance (see [`VisibilitySystems::CheckVisibility`]). Hidden instances are
 /// not updated.
+///
+/// [`VisibilitySystems::CheckVisibility`]: bevy::render::view::VisibilitySystems::CheckVisibility
 fn tick_spawners(
     time: Res<Time>,
     effects: Res<Assets<EffectAsset>>,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -77,6 +77,7 @@ impl Plugin for HanabiPlugin {
             );
 
         // Register the built-in shaders
+        // FIXME - Unused, we create the pipeline directly with include_str!() in render/mod.rs
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         let indirect_shader = Shader::from_wgsl(include_str!("render/vfx_indirect.wgsl"));
         shaders.set_untracked(VFX_INDIRECT_SHADER_HANDLE, indirect_shader);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -77,7 +77,8 @@ impl Plugin for HanabiPlugin {
             );
 
         // Register the built-in shaders
-        // FIXME - Unused, we create the pipeline directly with include_str!() in render/mod.rs
+        // FIXME - Unused, we create the pipeline directly with include_str!() in
+        // render/mod.rs
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         let indirect_shader = Shader::from_wgsl(include_str!("render/vfx_indirect.wgsl"));
         shaders.set_untracked(VFX_INDIRECT_SHADER_HANDLE, indirect_shader);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -24,7 +24,6 @@ use crate::{
         DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectSystems,
         EffectsMeta, ExtractedEffects, ParticleUpdateNode, ParticlesInitPipeline,
         ParticlesRenderPipeline, ParticlesUpdatePipeline, PipelineRegistry, SimParams,
-        VFX_INDIRECT_SHADER_HANDLE,
     },
     spawn::{self, Random},
     tick_spawners, ParticleEffect, RemovedEffectsEvent, Spawner,
@@ -75,13 +74,6 @@ impl Plugin for HanabiPlugin {
                 CoreStage::PostUpdate,
                 gather_removed_effects.label(EffectSystems::GatherRemovedEffects),
             );
-
-        // Register the built-in shaders
-        // FIXME - Unused, we create the pipeline directly with include_str!() in
-        // render/mod.rs
-        let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
-        let indirect_shader = Shader::from_wgsl(include_str!("render/vfx_indirect.wgsl"));
-        shaders.set_untracked(VFX_INDIRECT_SHADER_HANDLE, indirect_shader);
 
         // Register the component reflection
         app.register_type::<EffectAsset>();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,8 +20,8 @@ use crate::{
     render::{
         extract_effect_events, extract_effects, prepare_effects, queue_effects, DrawEffects,
         EffectAssetEvents, EffectBindGroups, EffectSystems, EffectsMeta, ExtractedEffects,
-        ParticleUpdateNode, ParticlesRenderPipeline, ParticlesUpdatePipeline, PipelineRegistry,
-        SimParams, PARTICLES_RENDER_SHADER_HANDLE, PARTICLES_UPDATE_SHADER_HANDLE,
+        ParticleUpdateNode, ParticlesRenderPipeline,ParticlesInitPipeline, ParticlesUpdatePipeline, PipelineRegistry,
+        SimParams
     },
     spawn::{self, Random},
     tick_spawners, ParticleEffect, RemovedEffectsEvent, Spawner,
@@ -59,13 +59,6 @@ impl Plugin for HanabiPlugin {
                 gather_removed_effects.label(EffectSystems::GatherRemovedEffects),
             );
 
-        // Register the particles shaders
-        let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
-        let update_shader = Shader::from_wgsl(include_str!("render/particles_update.wgsl"));
-        shaders.set_untracked(PARTICLES_UPDATE_SHADER_HANDLE, update_shader);
-        let render_shader = Shader::from_wgsl(include_str!("render/particles_render.wgsl"));
-        shaders.set_untracked(PARTICLES_RENDER_SHADER_HANDLE, render_shader);
-
         // Register the component reflection
         app.register_type::<EffectAsset>();
         app.register_type::<ParticleEffect>();
@@ -79,6 +72,8 @@ impl Plugin for HanabiPlugin {
         render_app
             .insert_resource(effects_meta)
             .init_resource::<EffectBindGroups>()
+            .init_resource::<ParticlesInitPipeline>()
+            .init_resource::<SpecializedComputePipelines<ParticlesInitPipeline>>()
             .init_resource::<ParticlesUpdatePipeline>()
             .init_resource::<SpecializedComputePipelines<ParticlesUpdatePipeline>>()
             .init_resource::<ParticlesRenderPipeline>()

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -7,7 +7,9 @@ use bevy::{
     render::{
         render_graph::RenderGraph,
         render_phase::DrawFunctions,
-        render_resource::{SpecializedComputePipelines, SpecializedRenderPipelines},
+        render_resource::{
+            SpecializedComputePipelines, SpecializedRenderPipelines, WgpuAdapterInfo,
+        },
         renderer::RenderDevice,
         view::visibility::VisibilitySystems,
         RenderApp, RenderStage,
@@ -18,10 +20,11 @@ use crate::{
     asset::{EffectAsset, EffectAssetLoader},
     gather_removed_effects,
     render::{
-        extract_effect_events, extract_effects, prepare_effects, queue_effects, DrawEffects,
-        EffectAssetEvents, EffectBindGroups, EffectSystems, EffectsMeta, ExtractedEffects,
-        ParticleUpdateNode, ParticlesInitPipeline, ParticlesRenderPipeline,
-        ParticlesUpdatePipeline, PipelineRegistry, SimParams, VFX_INDIRECT_SHADER_HANDLE, DispatchIndirectPipeline,
+        extract_effect_events, extract_effects, prepare_effects, queue_effects,
+        DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectSystems,
+        EffectsMeta, ExtractedEffects, ParticleUpdateNode, ParticlesInitPipeline,
+        ParticlesRenderPipeline, ParticlesUpdatePipeline, PipelineRegistry, SimParams,
+        VFX_INDIRECT_SHADER_HANDLE,
     },
     spawn::{self, Random},
     tick_spawners, ParticleEffect, RemovedEffectsEvent, Spawner,
@@ -40,6 +43,20 @@ pub struct HanabiPlugin;
 
 impl Plugin for HanabiPlugin {
     fn build(&self, app: &mut App) {
+        let render_device = app.world.get_resource::<RenderDevice>().unwrap().clone();
+
+        // Check device limits
+        let limits = render_device.limits();
+        if limits.max_bind_groups < 4 {
+            let adapter_name = app
+                .world
+                .get_resource::<WgpuAdapterInfo>()
+                .map(|ai| &ai.name[..])
+                .unwrap_or("<unknown>");
+            error!("Hanabi requires a GPU device supporting at least 4 bind groups (Limits::max_bind_groups).\n  Current adapter: {}\n  Supported bind groups: {}", adapter_name, limits.max_bind_groups);
+            return;
+        }
+
         // Register asset
         app.add_asset::<EffectAsset>()
             .add_event::<RemovedEffectsEvent>()
@@ -69,7 +86,6 @@ impl Plugin for HanabiPlugin {
         app.register_type::<ParticleEffect>();
         app.register_type::<Spawner>();
 
-        let render_device = app.world.get_resource::<RenderDevice>().unwrap();
         let effects_meta = EffectsMeta::new(render_device.clone());
 
         // Register the custom render pipeline

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,8 +20,8 @@ use crate::{
     render::{
         extract_effect_events, extract_effects, prepare_effects, queue_effects, DrawEffects,
         EffectAssetEvents, EffectBindGroups, EffectSystems, EffectsMeta, ExtractedEffects,
-        ParticleUpdateNode, ParticlesRenderPipeline,ParticlesInitPipeline, ParticlesUpdatePipeline, PipelineRegistry,
-        SimParams
+        ParticleUpdateNode, ParticlesInitPipeline, ParticlesRenderPipeline,
+        ParticlesUpdatePipeline, PipelineRegistry, SimParams, VFX_INDIRECT_SHADER_HANDLE, DispatchIndirectPipeline,
     },
     spawn::{self, Random},
     tick_spawners, ParticleEffect, RemovedEffectsEvent, Spawner,
@@ -59,6 +59,11 @@ impl Plugin for HanabiPlugin {
                 gather_removed_effects.label(EffectSystems::GatherRemovedEffects),
             );
 
+        // Register the built-in shaders
+        let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
+        let indirect_shader = Shader::from_wgsl(include_str!("render/vfx_indirect.wgsl"));
+        shaders.set_untracked(VFX_INDIRECT_SHADER_HANDLE, indirect_shader);
+
         // Register the component reflection
         app.register_type::<EffectAsset>();
         app.register_type::<ParticleEffect>();
@@ -72,6 +77,7 @@ impl Plugin for HanabiPlugin {
         render_app
             .insert_resource(effects_meta)
             .init_resource::<EffectBindGroups>()
+            .init_resource::<DispatchIndirectPipeline>()
             .init_resource::<ParticlesInitPipeline>()
             .init_resource::<SpecializedComputePipelines<ParticlesInitPipeline>>()
             .init_resource::<ParticlesUpdatePipeline>()

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -243,6 +243,7 @@ mod tests {
     use super::*;
 
     const INTS: &[usize] = &[1, 2, 4, 8, 9, 15, 16, 17, 23, 24, 31, 32, 33];
+    const INTS_POW2: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
 
     /// Same as `INTS`, rounded up to 16
     const INTS16: &[usize] = &[16, 16, 16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 48];
@@ -255,7 +256,7 @@ mod tests {
         }
 
         // zero-sized is always aligned
-        for &align in INTS {
+        for &align in INTS_POW2 {
             assert_eq!(0, next_multiple_of(0, align));
         }
 

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -25,7 +25,7 @@ pub(crate) fn next_multiple_of(value: usize, align: usize) -> usize {
 ///
 /// This is a helper to ensure the data is properly aligned when copied to GPU,
 /// depending on the device constraints and the WGSL rules. Generally the
-/// alignment is one of the [`wgpu::Limits`], and is also ensured to be
+/// alignment is one of the [`WgpuLimits`], and is also ensured to be
 /// compatible with WGSL.
 ///
 /// The element type `T` needs to implement the following traits:
@@ -36,6 +36,7 @@ pub(crate) fn next_multiple_of(value: usize, align: usize) -> usize {
 ///   runtime-sized array.
 ///
 /// [`BufferVec`]: bevy::render::render_resource::BufferVec
+/// [`WgpuLimits`]: bevy::render::settings::WgpuLimits
 pub struct AlignedBufferVec<T: Pod + ShaderType + ShaderSize> {
     values: Vec<T>,
     buffer: Option<Buffer>,

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -15,7 +15,8 @@ use copyless::VecHelper;
 
 // TODO - filler for usize.next_multiple_of()
 // https://github.com/rust-lang/rust/issues/88581
-fn next_multiple_of(value: usize, align: usize) -> usize {
+pub(crate) fn next_multiple_of(value: usize, align: usize) -> usize {
+    assert!(align & (align - 1) == 0); // power of 2
     let count = (value + align - 1) / align;
     count * align
 }

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -260,8 +260,7 @@ impl EffectBuffer {
                 //
                 slice[0].alive_count = 0;
                 slice[0].dead_count = capacity;
-                //
-                slice[0].__pad = 0xdeadbeef;
+                slice[0].max_spawn = capacity;
             }
             trace!(
                 "render_indirect_buffer ready = {:?}",

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -124,10 +124,10 @@ pub enum BufferState {
 
 impl EffectBuffer {
     /// Minimum buffer capacity to allocate, in number of particles.
-    // FIXME - Batching is broken due to binding a single GpuSpawnerParam instead of N,
-    // and inability for a particle index to tell which Spawner it should use. Setting
-    // this to 1 effectively ensures that all new buffers just fit the effect, so batching
-    // never occurs.
+    // FIXME - Batching is broken due to binding a single GpuSpawnerParam instead of
+    // N, and inability for a particle index to tell which Spawner it should
+    // use. Setting this to 1 effectively ensures that all new buffers just fit
+    // the effect, so batching never occurs.
     pub const MIN_CAPACITY: u32 = 1; //65536; // at least 64k particles
 
     /// Create a new group and a GPU buffer to back it up.

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -124,7 +124,7 @@ pub enum BufferState {
 
 impl EffectBuffer {
     /// Minimum buffer capacity to allocate, in number of particles.
-    pub const MIN_CAPACITY: u32 = 256; //65536; // at least 64k particles
+    pub const MIN_CAPACITY: u32 = 65536; // at least 64k particles
 
     /// Create a new group and a GPU buffer to back it up.
     ///
@@ -170,6 +170,7 @@ impl EffectBuffer {
         });
         // Set content
         {
+            // Scope get_mapped_range_mut() to force a drop before unmap()
             {
                 let slice = &mut indirect_buffer.slice(..).get_mapped_range_mut()
                     [..index_capacity_bytes as usize * 3];

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -249,7 +249,7 @@ impl EffectBuffer {
                 //
                 slice[0].ping = 0;
                 slice[0].__pad0 = 0xaaaaaaaa;
-                slice[0].__pad0 = 0xbbbbbbbb;
+                slice[0].__pad1 = 0xbbbbbbbb;
                 slice[0].__pad2 = 0xcccccccc;
             }
             trace!(

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -154,8 +154,7 @@ impl EffectBuffer {
             mapped_at_creation: false,
         });
 
-        let index_capacity_bytes: BufferAddress =
-            capacity as u64 * std::mem::size_of::<u32>() as u64;
+        let capacity_bytes: BufferAddress = capacity as u64 * 4;
 
         let indirect_label = if let Some(label) = label {
             format!("{}_indirect", label)
@@ -164,7 +163,7 @@ impl EffectBuffer {
         };
         let indirect_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some(&indirect_label),
-            size: index_capacity_bytes * 3, // ping-pong + deadlist
+            size: capacity_bytes * 3, // ping-pong + deadlist
             usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
             mapped_at_creation: true,
         });
@@ -173,7 +172,7 @@ impl EffectBuffer {
             // Scope get_mapped_range_mut() to force a drop before unmap()
             {
                 let slice = &mut indirect_buffer.slice(..).get_mapped_range_mut()
-                    [..index_capacity_bytes as usize * 3];
+                    [..capacity_bytes as usize * 3];
                 let slice: &mut [u32] = cast_slice_mut(slice);
                 for index in 0..capacity {
                     slice[3 * index as usize + 2] = capacity - 1 - index;

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -172,7 +172,7 @@ impl EffectBuffer {
         };
         let indirect_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some(&indirect_label),
-            size: index_capacity_bytes,
+            size: index_capacity_bytes * 2, // ping-pong
             usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
             mapped_at_creation: false,
         });
@@ -261,6 +261,11 @@ impl EffectBuffer {
                 slice[0].alive_count = 0;
                 slice[0].dead_count = capacity;
                 slice[0].max_spawn = capacity;
+                //
+                slice[0].ping = 0;
+                slice[0].__pad0 = 0xaaaaaaaa;
+                slice[0].__pad0 = 0xbbbbbbbb;
+                slice[0].__pad2 = 0xcccccccc;
             }
             trace!(
                 "render_indirect_buffer ready = {:?}",
@@ -336,7 +341,7 @@ impl EffectBuffer {
         BindingResource::Buffer(BufferBinding {
             buffer: &self.indirect_buffer,
             offset: 0,
-            size: Some(NonZeroU64::new(capacity_bytes).unwrap()),
+            size: Some(NonZeroU64::new(capacity_bytes * 2).unwrap()),
         })
     }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1149,6 +1149,8 @@ impl EffectsMeta {
             });
         }
 
+        // Ensure individual GpuSpawnerParams elements are properly aligned so they can
+        // be addressed individually by the computer shaders.
         let item_align = device.limits().min_storage_buffer_offset_alignment as u64;
 
         Self {
@@ -2495,7 +2497,7 @@ impl Node for ParticleUpdateNode {
                         compute_pass.set_bind_group(
                             1,
                             particles_bind_group,
-                            &[buffer_offset, buffer_offset],
+                            &[buffer_offset, buffer_offset], // FIXME: probably in bytes, so probably wrong!
                         );
                         compute_pass.set_bind_group(
                             2,
@@ -2598,7 +2600,7 @@ impl Node for ParticleUpdateNode {
                     compute_pass.set_bind_group(
                         1,
                         particles_bind_group,
-                        &[buffer_offset, buffer_offset],
+                        &[buffer_offset, buffer_offset], // FIXME: probably in bytes, so probably wrong!
                     );
                     compute_pass.set_bind_group(
                         2,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -286,7 +286,7 @@ pub(crate) struct ParticlesInitPipeline {
     sim_params_layout: BindGroupLayout,
     particles_buffer_layout: BindGroupLayout,
     spawner_buffer_layout: BindGroupLayout,
-    dead_list_layout: BindGroupLayout,
+    render_indirect_layout: BindGroupLayout,
     pipeline_layout: PipelineLayout,
 }
 
@@ -341,7 +341,7 @@ impl FromWorld for ParticlesInitPipeline {
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: true,
-                            min_binding_size: BufferSize::new(std::mem::size_of::<u32>() as u64),
+                            min_binding_size: BufferSize::new(12),
                         },
                         count: None,
                     },
@@ -369,24 +369,13 @@ impl FromWorld for ParticlesInitPipeline {
             });
 
         trace!(
-            "GpuDeadList: min_size={} | GpuRenderIndirect: min_size={}",
-            GpuDeadList::min_size(),
+            "GpuRenderIndirect: min_size={}",
             GpuRenderIndirect::min_size()
         );
-        let dead_list_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                BindGroupLayoutEntry {
+        let render_indirect_layout =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                entries: &[BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: ShaderStages::COMPUTE,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: true,
-                        min_binding_size: Some(GpuDeadList::min_size()),
-                    },
-                    count: None,
-                },
-                BindGroupLayoutEntry {
-                    binding: 1,
                     visibility: ShaderStages::COMPUTE,
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Storage { read_only: false },
@@ -394,10 +383,9 @@ impl FromWorld for ParticlesInitPipeline {
                         min_binding_size: Some(GpuRenderIndirect::min_size()),
                     },
                     count: None,
-                },
-            ],
-            label: Some("hanabi:init_dead_list_layout"),
-        });
+                }],
+                label: Some("hanabi:init_render_indirect_layout"),
+            });
 
         let pipeline_layout = render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
             label: Some("hanabi:init_pipeline_layout"),
@@ -405,7 +393,7 @@ impl FromWorld for ParticlesInitPipeline {
                 &sim_params_layout,
                 &particles_buffer_layout,
                 &spawner_buffer_layout,
-                &dead_list_layout,
+                &render_indirect_layout,
             ],
             push_constant_ranges: &[],
         });
@@ -414,7 +402,7 @@ impl FromWorld for ParticlesInitPipeline {
             sim_params_layout,
             particles_buffer_layout,
             spawner_buffer_layout,
-            dead_list_layout,
+            render_indirect_layout,
             pipeline_layout,
         }
     }
@@ -436,7 +424,7 @@ impl SpecializedComputePipeline for ParticlesInitPipeline {
                 self.sim_params_layout.clone(),
                 self.particles_buffer_layout.clone(),
                 self.spawner_buffer_layout.clone(),
-                self.dead_list_layout.clone(),
+                self.render_indirect_layout.clone(),
             ]),
             shader: key.shader,
             shader_defs: vec![],
@@ -449,7 +437,7 @@ pub(crate) struct ParticlesUpdatePipeline {
     sim_params_layout: BindGroupLayout,
     particles_buffer_layout: BindGroupLayout,
     spawner_buffer_layout: BindGroupLayout,
-    dead_list_layout: BindGroupLayout,
+    render_indirect_layout: BindGroupLayout,
     pipeline_layout: PipelineLayout,
 }
 
@@ -504,7 +492,7 @@ impl FromWorld for ParticlesUpdatePipeline {
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: true,
-                            min_binding_size: BufferSize::new(std::mem::size_of::<u32>() as u64),
+                            min_binding_size: BufferSize::new(12),
                         },
                         count: None,
                     },
@@ -531,21 +519,14 @@ impl FromWorld for ParticlesUpdatePipeline {
                 label: Some("hanabi:update_spawner_buffer_layout"),
             });
 
-        trace!("GpuDeadList: min_size={}", GpuDeadList::min_size());
-        let dead_list_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                BindGroupLayoutEntry {
+        trace!(
+            "GpuRenderIndirect: min_size={}",
+            GpuRenderIndirect::min_size()
+        );
+        let render_indirect_layout =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                entries: &[BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: ShaderStages::COMPUTE,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: true,
-                        min_binding_size: Some(GpuDeadList::min_size()),
-                    },
-                    count: None,
-                },
-                BindGroupLayoutEntry {
-                    binding: 1,
                     visibility: ShaderStages::COMPUTE,
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Storage { read_only: false },
@@ -553,10 +534,9 @@ impl FromWorld for ParticlesUpdatePipeline {
                         min_binding_size: Some(GpuRenderIndirect::min_size()),
                     },
                     count: None,
-                },
-            ],
-            label: Some("hanabi:update_dead_list_layout"),
-        });
+                }],
+                label: Some("hanabi:update_render_indirect_layout"),
+            });
 
         let pipeline_layout = render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
             label: Some("hanabi:update_pipeline_layout"),
@@ -564,7 +544,7 @@ impl FromWorld for ParticlesUpdatePipeline {
                 &sim_params_layout,
                 &particles_buffer_layout,
                 &spawner_buffer_layout,
-                &dead_list_layout,
+                &render_indirect_layout,
             ],
             push_constant_ranges: &[],
         });
@@ -573,7 +553,7 @@ impl FromWorld for ParticlesUpdatePipeline {
             sim_params_layout,
             particles_buffer_layout,
             spawner_buffer_layout,
-            dead_list_layout,
+            render_indirect_layout,
             pipeline_layout,
         }
     }
@@ -595,7 +575,7 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
                 self.sim_params_layout.clone(),
                 self.particles_buffer_layout.clone(),
                 self.spawner_buffer_layout.clone(),
-                self.dead_list_layout.clone(),
+                self.render_indirect_layout.clone(),
             ]),
             shader: key.shader,
             shader_defs: vec![],
@@ -1120,15 +1100,6 @@ struct GpuParticleVertex {
     pub uv: [f32; 2],
 }
 
-/// GPU representation of the dead particle index list stored in a GPU buffer.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, Pod, Zeroable, ShaderType)]
-struct GpuDeadList {
-    /// Runtime-sized array of indices. Only store the first element here,
-    /// to get the minimum binding size for the buffer.
-    pub indices: [u32; 1],
-}
-
 /// Global resource containing the GPU data to draw all the particle effects in
 /// all views.
 ///
@@ -1153,7 +1124,7 @@ pub(crate) struct EffectsMeta {
     /// Bind group for the spawning parameters (number of particles to spawn
     /// this frame, ...).
     spawner_bind_group: Option<BindGroup>,
-    dead_list_bind_group: Option<BindGroup>,
+    render_indirect_bind_group: Option<BindGroup>,
     sim_params_uniforms: UniformBuffer<SimParamsUniform>,
     spawner_buffer: AlignedBufferVec<GpuSpawnerParams>,
     /// Unscaled vertices of the mesh of a single particle, generally a quad.
@@ -1187,7 +1158,7 @@ impl EffectsMeta {
             sim_params_bind_group: None,
             particles_bind_group: None,
             spawner_bind_group: None,
-            dead_list_bind_group: None,
+            render_indirect_bind_group: None,
             sim_params_uniforms: UniformBuffer::default(),
             spawner_buffer: AlignedBufferVec::new(
                 BufferUsages::STORAGE,
@@ -1683,15 +1654,13 @@ pub(crate) struct EffectBindGroups {
     /// Bind groups for each group index for init shader.
     init_particle_buffers: HashMap<u32, BindGroup>,
     /// Bind groups for each group index for init shader.
-    init_dead_lists: HashMap<u32, BindGroup>,
+    init_render_indirect: HashMap<u32, BindGroup>,
     /// Bind groups for each group index for update shader.
     update_particle_buffers: HashMap<u32, BindGroup>,
     /// Bind groups for each group index for update shader.
-    update_dead_lists: HashMap<u32, BindGroup>,
+    update_render_indirect: HashMap<u32, BindGroup>,
     /// Same for render shader.
     render_particle_buffers: HashMap<u32, BindGroup>,
-    /// Same for render shader.
-    render_dead_lists: HashMap<u32, BindGroup>,
     ///
     images: HashMap<Handle<Image>, BindGroup>,
 }
@@ -1893,7 +1862,7 @@ pub(crate) fn queue_effects(
 
         trace!("effect init dead list buffer_index=#{}", buffer_index);
         effect_bind_groups
-            .init_dead_lists
+            .init_render_indirect
             .entry(buffer_index as u32)
             .or_insert_with(|| {
                 trace!(
@@ -1901,21 +1870,15 @@ pub(crate) fn queue_effects(
                     buffer_index
                 );
                 render_device.create_bind_group(&BindGroupDescriptor {
-                    entries: &[
-                        BindGroupEntry {
-                            binding: 0,
-                            resource: buffer.dead_list_max_binding(),
-                        },
-                        BindGroupEntry {
-                            binding: 1,
-                            resource: buffer.render_indirect_max_binding(),
-                        },
-                    ],
+                    entries: &[BindGroupEntry {
+                        binding: 0,
+                        resource: buffer.render_indirect_max_binding(),
+                    }],
                     label: Some(&format!(
-                        "hanabi:vfx_dead_list_bind_group_init{}",
+                        "hanabi:vfx_render_indirect_bind_group_init{}",
                         buffer_index
                     )),
-                    layout: &read_params.init_pipeline.dead_list_layout,
+                    layout: &read_params.init_pipeline.render_indirect_layout,
                 })
             });
 
@@ -1949,7 +1912,7 @@ pub(crate) fn queue_effects(
 
         trace!("effect update dead list buffer_index=#{}", buffer_index);
         effect_bind_groups
-            .update_dead_lists
+            .update_render_indirect
             .entry(buffer_index as u32)
             .or_insert_with(|| {
                 trace!(
@@ -1957,21 +1920,15 @@ pub(crate) fn queue_effects(
                     buffer_index
                 );
                 render_device.create_bind_group(&BindGroupDescriptor {
-                    entries: &[
-                        BindGroupEntry {
-                            binding: 0,
-                            resource: buffer.dead_list_max_binding(),
-                        },
-                        BindGroupEntry {
-                            binding: 1,
-                            resource: buffer.render_indirect_max_binding(),
-                        },
-                    ],
+                    entries: &[BindGroupEntry {
+                        binding: 0,
+                        resource: buffer.render_indirect_max_binding(),
+                    }],
                     label: Some(&format!(
-                        "hanabi:vfx_dead_list_bind_group_update{}",
+                        "hanabi:vfx_render_indirect_bind_group_update{}",
                         buffer_index
                     )),
-                    layout: &read_params.update_pipeline.dead_list_layout,
+                    layout: &read_params.update_pipeline.render_indirect_layout,
                 })
             });
 
@@ -2500,8 +2457,8 @@ impl Node for ParticleUpdateNode {
                             .get(&batch.buffer_index)
                             .unwrap();
 
-                        let dead_list_bind_group = effect_bind_groups
-                            .init_dead_lists
+                        let render_indirect_bind_group = effect_bind_groups
+                            .init_render_indirect
                             .get(&batch.buffer_index)
                             .unwrap();
 
@@ -2545,7 +2502,7 @@ impl Node for ParticleUpdateNode {
                             effects_meta.spawner_bind_group.as_ref().unwrap(),
                             &[spawner_base * spawner_buffer_aligned as u32],
                         );
-                        compute_pass.set_bind_group(3, dead_list_bind_group, &[0, 0]);
+                        compute_pass.set_bind_group(3, render_indirect_bind_group, &[0]);
                         compute_pass.dispatch_workgroups(workgroup_count, 1, 1);
                         trace!("init compute dispatched");
                     }
@@ -2607,8 +2564,8 @@ impl Node for ParticleUpdateNode {
                         .get(&batch.buffer_index)
                         .unwrap();
 
-                    let dead_list_bind_group = effect_bind_groups
-                        .update_dead_lists
+                    let render_indirect_bind_group = effect_bind_groups
+                        .update_render_indirect
                         .get(&batch.buffer_index)
                         .unwrap();
 
@@ -2648,7 +2605,7 @@ impl Node for ParticleUpdateNode {
                         effects_meta.spawner_bind_group.as_ref().unwrap(),
                         &[spawner_base * spawner_buffer_aligned as u32],
                     );
-                    compute_pass.set_bind_group(3, dead_list_bind_group, &[0, 0]);
+                    compute_pass.set_bind_group(3, render_indirect_bind_group, &[0]);
                     // TODO -clean-up this
                     if let Some(buffer) =
                         &effect_bind_groups.indirect_dispatch_indirect_dispatch_buffer

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -91,7 +91,7 @@ pub enum EffectSystems {
 }
 
 /// Reimplementing of bevy::sprite::Rect to avoid the dependency.
-/// See https://github.com/bevyengine/bevy/issues/5575
+/// See <https://github.com/bevyengine/bevy/issues/5575>
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub(crate) struct MinMaxRect {
     pub min: Vec2,
@@ -881,7 +881,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
 }
 
 /// A single effect instance extracted from a [`ParticleEffect`] as a
-/// [`RenderWorld`] item.
+/// render world item.
 #[derive(Component)]
 pub(crate) struct ExtractedEffect {
     /// Handle to the effect asset this instance is based on.
@@ -890,6 +890,8 @@ pub(crate) struct ExtractedEffect {
     pub handle: Handle<EffectAsset>,
     /// Number of particles to spawn this frame for the effect.
     /// Obtained from calling [`Spawner::tick()`] on the source effect instance.
+    ///
+    /// [`Spawner::tick()`]: crate::Spawner::tick
     pub spawn_count: u32,
     /// Global transform of the effect origin, extracted from the
     /// [`GlobalTransform`].
@@ -938,7 +940,7 @@ pub(crate) struct AddedEffect {
 }
 
 /// Collection of all extracted effects for this frame, inserted into the
-/// [`RenderWorld`] as a render resource.
+/// render world as a render resource.
 #[derive(Default)]
 pub(crate) struct ExtractedEffects {
     /// Map of extracted effects from the entity the source [`ParticleEffect`]
@@ -1199,9 +1201,15 @@ pub(crate) struct EffectsMeta {
     vertices: BufferVec<GpuParticleVertex>,
     ///
     indirect_dispatch_pipeline: Option<ComputePipeline>,
-    /// Size of [`GpuDispatchIndirect`] aligned to the contraint of [`WgpuLimits::min_storage_buffer_offset_alignment`].
+    /// Size of [`GpuDispatchIndirect`] aligned to the contraint of
+    /// [`WgpuLimits::min_storage_buffer_offset_alignment`].
+    ///
+    /// [`WgpuLimits::min_storage_buffer_offset_alignment`]: bevy::render::settings::WgpuLimits::min_storage_buffer_offset_alignment
     gpu_dispatch_indirect_aligned_size: Option<NonZeroU32>,
-    /// Size of [`GpuRenderIndirect`] aligned to the contraint of [`WgpuLimits::min_storage_buffer_offset_alignment`].
+    /// Size of [`GpuRenderIndirect`] aligned to the contraint of
+    /// [`WgpuLimits::min_storage_buffer_offset_alignment`].
+    ///
+    /// [`WgpuLimits::min_storage_buffer_offset_alignment`]: bevy::render::settings::WgpuLimits::min_storage_buffer_offset_alignment
     gpu_render_indirect_aligned_size: Option<NonZeroU32>,
 }
 
@@ -2012,7 +2020,8 @@ pub(crate) fn queue_effects(
             layout: &read_params.update_pipeline.render_indirect_layout,
         }));
 
-    // Make a copy of the buffer ID before borrowing effects_meta mutably in the loop below
+    // Make a copy of the buffer ID before borrowing effects_meta mutably in the
+    // loop below
     let indirect_buffer = effects_meta
         .dispatch_indirect_buffer
         .buffer()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -208,7 +208,7 @@ pub struct GpuRenderIndirect {
     pub max_spawn: u32,
     //
     pub ping: u32,
-    pub __pad0: u32,
+    pub max_update: u32,
     pub __pad1: u32,
     pub __pad2: u32,
     // FIXME - min_storage_buffer_offset_alignment
@@ -1384,6 +1384,7 @@ pub(crate) fn prepare_effects(
         ri.dead_count = added_effect.capacity;
         ri.max_spawn = added_effect.capacity;
         ri.ping = 0;
+        ri.max_update = 0;
 
         // FIXME - Think about batching those writes...
         // effects_meta

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1884,7 +1884,8 @@ pub(crate) fn queue_effects(
                 resource: effects_meta.sim_params_uniforms.binding().unwrap(),
             }],
             label: Some("hanabi:bind_group_sim_params"),
-            layout: &read_params.update_pipeline.sim_params_layout, // FIXME - Shared with vfx_update, is that OK?
+            layout: &read_params.update_pipeline.sim_params_layout, /* FIXME - Shared with
+                                                                     * vfx_update, is that OK? */
         }));
 
     // Create the bind group for the spawner parameters
@@ -1900,7 +1901,8 @@ pub(crate) fn queue_effects(
             }),
         }],
         label: Some("hanabi:bind_group_spawner_buffer"),
-        layout: &read_params.update_pipeline.spawner_buffer_layout, // FIXME - Shared with init, is that OK?
+        layout: &read_params.update_pipeline.spawner_buffer_layout, /* FIXME - Shared with init,
+                                                                     * is that OK? */
     }));
 
     // Create the bind group for the indirect dispatch of all effects

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -204,8 +204,8 @@ pub struct GpuRenderIndirect {
     //
     pub alive_count: u32,
     pub dead_count: u32,
-    //
-    pub __pad: u32, // FIXME - min_storage_buffer_offset_alignment
+    pub max_spawn: u32,
+    // FIXME - min_storage_buffer_offset_alignment
 }
 
 /// Compute pipeline to run the vfx_indirect dispatch workgroup calculation shader.
@@ -231,7 +231,7 @@ impl FromWorld for DispatchIndirectPipeline {
                         binding: 0,
                         visibility: ShaderStages::COMPUTE,
                         ty: BindingType::Buffer {
-                            ty: BufferBindingType::Storage { read_only: true },
+                            ty: BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: true,
                             min_binding_size: Some(GpuRenderIndirect::min_size()),
                         },

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1819,10 +1819,6 @@ pub(crate) struct QueueEffectsReadOnlyParams<'w, 's> {
     marker: PhantomData<&'s usize>,
 }
 
-// #[derive(SystemParam)]
-// struct QueueEffectsReadWriteParams<'w, 's> {
-// }
-
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn queue_effects(
     #[cfg(feature = "2d")] mut views_2d: Query<&mut RenderPhase<Transparent2d>>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2430,25 +2430,13 @@ impl Node for ParticleUpdateNode {
         let effects_meta = world.resource::<EffectsMeta>();
         let effect_bind_groups = world.resource::<EffectBindGroups>();
 
-        // Begin encoder
-        // trace!(
-        //     "begin compute init pass... (world={:?} ents={:?} comps={:?})",
-        //     world,
-        //     world.entities(),
-        //     world.components()
-        // );
-        trace!("begin compute init pass...");
-        render_context
-            .command_encoder
-            .push_debug_group("hanabi_init");
-
         // Compute init pass
         {
             let mut compute_pass =
                 render_context
                     .command_encoder
                     .begin_compute_pass(&ComputePassDescriptor {
-                        label: Some("hanabi:init_compute_pass"),
+                        label: Some("hanabi:init"),
                     });
 
             // Retrieve the ExtractedEffectEntities component itself
@@ -2538,29 +2526,13 @@ impl Node for ParticleUpdateNode {
             }
         }
 
-        // End encoder
-        render_context.command_encoder.pop_debug_group();
-        trace!("compute init pass done");
-
-        // Begin encoder
-        // trace!(
-        //     "begin compute indirect dispatch pass... (world={:?} ents={:?} comps={:?})",
-        //     world,
-        //     world.entities(),
-        //     world.components()
-        // );
-        trace!("begin compute indirect dispatch pass...");
-        render_context
-            .command_encoder
-            .push_debug_group("hanabi_indirect_dispatch");
-
         // Compute indirect dispatch pass
         {
             let mut compute_pass =
                 render_context
                     .command_encoder
                     .begin_compute_pass(&ComputePassDescriptor {
-                        label: Some("hanabi:indirect_dispatch_compute_pass"),
+                        label: Some("hanabi:indirect_dispatch"),
                     });
 
             // Dispatch indirect dispatch compute job
@@ -2579,29 +2551,13 @@ impl Node for ParticleUpdateNode {
             }
         }
 
-        // End encoder
-        render_context.command_encoder.pop_debug_group();
-        trace!("compute indirect dispatch pass done");
-
-        // Begin encoder
-        // trace!(
-        //     "begin compute update pass... (world={:?} ents={:?} comps={:?})",
-        //     world,
-        //     world.entities(),
-        //     world.components()
-        // );
-        trace!("begin compute update pass...");
-        render_context
-            .command_encoder
-            .push_debug_group("hanabi_update");
-
         // Compute update pass
         {
             let mut compute_pass =
                 render_context
                     .command_encoder
                     .begin_compute_pass(&ComputePassDescriptor {
-                        label: Some("hanabi:update_compute_pass"),
+                        label: Some("hanabi:update"),
                     });
 
             // Dispatch update compute jobs
@@ -2678,10 +2634,6 @@ impl Node for ParticleUpdateNode {
                 }
             }
         }
-
-        // End encoder
-        render_context.command_encoder.pop_debug_group();
-        trace!("compute update pass done");
 
         Ok(())
     }

--- a/src/render/particles_init.wgsl
+++ b/src/render/particles_init.wgsl
@@ -1,0 +1,189 @@
+struct Particle {
+    pos: vec3<f32>,
+    age: f32,
+    vel: vec3<f32>,
+    lifetime: f32,
+};
+
+struct ParticleBuffer {
+    particles: array<Particle>,
+};
+
+struct SimParams {
+    dt: f32,
+    time: f32,
+};
+
+struct ForceFieldSource {
+    position: vec3<f32>,
+    max_radius: f32,
+    min_radius: f32,
+    mass: f32,
+    force_exponent: f32,
+    conform_to_sphere: f32,
+};
+
+struct Spawner {
+    transform: mat3x4<f32>, // transposed (row-major)
+    accel: vec3<f32>,
+    spawn: atomic<i32>,
+    force_field: array<ForceFieldSource, 16>,
+    seed: u32,
+    count: atomic<i32>,
+    dead_count: atomic<i32>,
+};
+
+struct DeadListBuffer {
+    indices: array<u32>,
+};
+
+struct DispatchIndirectBuffer {
+    x: u32,
+    y: u32,
+    z: u32,
+    dead_count: atomic<u32>,
+    vertex_count: u32,
+    instance_count: atomic<u32>,
+    base_index: u32,
+    vertex_offset: i32,
+    base_instance: u32,
+};
+
+@group(0) @binding(0) var<uniform> sim_params : SimParams;
+@group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
+@group(2) @binding(0) var<storage, read_write> spawner : Spawner;
+@group(3) @binding(0) var<storage, read_write> dead_list : DeadListBuffer;
+@group(3) @binding(1) var<storage, read_write> dispatch_indirect : DispatchIndirectBuffer;
+
+var<private> seed : u32 = 0u;
+
+let tau: f32 = 6.283185307179586476925286766559;
+
+// Rand: PCG
+// https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/
+fn pcg_hash(input: u32) -> u32 {
+    var state: u32 = input * 747796405u + 2891336453u;
+    var word: u32 = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
+    return (word >> 22u) ^ word;
+}
+
+fn to_float01(u: u32) -> f32 {
+    // Note: could generate only 24 bits of randomness
+    return bitcast<f32>((u & 0x007fffffu) | 0x3f800000u) - 1.;
+}
+
+// Random floating-point number in [0:1]
+fn rand() -> f32 {
+    seed = pcg_hash(seed);
+    return to_float01(pcg_hash(seed));
+}
+
+// Random floating-point number in [0:1]^2
+fn rand2() -> vec2<f32> {
+    seed = pcg_hash(seed);
+    var x = to_float01(seed);
+    seed = pcg_hash(seed);
+    var y = to_float01(seed);
+    return vec2<f32>(x, y);
+}
+
+// Random floating-point number in [0:1]^3
+fn rand3() -> vec3<f32> {
+    seed = pcg_hash(seed);
+    var x = to_float01(seed);
+    seed = pcg_hash(seed);
+    var y = to_float01(seed);
+    seed = pcg_hash(seed);
+    var z = to_float01(seed);
+    return vec3<f32>(x, y, z);
+}
+
+// Random floating-point number in [0:1]^4
+fn rand4(input: u32) -> vec4<f32> {
+    // Each rand() produces 32 bits, and we need 24 bits per component,
+    // so can get away with only 3 calls.
+    var r0 = pcg_hash(seed);
+    var r1 = pcg_hash(r0);
+    var r2 = pcg_hash(r1);
+    seed = r2;
+    var x = to_float01(r0);
+    var r01 = (r0 & 0xff000000u) >> 8u | (r1 & 0x0000ffffu);
+    var y = to_float01(r01);
+    var r12 = (r1 & 0xffff0000u) >> 8u | (r2 & 0x000000ffu);
+    var z = to_float01(r12);
+    var r22 = r2 >> 8u;
+    var w = to_float01(r22);
+    return vec4<f32>(x, y, z, w);
+}
+
+struct PosVel {
+    pos: vec3<f32>,
+    vel: vec3<f32>,
+};
+
+fn init_pos_vel(index: u32, transform: mat4x4<f32>) -> PosVel {
+    var ret : PosVel;
+{{INIT_POS_VEL}}
+    return ret;
+}
+
+fn init_lifetime() -> f32 {
+    var ret : f32;
+{{INIT_LIFETIME}}
+    return ret;
+}
+
+fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {
+    return dot(v, u) / dot(u,u) * u;
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let max_particles : u32 = arrayLength(&particle_buffer.particles);
+    let index = global_invocation_id.x;
+    if (index >= max_particles) {
+        return;
+    }
+
+    let spawn_count : u32 = u32(atomicLoad(&spawner.spawn)); // FIXME - Doesn't need atomic here; this is fixed for init pass
+    if (index >= spawn_count) {
+        return;
+    }
+
+    // Recycle a dead particle
+    let dead_index = atomicSub(&dispatch_indirect.dead_count, 1u) - 1u;
+    let index = dead_list.indices[dead_index];
+
+    var vPos : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
+    var vVel : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
+    var vAge : f32 = 0.0;
+    var vLifetime : f32 = 0.0;
+
+    // Update PRNG seed
+    seed = pcg_hash(index ^ spawner.seed);
+
+    let transform = transpose(
+        mat4x4(
+            spawner.transform[0],
+            spawner.transform[1],
+            spawner.transform[2],
+            vec4<f32>(0.0, 0.0, 0.0, 1.0)
+        )
+    );
+
+    // Initialize new particle
+    var posVel = init_pos_vel(index, transform);
+    vPos = posVel.pos;
+    vVel = posVel.vel;
+    vAge = 0.0;
+    vLifetime = init_lifetime();
+
+    // Count as alive
+    var old_count : i32 = atomicAdd(&spawner.count, 1);
+
+    // Write back spawned particle
+    particle_buffer.particles[index].pos = vPos;
+    particle_buffer.particles[index].vel = vVel;
+    particle_buffer.particles[index].age = vAge;
+    particle_buffer.particles[index].lifetime = vLifetime;
+}

--- a/src/render/particles_init.wgsl
+++ b/src/render/particles_init.wgsl
@@ -37,10 +37,6 @@ struct IndirectBuffer {
     indices: array<u32>,
 };
 
-struct DeadListBuffer {
-    indices: array<u32>,
-};
-
 struct RenderIndirectBuffer {
     vertex_count: u32,
     instance_count: atomic<u32>,
@@ -60,8 +56,7 @@ struct RenderIndirectBuffer {
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner;
-@group(3) @binding(0) var<storage, read_write> dead_list : DeadListBuffer;
-@group(3) @binding(1) var<storage, read_write> render_indirect : RenderIndirectBuffer;
+@group(3) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
 
 var<private> seed : u32 = 0u;
 
@@ -164,7 +159,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Recycle a dead particle
     let dead_index = atomicSub(&render_indirect.dead_count, 1u) - 1u;
-    let index = dead_list.indices[dead_index];
+    let index = indirect_buffer.indices[3u * dead_index + 2u];
 
     var vPos : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
     var vVel : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
@@ -198,7 +193,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Add to alive list
     let indirect_index = atomicAdd(&render_indirect.instance_count, 1u);
-    indirect_buffer.indices[2u * indirect_index + ping] = index;
+    indirect_buffer.indices[3u * indirect_index + ping] = index;
 
     // Write back spawned particle
     particle_buffer.particles[index].pos = vPos;

--- a/src/render/particles_init.wgsl
+++ b/src/render/particles_init.wgsl
@@ -31,6 +31,7 @@ struct Spawner {
     seed: u32,
     count: atomic<i32>,
     dead_count: atomic<i32>,
+    effect_index: u32,
 };
 
 struct IndirectBuffer {
@@ -47,15 +48,12 @@ struct RenderIndirectBuffer {
     dead_count: atomic<u32>,
     max_spawn: u32,
     ping: u32,
-    __pad0: u32,
-    __pad1: u32,
-    __pad2: u32,
 };
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
-@group(2) @binding(0) var<storage, read_write> spawner : Spawner;
+@group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as update
 @group(3) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
 
 var<private> seed : u32 = 0u;

--- a/src/render/particles_render.wgsl
+++ b/src/render/particles_render.wgsl
@@ -21,6 +21,17 @@ struct ParticlesBuffer {
     particles: array<Particle>,
 };
 
+struct IndirectBuffer {
+    indices: array<u32>,
+};
+
+struct DispatchIndirect {
+    x: u32,
+    y: u32,
+    z: u32,
+    pong: u32,
+};
+
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
@@ -31,6 +42,8 @@ struct VertexOutput {
 
 @group(0) @binding(0) var<uniform> view: View;
 @group(1) @binding(0) var<storage, read> particle_buffer : ParticlesBuffer;
+@group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
+@group(1) @binding(2) var<storage, read> dispatch_indirect : DispatchIndirect;
 #ifdef PARTICLE_TEXTURE
 @group(2) @binding(0) var particle_texture: texture_2d<f32>;
 @group(2) @binding(1) var particle_sampler: sampler;
@@ -66,7 +79,9 @@ fn vertex(
     // @location(1) vertex_color: u32,
     // @location(1) vertex_velocity: vec3<f32>,
 ) -> VertexOutput {
-    var particle = particle_buffer.particles[instance_index];
+    let pong = dispatch_indirect.pong;
+    let index = indirect_buffer.indices[3u * instance_index + pong];
+    var particle = particle_buffer.particles[index];
     var out: VertexOutput;
 #ifdef PARTICLE_TEXTURE
     out.uv = vertex_uv;

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -47,6 +47,7 @@ struct RenderIndirectBuffer {
     dead_count: atomic<u32>,
     max_spawn: atomic<u32>,
     ping: u32,
+    max_update: u32,
 };
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
@@ -132,8 +133,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     }
 
     // Cap at maximum number of alive particles.
-    let alive_count = u32(atomicLoad(&render_indirect.alive_count));
-    if (thread_index >= alive_count) {
+    if (thread_index >= render_indirect.max_update) {
         return;
     }
 
@@ -160,7 +160,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         // Also increment copy of dead count, which was updated in dispatch indirect
         // pass just before, and need to remain right after this pass
         atomicAdd(&render_indirect.max_spawn, 1u);
-        //atomicSub(&render_indirect.alive_count, 1u); // WRONG! We use alive_count above as a pass-constant maximum
+        atomicSub(&render_indirect.alive_count, 1u);
         return;
     }
 

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -38,8 +38,8 @@ struct IndirectBuffer {
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
+@group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner;
-@group(3) @binding(0) var<storage, read_write> indirect_buffer : IndirectBuffer;
 
 var<private> seed : u32 = 0u;
 

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -30,6 +30,7 @@ struct Spawner {
     force_field: array<ForceFieldSource, 16>,
     seed: u32,
     count_unused: u32,
+    effect_index: u32,
 };
 
 struct IndirectBuffer {
@@ -46,15 +47,12 @@ struct RenderIndirectBuffer {
     dead_count: atomic<u32>,
     max_spawn: atomic<u32>,
     ping: u32,
-    __pad0: u32,
-    __pad1: u32,
-    __pad2: u32,
 };
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
-@group(2) @binding(0) var<storage, read_write> spawner : Spawner;
+@group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as init
 @group(3) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
 
 var<private> seed : u32 = 0u;
@@ -162,7 +160,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         // Also increment copy of dead count, which was updated in dispatch indirect
         // pass just before, and need to remain right after this pass
         atomicAdd(&render_indirect.max_spawn, 1u);
-        atomicSub(&render_indirect.alive_count, 1u);
+        //atomicSub(&render_indirect.alive_count, 1u); // WRONG! We use alive_count above as a pass-constant maximum
         return;
     }
 

--- a/src/render/particles_update.wgsl
+++ b/src/render/particles_update.wgsl
@@ -36,10 +36,28 @@ struct IndirectBuffer {
     indices: array<u32>,
 };
 
+struct DeadListBuffer {
+    indices: array<u32>,
+};
+
+struct DispatchIndirectBuffer {
+    x: u32,
+    y: u32,
+    z: u32,
+    dead_count: atomic<u32>,
+    vertex_count: u32,
+    instance_count: atomic<u32>,
+    base_index: u32,
+    vertex_offset: i32,
+    base_instance: u32,
+};
+
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner;
+@group(3) @binding(0) var<storage, read_write> dead_list : DeadListBuffer;
+@group(3) @binding(1) var<storage, read_write> dispatch_indirect : DispatchIndirectBuffer;
 
 var<private> seed : u32 = 0u;
 
@@ -102,33 +120,20 @@ fn rand4(input: u32) -> vec4<f32> {
     return vec4<f32>(x, y, z, w);
 }
 
-struct PosVel {
-    pos: vec3<f32>,
-    vel: vec3<f32>,
-};
-
-fn init_pos_vel(index: u32, transform: mat4x4<f32>) -> PosVel {
-    var ret : PosVel;
-{{INIT_POS_VEL}}
-    return ret;
-}
-
-fn init_lifetime() -> f32 {
-    var ret : f32;
-{{INIT_LIFETIME}}
-    return ret;
-}
-
 fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {
     return dot(v, u) / dot(u,u) * u;
 }
-
 
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let max_particles : u32 = arrayLength(&particle_buffer.particles);
     let index = global_invocation_id.x;
     if (index >= max_particles) {
+        return;
+    }
+
+    let alive_count = u32(atomicLoad(&spawner.count));
+    if (index >= alive_count) {
         return;
     }
 
@@ -140,36 +145,19 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Age the particle
     vAge = vAge + sim_params.dt;
     if (vAge >= vLifetime) {
-        // Particle dead; try to recycle into newly-spawned one
-        if (atomicSub(&spawner.spawn, 1) > 0) {
-            // Update PRNG seed
-            seed = pcg_hash(index ^ spawner.seed);
-
-            let transform = transpose(
-                mat4x4(
-                    spawner.transform[0],
-                    spawner.transform[1],
-                    spawner.transform[2],
-                    vec4<f32>(0.0, 0.0, 0.0, 1.0)
-                )
-            );
-
-            // Initialize new particle
-            var posVel = init_pos_vel(index, transform);
-            vPos = posVel.pos;
-            vVel = posVel.vel;
-            vAge = 0.0;
-            vLifetime = init_lifetime();
-        } else {
-            // Nothing to spawn; simply return without writing any update
-            return;
-        }
+        // Write back constant "dead" age
+        vAge = vLifetime + 1.0;
+        particle_buffer.particles[index].age = vAge;
+        // Save dead index
+        let dead_index = atomicAdd(&dispatch_indirect.dead_count, 1u);
+        dead_list.indices[dead_index] = index;
+        return;
     }
 
 {{FORCE_FIELD_CODE}}
 
-    // Increment alive particle count and write indirection index
-    let indirect_index = atomicAdd(&spawner.count, 1);
+    // Increment alive particle count and write indirection index for later rendering
+    let indirect_index = atomicAdd(&dispatch_indirect.instance_count, 1u);
     indirect_buffer.indices[indirect_index] = index;
 
     // Write back particle itself

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -1,58 +1,80 @@
 
-struct RenderIndirect {
-    @align(256) vertex_count: u32,
-    instance_count: u32,
-    base_index: u32,
-    vertex_offset: i32,
-    base_instance: u32,
-    alive_count: u32,
-    dead_count: u32,
-    max_spawn: u32,
-    ping: u32,
-    max_update: u32,
+// struct RenderIndirect {
+//     vertex_count: u32,
+//     instance_count: u32,
+//     base_index: u32,
+//     vertex_offset: i32,
+//     base_instance: u32,
+//     alive_count: u32,
+//     dead_count: u32,
+//     max_spawn: u32,
+//     ping: u32,
+//     max_update: u32,
+// };
+
+// struct DispatchIndirect {
+//     x: u32,
+//     y: u32,
+//     z: u32,
+// };
+
+struct SimParams {
+    dt: f32,
+    time: f32,
+    num_effects: u32,
+    render_stride: u32,
+    dispatch_stride: u32,
 };
 
-struct DispatchIndirect {
-    @align(256) x: u32,
-    y: u32,
-    z: u32,
-};
+// naga doesn't support 'const' yet
+// https://github.com/gfx-rs/naga/issues/1829
 
-@group(0) @binding(0) var<storage, read_write> render_indirect_buffer : array<RenderIndirect>;
-@group(0) @binding(1) var<storage, read_write> dispatch_indirect : array<DispatchIndirect>;
+// const OFFSET_INSTANCE_COUNT: u32 = 1u;
+// const OFFSET_ALIVE_COUNT: u32 = 5u;
+// const OFFSET_DEAD_COUNT: u32 = 6u;
+// const OFFSET_MAX_SPAWN: u32 = 7u
+// const OFFSET_PING: u32 = 8u;
+// const OFFSET_MAX_UPDATE: u32 = 9u;
+
+// const OFFSET_X: u32 = 0u;
+
+@group(0) @binding(0) var<storage, read_write> render_indirect_buffer : array<u32>;
+@group(0) @binding(1) var<storage, read_write> dispatch_indirect : array<u32>;
+@group(1) @binding(0) var<uniform> sim_params : SimParams;
 
 /// Calculate the indirect workgroups counts based on the number of particles alive.
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let num_effects = 3u; // FIXME
 
+    // Cap at maximum number of effect to process
     let effect_index = global_invocation_id.x;
-    if (effect_index >= num_effects) {
+    if (effect_index >= sim_params.num_effects) {
         return;
     }
-
-    let render_indirect = &render_indirect_buffer[effect_index];
+    
+    let ri_base = sim_params.render_stride * effect_index / 4u;
+    let di_base = sim_params.dispatch_stride * effect_index / 4u;
 
     // Calculate the number of thread groups to dispatch for the update pass, which is
     // the number of alive particles rounded up to 64 (workgroup_size).
-    let alive_count = (*render_indirect).alive_count;
-    dispatch_indirect[effect_index].x = (alive_count + 63u) / 64u;
+    let alive_count = render_indirect_buffer[ri_base + 5u];
+    dispatch_indirect[di_base + 0u] = (alive_count + 63u) / 64u;
 
     // Update max_update from current value of alive_count, so that the update pass
     // coming next can cap its threads to this value, while also atomically modifying
     // alive_count itself for next frame.
-    (*render_indirect).max_update = alive_count;
+    render_indirect_buffer[ri_base + 9u] = alive_count;
 
     // Copy the number of dead particles to a constant location, so that the init pass
     // on next frame can atomically modify dead_count in parallel yet still read its
     // initial value at the beginning of the init pass, and limit the number of particles
     // spawned to the number of dead particles to recycle.
-    let dead_count = (*render_indirect).dead_count;
-    (*render_indirect).max_spawn = dead_count;
+    let dead_count = render_indirect_buffer[ri_base + 6u];
+    render_indirect_buffer[ri_base + 7u] = dead_count;
 
     // Clear the rendering instance count, which will be upgraded by the update pass
     // with the particles actually alive at the end of their update (after aged).
-    (*render_indirect).instance_count = 0u;
+    render_indirect_buffer[ri_base + 1u] = 0u;
 
-    (*render_indirect).ping = 1u - (*render_indirect).ping;
+    render_indirect_buffer[ri_base + 8u] = 1u - render_indirect_buffer[ri_base + 8u];
 }

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -9,6 +9,7 @@ struct RenderIndirect {
     dead_count: u32,
     max_spawn: u32,
     ping: u32,
+    max_update: u32,
 };
 
 struct DispatchIndirect {
@@ -36,6 +37,11 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // the number of alive particles rounded up to 64 (workgroup_size).
     let alive_count = (*render_indirect).alive_count;
     dispatch_indirect[effect_index].x = (alive_count + 63u) / 64u;
+
+    // Update max_update from current value of alive_count, so that the update pass
+    // coming next can cap its threads to this value, while also atomically modifying
+    // alive_count itself for next frame.
+    (*render_indirect).max_update = alive_count;
 
     // Copy the number of dead particles to a constant location, so that the init pass
     // on next frame can atomically modify dead_count in parallel yet still read its

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -1,52 +1,52 @@
 
-struct RenderIndirectBuffer {
-    vertex_count: u32,
-    instance_count: atomic<u32>,
+struct RenderIndirect {
+    @align(256) vertex_count: u32,
+    instance_count: u32,
     base_index: u32,
     vertex_offset: i32,
     base_instance: u32,
-    alive_count: atomic<u32>,
-    dead_count: atomic<u32>,
+    alive_count: u32,
+    dead_count: u32,
     max_spawn: u32,
     ping: u32,
-    __pad0: u32,
-    __pad1: u32,
-    __pad2: u32,
 };
 
-struct DispatchIndirectBuffer {
-    x: u32,
+struct DispatchIndirect {
+    @align(256) x: u32,
     y: u32,
     z: u32,
-    __pad: u32,
 };
 
-@group(0) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
-@group(0) @binding(1) var<storage, read_write> dispatch_indirect : DispatchIndirectBuffer;
+@group(0) @binding(0) var<storage, read_write> render_indirect_buffer : array<RenderIndirect>;
+@group(0) @binding(1) var<storage, read_write> dispatch_indirect : array<DispatchIndirect>;
 
 /// Calculate the indirect workgroups counts based on the number of particles alive.
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let index = global_invocation_id.x;
-    if (index >= 1u) { // FIXME - batch all effects together in a single dispatch
+    let num_effects = 3u; // FIXME
+
+    let effect_index = global_invocation_id.x;
+    if (effect_index >= num_effects) {
         return;
     }
 
+    let render_indirect = &render_indirect_buffer[effect_index];
+
     // Calculate the number of thread groups to dispatch for the update pass, which is
     // the number of alive particles rounded up to 64 (workgroup_size).
-    let alive_count = atomicLoad(&render_indirect.alive_count);
-    dispatch_indirect.x = (alive_count + 63u) / 64u;
+    let alive_count = (*render_indirect).alive_count;
+    dispatch_indirect[effect_index].x = (alive_count + 63u) / 64u;
 
     // Copy the number of dead particles to a constant location, so that the init pass
     // on next frame can atomically modify dead_count in parallel yet still read its
     // initial value at the beginning of the init pass, and limit the number of particles
     // spawned to the number of dead particles to recycle.
-    let dead_count = atomicLoad(&render_indirect.dead_count);
-    render_indirect.max_spawn = dead_count;
+    let dead_count = (*render_indirect).dead_count;
+    (*render_indirect).max_spawn = dead_count;
 
     // Clear the rendering instance count, which will be upgraded by the update pass
     // with the particles actually alive at the end of their update (after aged).
-    render_indirect.instance_count = 0u;
+    (*render_indirect).instance_count = 0u;
 
-    render_indirect.ping = 1u - render_indirect.ping;
+    (*render_indirect).ping = 1u - (*render_indirect).ping;
 }

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -1,0 +1,33 @@
+
+struct RenderIndirectBuffer {
+    vertex_count: u32,
+    instance_count: atomic<u32>,
+    base_index: u32,
+    vertex_offset: i32,
+    base_instance: u32,
+    alive_count: atomic<u32>,
+    dead_count: atomic<u32>,
+    __pad: u32,
+};
+
+struct DispatchIndirectBuffer {
+    x: u32,
+    y: u32,
+    z: u32,
+    __pad: u32,
+};
+
+@group(0) @binding(0) var<storage, read> render_indirect : RenderIndirectBuffer;
+@group(0) @binding(1) var<storage, read_write> dispatch_indirect : DispatchIndirectBuffer;
+
+/// Calculate the indirect workgroups counts based on the number of particles alive.
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let index = global_invocation_id.x;
+    if (index >= 1u) { // FIXME - batch all effects together in a single dispatch
+        return;
+    }
+
+    let alive_count = atomicLoad(&render_indirect.alive_count);
+    dispatch_indirect.x = (alive_count + 63u) / 64u;
+}

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -7,7 +7,7 @@ struct RenderIndirectBuffer {
     base_instance: u32,
     alive_count: atomic<u32>,
     dead_count: atomic<u32>,
-    __pad: u32,
+    max_spawn: u32,
 };
 
 struct DispatchIndirectBuffer {
@@ -17,7 +17,7 @@ struct DispatchIndirectBuffer {
     __pad: u32,
 };
 
-@group(0) @binding(0) var<storage, read> render_indirect : RenderIndirectBuffer;
+@group(0) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
 @group(0) @binding(1) var<storage, read_write> dispatch_indirect : DispatchIndirectBuffer;
 
 /// Calculate the indirect workgroups counts based on the number of particles alive.
@@ -28,6 +28,15 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         return;
     }
 
+    // Calculate the number of thread groups to dispatch for the update pass, which is
+    // the number of alive particles rounded up to 64 (workgroup_size).
     let alive_count = atomicLoad(&render_indirect.alive_count);
     dispatch_indirect.x = (alive_count + 63u) / 64u;
+
+    // Copy the number of dead particles to a constant location, so that the init pass
+    // on next frame can atomically modify dead_count in parallel yet still read its
+    // initial value at the beginning of the init pass, and limit the number of particles
+    // spawned to the number of dead particles to recycle.
+    let dead_count = atomicLoad(&render_indirect.dead_count);
+    render_indirect.max_spawn = dead_count;
 }

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -8,6 +8,10 @@ struct RenderIndirectBuffer {
     alive_count: atomic<u32>,
     dead_count: atomic<u32>,
     max_spawn: u32,
+    ping: u32,
+    __pad0: u32,
+    __pad1: u32,
+    __pad2: u32,
 };
 
 struct DispatchIndirectBuffer {
@@ -39,4 +43,10 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // spawned to the number of dead particles to recycle.
     let dead_count = atomicLoad(&render_indirect.dead_count);
     render_indirect.max_spawn = dead_count;
+
+    // Clear the rendering instance count, which will be upgraded by the update pass
+    // with the particles actually alive at the end of their update (after aged).
+    render_indirect.instance_count = 0u;
+
+    render_indirect.ping = 1u - render_indirect.ping;
 }

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -16,6 +16,7 @@
 //     x: u32,
 //     y: u32,
 //     z: u32,
+//     pong: u32,
 // };
 
 struct SimParams {
@@ -37,6 +38,9 @@ struct SimParams {
 // const OFFSET_MAX_UPDATE: u32 = 9u;
 
 // const OFFSET_X: u32 = 0u;
+// const OFFSET_Y: u32 = 1u;
+// const OFFSET_Z: u32 = 2u;
+// const OFFSET_PONG: u32 = 3u;
 
 @group(0) @binding(0) var<storage, read_write> render_indirect_buffer : array<u32>;
 @group(0) @binding(1) var<storage, read_write> dispatch_indirect : array<u32>;
@@ -76,5 +80,12 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // with the particles actually alive at the end of their update (after aged).
     render_indirect_buffer[ri_base + 1u] = 0u;
 
-    render_indirect_buffer[ri_base + 8u] = 1u - render_indirect_buffer[ri_base + 8u];
+    // Swap ping/pong buffers
+    let ping = render_indirect_buffer[ri_base + 8u];
+    let pong = 1u - ping;
+    render_indirect_buffer[ri_base + 8u] = pong;
+
+    // Copy the new pong into the dispatch buffer, which will be used during rendering
+    // to determine where to read particle indices.
+    dispatch_indirect[di_base + 3u] = pong;
 }


### PR DESCRIPTION
Split the init and update compute passes. The init pass is dispatched from CPU
when new particles need to be spawned, while the update pass is now GPU-driven
(indirect dispatch). The render pass is also modified to be GPU-driven
(indirect render), avoiding the unnecessary rendering of dead particles
previously occurring.

Add a new `instancing` example demonstrating many instances of the same effect
used in parallel.

Fixes #19
