### PR TITLE
Fix regression in 2D rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix (most common cases of) a bug where effects spawned after another effect was despawned will not work. This is a partial workaround; the bug can still trigger but under more rare conditions. (#106)
 - Fix simulate compute jobs running once per view instead of once per frame. (#102)
+- Fix 2D rendering not using indirect (GPU-driven) rendering.
 
 ### Removed
 

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -129,7 +129,10 @@ impl EffectBuffer {
             capacity,
             item_size
         );
+
         let capacity = capacity.max(Self::MIN_CAPACITY);
+        debug_assert!(capacity > 0, "Attempted to create a zero-sized effect buffer.");
+
         let particle_capacity_bytes: BufferAddress = capacity as u64 * item_size as u64;
         let particle_buffer = render_device.create_buffer(&BufferDescriptor {
             label,


### PR DESCRIPTION
Fix a regression in 2D rendering introduced in #107, and fix 2D rendering not using indirect (GPU-driven) rendering.