### PR TITLE
Improve testing with `AbsDiffEq`

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -240,6 +240,8 @@ impl<T: Lerp> Gradient<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_utils::*;
+
     use super::*;
 
     fn color_approx_eq(c0: Vec4, c1: Vec4, tol: f32) -> bool {
@@ -247,6 +249,32 @@ mod tests {
             && ((c0.y - c1.y).abs() < tol)
             && ((c0.z - c1.z).abs() < tol)
             && ((c0.w - c1.w).abs() < tol)
+    }
+
+    #[test]
+    fn lerp_test() {
+        assert_approx_eq!(Lerp::lerp(3_f32, 5_f32, 0.1), 3.2_f32);
+        assert_approx_eq!(Lerp::lerp(3_f32, 5_f32, 0.5), 4.0_f32);
+        assert_approx_eq!(Lerp::lerp(3_f32, 5_f32, 0.9), 4.8_f32);
+        assert_approx_eq!(Lerp::lerp(5_f32, 3_f32, 0.1), 4.8_f32);
+        assert_approx_eq!(Lerp::lerp(5_f32, 3_f32, 0.5), 4.0_f32);
+        assert_approx_eq!(Lerp::lerp(5_f32, 3_f32, 0.9), 3.2_f32);
+
+        assert_approx_eq!(Lerp::lerp(3_f64, 5_f64, 0.1), 3.2_f64);
+        assert_approx_eq!(Lerp::lerp(3_f64, 5_f64, 0.5), 4.0_f64);
+        assert_approx_eq!(Lerp::lerp(3_f64, 5_f64, 0.9), 4.8_f64);
+        assert_approx_eq!(Lerp::lerp(5_f64, 3_f64, 0.1), 4.8_f64);
+        assert_approx_eq!(Lerp::lerp(5_f64, 3_f64, 0.5), 4.0_f64);
+        assert_approx_eq!(Lerp::lerp(5_f64, 3_f64, 0.9), 3.2_f64);
+
+        let s = Quat::IDENTITY;
+        let e = Quat::from_rotation_x(90_f32.to_radians());
+        assert_approx_eq!(Lerp::lerp(s, e, 0.1), s.slerp(e, 0.1));
+        assert_approx_eq!(Lerp::lerp(s, e, 0.5), s.slerp(e, 0.5));
+        assert_approx_eq!(Lerp::lerp(s, e, 0.9), s.slerp(e, 0.9));
+        assert_approx_eq!(Lerp::lerp(e, s, 0.1), s.slerp(e, 0.9));
+        assert_approx_eq!(Lerp::lerp(e, s, 0.5), s.slerp(e, 0.5));
+        assert_approx_eq!(Lerp::lerp(e, s, 0.9), s.slerp(e, 0.1));
     }
 
     #[test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,8 +1,76 @@
-use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::{
+    prelude::{Quat, Vec2, Vec3, Vec4},
+    render::renderer::{RenderDevice, RenderQueue},
+};
+use std::ops::Sub;
 
-/// Utility to compare floating-point values with a tolerance.
-pub(crate) fn abs_diff_eq(a: f32, b: f32, tol: f32) -> bool {
-    (a - b).abs() < tol
+/// Utility trait to compare floating-point values with a tolerance.
+pub(crate) trait AbsDiffEq {
+    /// Calculate the absolute value of the difference between two floating-point quantities. For non-scalar quantities, the maximum absolute difference for all components is returned.
+    fn abs_diff(a: &Self, b: &Self) -> f32;
+
+    /// Check if two floating-point quantities are approximately equal within a given tolerance. Non-scalar values are checked component-wise.
+    fn abs_diff_eq(a: &Self, b: &Self, tol: f32) -> bool;
+}
+
+impl AbsDiffEq for f32 {
+    fn abs_diff(a: &f32, b: &f32) -> f32 {
+        (a - b).abs()
+    }
+
+    fn abs_diff_eq(a: &f32, b: &f32, tol: f32) -> bool {
+        (a - b).abs() < tol
+    }
+}
+
+impl AbsDiffEq for f64 {
+    fn abs_diff(a: &f64, b: &f64) -> f32 {
+        (a - b).abs() as f32
+    }
+
+    fn abs_diff_eq(a: &f64, b: &f64, tol: f32) -> bool {
+        (a - b).abs() < tol as f64
+    }
+}
+
+impl AbsDiffEq for Vec2 {
+    fn abs_diff(a: &Vec2, b: &Vec2) -> f32 {
+        a.sub(*b).abs().max_element()
+    }
+
+    fn abs_diff_eq(a: &Vec2, b: &Vec2, tol: f32) -> bool {
+        a.abs_diff_eq(*b, tol)
+    }
+}
+
+impl AbsDiffEq for Vec3 {
+    fn abs_diff(a: &Vec3, b: &Vec3) -> f32 {
+        a.sub(*b).abs().max_element()
+    }
+
+    fn abs_diff_eq(a: &Vec3, b: &Vec3, tol: f32) -> bool {
+        a.abs_diff_eq(*b, tol)
+    }
+}
+
+impl AbsDiffEq for Vec4 {
+    fn abs_diff(a: &Vec4, b: &Vec4) -> f32 {
+        a.sub(*b).abs().max_element()
+    }
+
+    fn abs_diff_eq(a: &Vec4, b: &Vec4, tol: f32) -> bool {
+        a.abs_diff_eq(*b, tol)
+    }
+}
+
+impl AbsDiffEq for Quat {
+    fn abs_diff(a: &Quat, b: &Quat) -> f32 {
+        Vec4::from(*a).sub(Vec4::from(*b)).abs().max_element()
+    }
+
+    fn abs_diff_eq(a: &Quat, b: &Quat, tol: f32) -> bool {
+        a.abs_diff_eq(*b, tol)
+    }
 }
 
 /// Assert that two floating-point quantities are approximately equal.
@@ -10,6 +78,10 @@ pub(crate) fn abs_diff_eq(a: f32, b: f32, tol: f32) -> bool {
 /// This macro asserts that the absolute difference between the two first
 /// arguments is strictly less than a tolerance factor, which can be explicitly
 /// passed as third argument or implicitly defaults to `1e-5`.
+///
+/// The two quantities must implement the [`AbsDiffEq`] helper trait. This trait
+/// is implemented for common floating-point quantities like `f32` or `f64`, or
+/// associated vector math types like `Vec3` or `Quat`.
 ///
 /// # Usage
 ///
@@ -25,11 +97,11 @@ macro_rules! assert_approx_eq {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 assert!(
-                    abs_diff_eq(*left_val, *right_val, 1e-5),
+                    AbsDiffEq::abs_diff_eq(left_val, right_val, 1e-5),
                     "assertion failed: expected={} actual={} delta={} tol=1e-5(default)",
                     left_val,
                     right_val,
-                    (left_val - right_val).abs(),
+                    AbsDiffEq::abs_diff(left_val, right_val),
                 );
             }
         }
@@ -38,11 +110,11 @@ macro_rules! assert_approx_eq {
         match (&$left, &$right, &$tol) {
             (left_val, right_val, tol_val) => {
                 assert!(
-                    abs_diff_eq(*left_val, *right_val, *tol_val),
+                    AbsDiffEq::abs_diff_eq(left_val, right_val, *tol_val),
                     "assertion failed: expected={} actual={} delta={} tol={}",
                     left_val,
                     right_val,
-                    (left_val - right_val).abs(),
+                    AbsDiffEq::abs_diff(left_val, right_val),
                     tol_val
                 );
             }


### PR DESCRIPTION
Add a new utility trait `AbsDiffEq` allowing to extend the use of the testing macro `assert_approx_eq!()` to various scalar and vector floating-point math types.