### PR TITLE
Add support for HDR cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for HDR cameras (`Camera::hdr == true`).
+
 ### Fixed
 
 - Fix a panic when running the plugin without any effect.

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -40,7 +40,14 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let mut camera = Camera3dBundle::default();
+    // Spawn a camera. For this example, we also demonstrate that we can use an HDR camera.
+    let mut camera = Camera3dBundle {
+        camera: Camera {
+            hdr: true,
+            ..default()
+        },
+        ..default()
+    };
     camera.transform.translation = Vec3::new(0.0, 0.0, 100.0);
     commands.spawn(camera);
 


### PR DESCRIPTION
Ensure HDR cameras (`Camera::hdr == true`) can be used for rendering, by selecting the proper render target format.

Fixes #92