### PR TITLE
Fix panic when no effect exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix a panic when running the plugin without any effect.
+
 ## [0.5.0] 2022-11-14
 
 ### Changed

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2718,7 +2718,8 @@ impl Node for ParticleUpdateNode {
         }
 
         // Compute indirect dispatch pass
-        {
+        if effects_meta.spawner_buffer.buffer().is_some() {
+            // Only if there's an effect
             let mut compute_pass =
                 render_context
                     .command_encoder


### PR DESCRIPTION
Fix a panic in the render module when no effect exist, and the queuing earlied out before initializing some GPU resources.

Fixes #90