### PR TITLE
`RenderLayout::{size_color,lifetime_size}_gradient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disabled broken effect batching until #73 is fixed, to prevent triggering batching which breaks rendering.
 - Switched to a new internal architecture, splitting the initializing of newly spawned particles from the updating of all alive particles, to achieve more consistent workload on the update compute. Added GPU-driven compute dispatch and rendering, which slighly improves performance and reduces CPU dependency/synchronization. This is mostly an internal change, but with the potential to unblock or facilitate several other issues. (#19)
 - Removed `ParticleEffect::spawner()` from the public API, which was intended for internal use and is a bit confusing.
+- Renamed the oddly-named `RenderLayout::size_color_gradient` into the more understandable `RenderLayout::lifetime_size_gradient`.
 
 ## [0.4.1] 2022-10-28
 

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -1,12 +1,15 @@
 @echo on
 echo Run all examples
+REM 3D
 cargo r --example spawn --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example random --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
-cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
-cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
 cargo r --example spawn_on_command --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example activate --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example force_field --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
-cargo r --example 2d --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d"
 cargo r --example lifetime --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example instancing --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
+REM 3D + PNG
+cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
+cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
+REM 2D
+cargo r --example 2d --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -53,7 +53,7 @@ pub struct RenderLayout {
     /// lifetime.
     pub lifetime_color_gradient: Option<Gradient<Vec4>>,
     /// Optional size gradient used to vary the particle size over its lifetime.
-    pub size_color_gradient: Option<Gradient<Vec2>>,
+    pub lifetime_size_gradient: Option<Gradient<Vec2>>,
     /// If true, renders sprites as "billboards", that is, they will always face
     /// the camera when rendered.
     pub billboard: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,7 +599,7 @@ fn tick_spawners(
                 } else {
                     String::new()
                 };
-            if let Some(grad) = &asset.render_layout.size_color_gradient {
+            if let Some(grad) = &asset.render_layout.lifetime_size_gradient {
                 vertex_modifiers += &grad.to_shader_code();
             }
 

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -47,7 +47,7 @@ pub struct SizeOverLifetimeModifier {
 
 impl RenderModifier for SizeOverLifetimeModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
-        render_layout.size_color_gradient = Some(self.gradient.clone());
+        render_layout.lifetime_size_gradient = Some(self.gradient.clone());
     }
 }
 
@@ -58,5 +58,70 @@ pub struct BillboardModifier;
 impl RenderModifier for BillboardModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.billboard = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::asset::HandleId;
+
+    use super::*;
+
+    #[test]
+    fn mod_particle_texture() {
+        let texture = Handle::weak(HandleId::default::<Image>());
+        let modifier = ParticleTextureModifier {
+            texture: texture.clone(),
+        };
+
+        let mut layout = RenderLayout::default();
+        modifier.apply(&mut layout);
+
+        assert!(layout.particle_texture.is_some());
+        assert_eq!(layout.particle_texture.unwrap(), texture);
+    }
+
+    #[test]
+    fn mod_color_over_lifetime() {
+        let red: Vec4 = Vec4::new(1., 0., 0., 1.);
+        let blue: Vec4 = Vec4::new(0., 0., 1., 1.);
+        let mut gradient = Gradient::new();
+        gradient.add_key(0.5, red);
+        gradient.add_key(0.8, blue);
+        let modifier = ColorOverLifetimeModifier {
+            gradient: gradient.clone(),
+        };
+
+        let mut layout = RenderLayout::default();
+        modifier.apply(&mut layout);
+
+        assert!(layout.lifetime_color_gradient.is_some());
+        assert_eq!(layout.lifetime_color_gradient.unwrap(), gradient);
+    }
+
+    #[test]
+    fn mod_size_over_lifetime() {
+        let x = Vec2::new(1., 0.);
+        let y = Vec2::new(0., 1.);
+        let mut gradient = Gradient::new();
+        gradient.add_key(0.5, x);
+        gradient.add_key(0.8, y);
+        let modifier = SizeOverLifetimeModifier {
+            gradient: gradient.clone(),
+        };
+
+        let mut layout = RenderLayout::default();
+        modifier.apply(&mut layout);
+
+        assert!(layout.lifetime_size_gradient.is_some());
+        assert_eq!(layout.lifetime_size_gradient.unwrap(), gradient);
+    }
+
+    #[test]
+    fn mod_billboard() {
+        let modifier = BillboardModifier;
+        let mut layout = RenderLayout::default();
+        modifier.apply(&mut layout);
+        assert!(layout.billboard);
     }
 }


### PR DESCRIPTION
Rename the oddly-named `RenderLayout::size_color_gradient` into the more understandable `RenderLayout::lifetime_size_gradient`.

Add a few tests for `RenderLayout`.

Reorder examples in `run_examples.bat` by feature set.