### PR TITLE
Update `ron` dependency to `0.8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8"
 rand_pcg = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-ron = "0.7"
+ron = "0.8"
 bitflags = "1.3"
 
 [dependencies.bevy]


### PR DESCRIPTION
Align with the version used by Bevy 0.9.