### PR TITLE
Run simulation render graph once per frame

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,8 @@ impl ParticleEffect {
         self.spawner.as_mut().unwrap()
     }
 
-    /// Get the init, update, and render shaders if they're all configured, or `None` otherwise.
+    /// Get the init, update, and render shaders if they're all configured, or
+    /// `None` otherwise.
     pub(crate) fn get_configured_shaders(
         &self,
     ) -> Option<(Handle<Shader>, Handle<Shader>, Handle<Shader>)> {


### PR DESCRIPTION
Add a simulation sub-graph to the main render graph, driven by the `VfxSimulateDriverNode` render node. This sub-graph is run once per frame, before any camera.

Fixes #102