### PR TITLE
Remove `#[derive(Resource)]` from `EffectAsset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed `MinMaxRect` in favor of Bevy's own `Rect` type.
+- Removed `Resource` derive from `EffectAsset`, which made little sense on an asset.
 
 ## [0.5.1] 2022-12-03
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -71,8 +71,7 @@ pub struct RenderLayout {
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Resource, Reflect, TypeUuid)]
-#[reflect(Resource)]
+#[derive(Debug, Default, Clone, PartialEq, TypeUuid, Reflect, Serialize, Deserialize)]
 #[uuid = "249aefa4-9b8e-48d3-b167-3adf6c081c34"]
 pub struct EffectAsset {
     /// Display name of the effect.

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,6 +1,5 @@
 use bevy::{
     asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
-    ecs::{reflect::ReflectResource, system::Resource},
     math::{Vec2, Vec3, Vec4},
     reflect::{Reflect, TypeUuid},
     render::texture::Image,


### PR DESCRIPTION
Remove the `Resource` derive from `EffectAsset`, which makes little sense on an asset.