### PR TITLE
Mark `ParticleEffect::spawner()` as private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disabled broken effect batching until #73 is fixed, to prevent triggering batching which breaks rendering.
 - Switched to a new internal architecture, splitting the initializing of newly spawned particles from the updating of all alive particles, to achieve more consistent workload on the update compute. Added GPU-driven compute dispatch and rendering, which slighly improves performance and reduces CPU dependency/synchronization. This is mostly an internal change, but with the potential to unblock or facilitate several other issues. (#19)
+- Removed `ParticleEffect::spawner()` from the public API, which was intended for internal use and is a bit confusing.
 
 ## [0.4.1] 2022-10-28
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,16 @@ impl ParticleEffect {
         self.spawner = Some(spawner);
     }
 
+    /// Get the spawner of this particle effect.
+    ///
+    /// Returns `None` if the effect has not yet been copied from the
+    /// [`EffectAsset`] nor overridden by [`set_spawner()`].
+    ///
+    /// [`set_spawner()`]: ParticleEffect::set_spawner
+    pub fn maybe_spawner(&mut self) -> Option<&mut Spawner> {
+        self.spawner.as_mut()
+    }
+
     /// Configure the spawner of a new particle effect.
     ///
     /// In general this is called internally while the spawner is ticked, to
@@ -341,21 +351,11 @@ impl ParticleEffect {
     ///
     /// Returns a reference to the added spawner owned by the current instance,
     /// allowing to chain adding modifiers to the effect.
-    pub fn spawner(&mut self, spawner: &Spawner) -> &mut Spawner {
+    pub(crate) fn configure_spawner(&mut self, spawner: &Spawner) -> &mut Spawner {
         if self.spawner.is_none() {
             self.spawner = Some(*spawner);
         }
         self.spawner.as_mut().unwrap()
-    }
-
-    /// Get the spawner of this particle effect.
-    ///
-    /// Returns `None` if [`configure_spawner()`] was not called and the effect
-    /// has not been internally allocated yet.
-    ///
-    /// [`configure_spawner()`]: crate::ParticleEffect::configure_spawner
-    pub fn maybe_spawner(&mut self) -> Option<&mut Spawner> {
-        self.spawner.as_mut()
     }
 }
 
@@ -542,7 +542,7 @@ fn tick_spawners(
                 continue;
             };
 
-            effect.spawner(&asset.spawner)
+            effect.configure_spawner(&asset.spawner)
         };
 
         // Tick the effect's spawner to determine the spawn count for this frame


### PR DESCRIPTION
The `ParticleEffect::spawner()` method is used internally to initialize the spawner of a `ParticleEffect` from the one of its `EffectAsset`. It was not designed to be used publicly and its usage is somewhat confusing. Hide the method by marking it as `pub(crate)`.