### PR TITLE
Fix particle resetting after spawn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = [ "2d", "3d", "gpu_tests" ]
 gpu_tests = []
 
 [dependencies]
-bytemuck = { version = "1.5", features = ["derive"] }
+bytemuck = { version = "=1.12.3", features = ["derive"] }
 copyless = "0.1"
 rand = "0.8"
 rand_pcg = "0.3"

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -3,6 +3,15 @@ use bevy_inspector_egui::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
+#[derive(Default, Resource)]
+struct MyEffect {
+    effect: Handle<EffectAsset>,
+    mesh: Handle<Mesh>,
+    material: Handle<StandardMaterial>,
+    next_pos: IVec2,
+    instances: Vec<Entity>,
+}
+
 fn main() {
     App::default()
         .add_plugins(DefaultPlugins.set(LogPlugin {
@@ -12,7 +21,9 @@ fn main() {
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin::new())
+        .init_resource::<MyEffect>()
         .add_startup_system(setup)
+        .add_system(keyboard_input_system)
         .run();
 }
 
@@ -21,7 +32,10 @@ fn setup(
     mut effects: ResMut<Assets<EffectAsset>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    mut my_effect: ResMut<MyEffect>,
 ) {
+    info!("Usage: Press the SPACE key to spawn more instances, and the DELETE key to remove an existing instance.");
+
     let mut camera = Camera3dBundle::default();
     camera.transform.translation = Vec3::new(0.0, 0.0, 180.0);
     commands.spawn(camera);
@@ -37,7 +51,7 @@ fn setup(
         ..Default::default()
     });
 
-    let cube = meshes.add(Mesh::from(Cube { size: 1.0 }));
+    let mesh = meshes.add(Mesh::from(Cube { size: 1.0 }));
     let mat = materials.add(Color::PURPLE.into());
 
     let mut gradient = Gradient::new();
@@ -61,32 +75,96 @@ fn setup(
         .render(ColorOverLifetimeModifier { gradient }),
     );
 
-    for j in -4..=4 {
-        for i in -5..=5 {
-            commands
-                .spawn((
-                    Name::new(format!("({},{})", i, j)),
-                    ParticleEffectBundle {
-                        effect: ParticleEffect::new(effect.clone()),
-                        transform: Transform::from_translation(Vec3::new(
-                            i as f32 * 10.,
-                            j as f32 * 10.,
-                            0.,
-                        )),
-                        ..Default::default()
-                    },
-                ))
-                .with_children(|p| {
-                    // Reference cube to visualize the emit origin
-                    p.spawn((
-                        PbrBundle {
-                            mesh: cube.clone(),
-                            material: mat.clone(),
-                            ..Default::default()
-                        },
-                        Name::new("source"),
-                    ));
-                });
+    // Store the effect for later reference
+    my_effect.effect = effect.clone();
+    my_effect.next_pos = IVec2::new(-5, -4);
+    my_effect.mesh = mesh.clone();
+    my_effect.material = mat.clone();
+
+    // Spawn a few effects as example; others can be added/removed with keyboard
+    for _ in 0..45 {
+        let (id, next_pos) = spawn_instance(
+            &mut commands,
+            my_effect.next_pos,
+            my_effect.effect.clone(),
+            my_effect.mesh.clone(),
+            my_effect.material.clone(),
+        );
+        my_effect.instances.push(id);
+        my_effect.next_pos = next_pos;
+    }
+}
+
+fn spawn_instance(
+    commands: &mut Commands,
+    pos: IVec2,
+    effect: Handle<EffectAsset>,
+    mesh: Handle<Mesh>,
+    material: Handle<StandardMaterial>,
+) -> (Entity, IVec2) {
+    let mut next_pos = pos;
+    next_pos.x += 1;
+    if next_pos.x > 5 {
+        next_pos.x = -5;
+        next_pos.y += 1;
+    }
+
+    let id = commands
+        .spawn((
+            Name::new(format!("{:?}", pos)),
+            ParticleEffectBundle {
+                effect: ParticleEffect::new(effect),
+                transform: Transform::from_translation(Vec3::new(
+                    pos.x as f32 * 10.,
+                    pos.y as f32 * 10.,
+                    0.,
+                )),
+                ..Default::default()
+            },
+        ))
+        .with_children(|p| {
+            // Reference cube to visualize the emit origin
+            p.spawn((
+                PbrBundle {
+                    mesh,
+                    material,
+                    ..Default::default()
+                },
+                Name::new("source"),
+            ));
+        })
+        .id();
+
+    (id, next_pos)
+}
+
+fn keyboard_input_system(
+    keyboard_input: Res<Input<KeyCode>>,
+    mut commands: Commands,
+    mut my_effect: ResMut<MyEffect>,
+) {
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        // Spawn a new instance
+        let (id, next_pos) = spawn_instance(
+            &mut commands,
+            my_effect.next_pos,
+            my_effect.effect.clone(),
+            my_effect.mesh.clone(),
+            my_effect.material.clone(),
+        );
+        my_effect.instances.push(id);
+        my_effect.next_pos = next_pos;
+    } else if keyboard_input.just_pressed(KeyCode::Delete) {
+        // Delete an existing instance
+        if let Some(entity) = my_effect.instances.pop() {
+            if let Some(entity_commands) = commands.get_entity(entity) {
+                entity_commands.despawn_recursive();
+            }
+            my_effect.next_pos.x -= 1;
+            if my_effect.next_pos.x < -5 {
+                my_effect.next_pos.x = 5;
+                my_effect.next_pos.y -= 1;
+            }
         }
     }
 }

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -29,8 +29,10 @@ use crate::next_multiple_of;
 ///
 /// [`BufferVec`]: bevy::render::render_resource::BufferVec
 /// [`WgpuLimits`]: bevy::render::settings::WgpuLimits
-pub struct AlignedBufferVec<T: Pod + ShaderType + ShaderSize> {
+pub struct AlignedBufferVec<T: Pod + ShaderSize> {
+    /// Pending values accumulated on CPU and not yet written to GPU.
     values: Vec<T>,
+    /// GPU buffer if already allocated, or `None` otherwise.
     buffer: Option<Buffer>,
     /// Capacity of the buffer, in number of elements.
     capacity: usize,
@@ -39,7 +41,9 @@ pub struct AlignedBufferVec<T: Pod + ShaderType + ShaderSize> {
     /// Size of a single buffer element, in bytes, aligned to GPU memory
     /// constraints.
     aligned_size: usize,
+    /// GPU buffer usages.
     buffer_usage: BufferUsages,
+    /// Optional GPU buffer name, for debugging.
     label: Option<String>,
 }
 

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -1,0 +1,1007 @@
+use bevy::{
+    core::{cast_slice, Pod},
+    //log::trace,
+    render::{
+        render_resource::{
+            Buffer, BufferAddress, BufferDescriptor, BufferUsages, CommandEncoder, ShaderSize,
+            ShaderType,
+        },
+        renderer::{RenderDevice, RenderQueue},
+    },
+};
+use copyless::VecHelper;
+use std::num::NonZeroU64;
+
+use crate::next_multiple_of;
+
+/// Index of a row in a [`BufferTable`].
+pub struct BufferTableId(pub(crate) u32); // TEMP: pub(crate)
+
+#[derive(Debug)]
+struct AllocatedBuffer {
+    /// Currently allocated buffer, of size equal to [`size`].
+    buffer: Buffer,
+    /// Size of the currently allocated buffer, in bytes.
+    size: usize,
+    /// Previously allocated buffer if any, cached until the next buffer write
+    /// so that old data can be copied into the newly-allocated buffer.
+    old_buffer: Option<Buffer>,
+    /// Size of the old buffer if any, in bytes.
+    old_size: usize,
+}
+
+impl AllocatedBuffer {
+    /// Get the size in bytes of the currently allocated GPU buffer.
+    ///
+    /// On capacity grow, the size is valid until the next buffer swap.
+    pub fn allocated_size(&self) -> usize {
+        if self.old_buffer.is_some() {
+            self.old_size
+        } else {
+            self.size
+        }
+    }
+}
+
+/// GPU buffer holding a table.
+///
+/// The buffer table data structure represents a GPU buffer holding a table made
+/// of individual rows. Each row of the table has the same layout (same size),
+/// and can be allocated (assigned to an existing index) or free (available for
+/// future allocation). The data structure manages a free list of rows, and copy
+/// of rows modified on CPU to the GPU without touching other rows. This ensures
+/// that existing rows in the GPU buffer can be accessed and modified by the GPU
+/// without being overwritten by the CPU and without the need for the CPU to
+/// read the data back from GPU into CPU memory.
+///
+/// The element type `T` needs to implement the following traits:
+/// - [`Pod`] to allow copy.
+/// - [`ShaderType`] because it needs to be mapped for a shader.
+/// - [`ShaderSize`] to ensure a fixed footprint, to allow packing multiple
+///   instances inside a single buffer. This therefore excludes any
+///   runtime-sized array.
+///
+/// This is similar to a [`BufferVec`] or [`AlignedBufferVec`], but unlike those
+/// data structures a buffer table preserves rows modified by the GPU without
+/// overwriting.
+///
+/// # Usage
+///
+/// - During the [`RenderStage::Prepare`] stage, call
+///   [`clear_previous_frame_resizes()`] to clear any stale buffer from the
+/// previous frame. Then insert new rows with [`insert()`] and if you made
+/// changes call [`allocate_gpu()`] at the end to allocate any new buffer
+/// needed.
+/// - During the [`RenderStage::Render`] stage, call [`write_buffer()`] from a
+///   command encoder before using any row, to perform any buffer resize copy
+///   pending.
+///
+/// [`BufferVec`]: bevy::render::render_resource::BufferVec
+/// [`AlignedBufferVec`]: bevy_haanabi::render::aligned_buffer_vec::AlignedBufferVec
+#[derive(Debug)]
+pub struct BufferTable<T: Pod + ShaderSize> {
+    /// GPU buffer if already allocated, or `None` otherwise.
+    buffer: Option<AllocatedBuffer>,
+    /// GPU buffer usages.
+    buffer_usage: BufferUsages,
+    /// Optional GPU buffer name, for debugging.
+    label: Option<String>,
+    /// Size of a single buffer element, in bytes, in CPU memory (Rust layout).
+    item_size: usize,
+    /// Size of a single buffer element, in bytes, aligned to GPU memory
+    /// constraints.
+    aligned_size: usize,
+    /// Capacity of the buffer, in number of rows.
+    capacity: usize,
+    /// Size of the "active" portion of the table, which includes allocated rows
+    /// and any row in the free list. All other rows in the
+    /// `active_size..capacity` range are implicitly unallocated.
+    active_size: usize,
+    /// Free list of rows available in the GPU buffer for a new allocation. This
+    /// only contains indices in the `0..active_size` range; all row indices in
+    /// `active_size..capacity` are assumed to be unallocated.
+    free_indices: Vec<u32>,
+    /// Pending values accumulated on CPU and not yet written to GPU, and their
+    /// rows.
+    pending_values: Vec<(u32, T)>,
+    /// Extra pending values accumulated on CPU like `pending_values`, but for
+    /// which there's not enough space in the current GPU buffer. Those values
+    /// are sorted in index order, occupying the range `buffer.size..`.
+    extra_pending_values: Vec<T>,
+}
+
+impl<T: Pod + ShaderSize> Default for BufferTable<T> {
+    fn default() -> Self {
+        let item_size = std::mem::size_of::<T>();
+        let aligned_size = <T as ShaderSize>::SHADER_SIZE.get() as usize;
+        assert!(aligned_size >= item_size);
+        Self {
+            buffer: None,
+            buffer_usage: BufferUsages::all(),
+            label: None,
+            item_size,
+            aligned_size,
+            capacity: 0,
+            active_size: 0,
+            free_indices: Vec::new(),
+            pending_values: Vec::new(),
+            extra_pending_values: Vec::new(),
+        }
+    }
+}
+
+impl<T: Pod + ShaderSize> BufferTable<T> {
+    /// Create a new collection.
+    ///
+    /// `item_align` is an optional additional alignment for items in the
+    /// collection. If greater than the natural alignment dictated by WGSL
+    /// rules, this extra alignment is enforced. Otherwise it's ignored (so you
+    /// can pass `0` to ignore).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `buffer_usage` contains [`BufferUsages::UNIFORM`] and the
+    /// layout of the element type `T` does not meet the requirements of the
+    /// uniform address space, as tested by
+    /// [`ShaderType::assert_uniform_compat()`].
+    ///
+    /// [`BufferUsages::UNIFORM`]: bevy::render::render_resource::BufferUsages::UNIFORM
+    pub fn new(
+        buffer_usage: BufferUsages,
+        item_align: Option<NonZeroU64>,
+        label: Option<String>,
+    ) -> Self {
+        // GPU-aligned item size, compatible with WGSL rules
+        let item_size = <T as ShaderSize>::SHADER_SIZE.get() as usize;
+        // Extra manual alignment for device constraints
+        let aligned_size = if let Some(item_align) = item_align {
+            let item_align = item_align.get() as usize;
+            let aligned_size = next_multiple_of(item_size, item_align);
+            assert!(aligned_size >= item_size);
+            assert!(aligned_size % item_align == 0);
+            aligned_size
+        } else {
+            item_size
+        };
+        println!(
+            "BufferTable: item_size={} aligned_size={}",
+            item_size, aligned_size
+        );
+        if buffer_usage.contains(BufferUsages::UNIFORM) {
+            <T as ShaderType>::assert_uniform_compat();
+        }
+        Self {
+            // Need COPY_SRC and COPY_DST to copy from old to new buffer on resize
+            buffer_usage: buffer_usage | BufferUsages::COPY_SRC | BufferUsages::COPY_DST,
+            aligned_size,
+            label,
+            ..Default::default()
+        }
+    }
+
+    /// Reference to the GPU buffer, if already allocated.
+    ///
+    /// This reference corresponds to the currently allocated GPU buffer, which
+    /// may not contain all data since the last [`insert()`] call, and could
+    /// become invalid if a new larger buffer needs to be allocated to store the
+    /// pending values inserted with [`insert()`].
+    ///
+    /// [`insert()]`: BufferTable::insert
+    #[inline]
+    pub fn buffer(&self) -> Option<&Buffer> {
+        self.buffer.as_ref().map(|ab| &ab.buffer)
+    }
+
+    /// Maximum number of rows the table can hold without reallocation.
+    ///
+    /// This is the maximum number of rows that can be added to the table
+    /// without forcing a new GPU buffer to be allocated and a copy from the old
+    /// to the new buffer.
+    ///
+    /// Note that this doesn't imply that no GPU buffer allocation will ever
+    /// occur; if a GPU buffer was never allocated, and there are pending
+    /// CPU rows to insert, then a new buffer will be allocated on next
+    /// update with this capacity.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Current number of rows in use in the table.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.active_size - self.free_indices.len()
+    }
+
+    /// Size of a single row in the table, in bytes, aligned to GPU constraints.
+    #[inline]
+    pub fn aligned_size(&self) -> usize {
+        self.aligned_size
+    }
+
+    /// Is the table empty?
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.active_size == 0
+    }
+
+    /// Clear all rows of the table without deallocating any existing GPU
+    /// buffer.
+    ///
+    /// This operation only updates the CPU cache of the table, without touching
+    /// any GPU buffer. On next GPU buffer update, the GPU buffer will be
+    /// deallocated.
+    pub fn clear(&mut self) {
+        self.pending_values.clear();
+        self.extra_pending_values.clear();
+        self.free_indices.clear();
+        self.active_size = 0;
+    }
+
+    /// Clear any stale buffer used for resize in the previous frame during
+    /// rendering while the data structure was immutable.
+    ///
+    /// This must be called before any new [`insert()`].
+    ///
+    /// [`insert()`]: crate::BufferTable::insert
+    pub fn clear_previous_frame_resizes(&mut self) {
+        if let Some(ab) = self.buffer.as_mut() {
+            ab.old_buffer = None;
+            ab.old_size = 0;
+        }
+    }
+
+    /// Insert a new row into the table.
+    ///
+    /// For performance reasons, this buffers the row content on the CPU until
+    /// the next GPU update, to minimize the number of CPU to GPU transfers.
+    pub fn insert(&mut self, value: T) -> BufferTableId {
+        let index = self.free_indices.pop().unwrap_or_else(|| {
+            let index = self.active_size;
+            if index == self.capacity {
+                self.capacity += 1;
+            }
+            debug_assert!(index < self.capacity);
+            self.active_size += 1;
+            index as u32
+        }) as usize;
+        let allocated_size = self
+            .buffer
+            .as_ref()
+            .map(|ab| ab.allocated_size())
+            .unwrap_or(0);
+        debug_assert!(allocated_size % self.aligned_size == 0);
+        let allocated_count = allocated_size / self.aligned_size;
+        if index < allocated_count {
+            self.pending_values.alloc().init((index as u32, value));
+        } else {
+            let extra_index = index - allocated_count;
+            if extra_index < self.extra_pending_values.len() {
+                self.extra_pending_values[extra_index] = value;
+            } else {
+                self.extra_pending_values.alloc().init(value);
+            }
+        }
+        BufferTableId(index as u32)
+    }
+
+    /// Remove a row from the table.
+    pub fn remove(&mut self, id: BufferTableId) {
+        let index = id.0;
+        assert!(index < self.active_size as u32);
+
+        // let allocated_size = self
+        //     .buffer
+        //     .as_ref()
+        //     .map(|ab| ab.allocated_size())
+        //     .unwrap_or(0);
+        // debug_assert!(allocated_size % self.aligned_size == 0);
+        // let allocated_count = allocated_size / self.aligned_size;
+
+        // If this is the last item in the active zone, just shrink the active zone (implicit free list).
+        if index == self.active_size as u32 - 1 {
+            self.active_size -= 1;
+            self.capacity -= 1;
+        } else {
+            self.free_indices.push(index);
+        }
+    }
+
+    /// Allocate any GPU buffer if needed, based on the most recent capacity
+    /// requested.
+    ///
+    /// This should be called only once per frame after all allocation requests
+    /// have been made via [`insert()`] but before the GPU buffer is actually
+    /// updated. This is an optimization to enable allocating the GPU buffer
+    /// earlier than it's actually needed. Calling this multiple times will work
+    /// but will be inefficient and allocate GPU buffers for nothing. Not
+    /// calling it is safe, as the next update will call it just-in-time anyway.
+    ///
+    /// [`insert()]`: BufferTable::insert
+    pub fn allocate_gpu(&mut self, device: &RenderDevice, queue: &RenderQueue) {
+        // The allocated capacity is the capacity of the currently allocated GPU buffer,
+        // which can be different from the expected capacity (self.capacity) for next
+        // update.
+        let allocated_size = self.buffer.as_ref().map(|ab| ab.size).unwrap_or(0);
+        let size = self.aligned_size * self.capacity;
+        if size > allocated_size {
+            println!(
+                "reserve: increase capacity from {} to {} elements, new size {} bytes",
+                allocated_size / self.aligned_size,
+                self.capacity,
+                size
+            );
+
+            // Create the new buffer, swapping with the old one if any
+            let new_buffer = device.create_buffer(&BufferDescriptor {
+                label: self.label.as_ref().map(|s| &s[..]),
+                size: size as BufferAddress,
+                usage: self.buffer_usage,
+                mapped_at_creation: false,
+            });
+            if let Some(mut ab) = self.buffer.as_mut() {
+                // If there's any data currently in the GPU buffer, we need to copy it on next
+                // update to preserve it, but only if there's no pending copy already.
+                if self.active_size > 0 && ab.old_buffer.is_none() {
+                    ab.old_buffer = Some(ab.buffer.clone()); // TODO: swap
+                    ab.old_size = ab.size;
+                }
+                ab.buffer = new_buffer;
+                ab.size = size;
+            } else {
+                self.buffer = Some(AllocatedBuffer {
+                    buffer: new_buffer,
+                    size,
+                    old_buffer: None,
+                    old_size: 0,
+                });
+            }
+        }
+
+        // Immediately schedule a copy of all pending rows.
+        // - For new rows, copy directly in the new buffer, which is the only one that
+        //   can hold them since the old buffer was too small.
+        // - For old rows, copy into the old buffer because the old-to-new buffer copy
+        //   will be executed during a command queue while any CPU to GPU upload is
+        //   prepended before the next command queue. To ensure things do get out of
+        //   order with the CPU upload overwriting the GPU-to-GPU copy, make sure those
+        //   two are disjoint.
+        if let Some(ab) = self.buffer.as_ref() {
+            let buffer = ab.old_buffer.as_ref().unwrap_or(&ab.buffer);
+            for (index, content) in self.pending_values.drain(..) {
+                let byte_size = self.aligned_size;
+                let byte_offset = byte_size * index as usize;
+
+                // Copy Rust value into a GPU-ready format, including GPU padding.
+                // TODO - Do that in insert()!
+                let mut aligned_buffer: Vec<u8> = vec![0; self.aligned_size];
+                let src: &[u8] = cast_slice(std::slice::from_ref(&content));
+                let dst_range = ..self.item_size;
+                println!(
+                    "+ copy: index={} src={:?} dst={:?} byte_offset={} byte_size={}",
+                    index,
+                    src.as_ptr(),
+                    dst_range,
+                    byte_offset,
+                    byte_size
+                );
+                let dst = &mut aligned_buffer[dst_range];
+                dst.copy_from_slice(src);
+
+                // Upload to GPU
+                // TODO - Merge contiguous blocks into a single write_buffer()
+                let bytes: &[u8] = cast_slice(&aligned_buffer);
+                queue.write_buffer(buffer, byte_offset as u64, bytes);
+            }
+
+            // If there's any extra values, this means the buffer was (re)allocated, so we
+            // can schedule copies of those rows into the new buffer which has enough
+            // capacity for them.
+            if !self.extra_pending_values.is_empty() {
+                let base_size = ab.old_size;
+                debug_assert!(base_size % self.aligned_size == 0);
+                let base_count = base_size / self.aligned_size;
+                let buffer = &ab.buffer;
+                for (rel_index, content) in self.extra_pending_values.drain(..).enumerate() {
+                    let index = base_count + rel_index;
+                    let byte_size = self.aligned_size; // single row
+                    let byte_offset = byte_size * index;
+
+                    // Copy Rust value into a GPU-ready format, including GPU padding.
+                    // TODO - Do that in insert()!
+                    let mut aligned_buffer: Vec<u8> = vec![0; self.aligned_size];
+                    let src: &[u8] = cast_slice(std::slice::from_ref(&content));
+                    let dst_range = ..self.item_size;
+                    println!(
+                        "+ copy: index={} src={:?} dst={:?} byte_offset={} byte_size={}",
+                        index,
+                        src.as_ptr(),
+                        dst_range,
+                        byte_offset,
+                        byte_size
+                    );
+                    let dst = &mut aligned_buffer[dst_range];
+                    dst.copy_from_slice(src);
+
+                    // Upload to GPU
+                    // TODO - Merge contiguous blocks into a single write_buffer()
+                    // ESPECIALLY SINCE THIS IS TRIVIAL FOR THIS CASE!!!
+                    let bytes: &[u8] = cast_slice(&aligned_buffer);
+                    queue.write_buffer(buffer, byte_offset as u64, bytes);
+                }
+            }
+        } else {
+            debug_assert!(self.pending_values.is_empty());
+            debug_assert!(self.extra_pending_values.is_empty());
+        }
+    }
+
+    /// Write CPU data to the GPU buffer, (re)allocating it as needed.
+    pub fn write_buffer(&self, encoder: &mut CommandEncoder) {
+        // Check if there's any work to do: either some pending values to upload or some
+        // existing buffer to copy into a newly-allocated one.
+        if self.pending_values.is_empty()
+            && self
+                .buffer
+                .as_ref()
+                .map(|ab| ab.old_buffer.is_none())
+                .unwrap_or(true)
+        {
+            return;
+        }
+
+        println!(
+            "write_buffer: pending_values.len={} item_size={} aligned_size={} buffer={:?}",
+            self.pending_values.len(),
+            self.item_size,
+            self.aligned_size,
+            self.buffer,
+        );
+
+        // If there's no more GPU buffer, there's nothing to do
+        let Some(ab) = self.buffer.as_ref() else { return; };
+
+        // Copy any old buffer into the new one, and clear the old buffer. Note that we
+        // only clear the ref-counted reference to the buffer, not the actual buffer,
+        // which stays alive until the copy is done (but we don't need to care about
+        // keeping it alive, wgpu does that for us).
+        if let Some(old_buffer) = ab.old_buffer.as_ref() {
+            println!("Copy old buffer id {:?} of size {} bytes into newly-allocated buffer {:?} of size {} bytes.", old_buffer.id(), ab.old_size, ab.buffer.id(), ab.size);
+            encoder.copy_buffer_to_buffer(old_buffer, 0, &ab.buffer, 0, ab.old_size as u64);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::math::Vec3;
+    use bytemuck::{Pod, Zeroable};
+
+    use super::*;
+
+    #[repr(C)]
+    #[derive(Debug, Default, Clone, Copy, Pod, Zeroable, ShaderType)]
+    pub(crate) struct GpuDummy {
+        pub v: Vec3,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Default, Clone, Copy, Pod, Zeroable, ShaderType)]
+    pub(crate) struct GpuDummyComposed {
+        pub simple: GpuDummy,
+        pub tag: u32,
+        // GPU padding to 16 bytes due to GpuDummy forcing align to 16 bytes
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, Pod, Zeroable, ShaderType)]
+    pub(crate) struct GpuDummyLarge {
+        pub simple: GpuDummy,
+        pub tag: u32,
+        pub large: [f32; 128],
+    }
+
+    #[test]
+    fn table_sizes() {
+        // Rust
+        assert_eq!(std::mem::size_of::<GpuDummy>(), 12);
+        assert_eq!(std::mem::align_of::<GpuDummy>(), 4);
+        assert_eq!(std::mem::size_of::<GpuDummyComposed>(), 16); // tight packing
+        assert_eq!(std::mem::align_of::<GpuDummyComposed>(), 4);
+        assert_eq!(std::mem::size_of::<GpuDummyLarge>(), 132 * 4); // tight packing
+        assert_eq!(std::mem::align_of::<GpuDummyLarge>(), 4);
+
+        // GPU
+        assert_eq!(<GpuDummy as ShaderType>::min_size().get(), 16); // Vec3 gets padded to 16 bytes
+        assert_eq!(<GpuDummy as ShaderSize>::SHADER_SIZE.get(), 16);
+        assert_eq!(<GpuDummyComposed as ShaderType>::min_size().get(), 32); // align is 16 bytes, forces padding
+        assert_eq!(<GpuDummyComposed as ShaderSize>::SHADER_SIZE.get(), 32);
+        assert_eq!(<GpuDummyLarge as ShaderType>::min_size().get(), 544); // align is 16 bytes, forces padding
+        assert_eq!(<GpuDummyLarge as ShaderSize>::SHADER_SIZE.get(), 544);
+
+        for (item_align, expected_aligned_size) in [
+            (0, 16),
+            (4, 16),
+            (8, 16),
+            (16, 16),
+            (32, 32),
+            (256, 256),
+            (512, 512),
+        ] {
+            let mut table = BufferTable::<GpuDummy>::new(
+                BufferUsages::STORAGE,
+                NonZeroU64::new(item_align),
+                None,
+            );
+            assert_eq!(table.aligned_size(), expected_aligned_size);
+            assert!(table.is_empty());
+            table.insert(GpuDummy::default());
+            assert!(!table.is_empty());
+            assert_eq!(table.len(), 1);
+        }
+
+        for (item_align, expected_aligned_size) in [
+            (0, 32),
+            (4, 32),
+            (8, 32),
+            (16, 32),
+            (32, 32),
+            (256, 256),
+            (512, 512),
+        ] {
+            let mut table = BufferTable::<GpuDummyComposed>::new(
+                BufferUsages::STORAGE,
+                NonZeroU64::new(item_align),
+                None,
+            );
+            assert_eq!(table.aligned_size(), expected_aligned_size);
+            assert!(table.is_empty());
+            table.insert(GpuDummyComposed::default());
+            assert!(!table.is_empty());
+            assert_eq!(table.len(), 1);
+        }
+
+        for (item_align, expected_aligned_size) in [
+            (0, 544),
+            (4, 544),
+            (8, 544),
+            (16, 544),
+            (32, 544),
+            (256, 768),
+            (512, 1024),
+        ] {
+            let mut table = BufferTable::<GpuDummyLarge>::new(
+                BufferUsages::STORAGE,
+                NonZeroU64::new(item_align),
+                None,
+            );
+            assert_eq!(table.aligned_size(), expected_aligned_size);
+            assert!(table.is_empty());
+            table.insert(GpuDummyLarge {
+                simple: Default::default(),
+                tag: 0,
+                large: [0.; 128],
+            });
+            assert!(!table.is_empty());
+            assert_eq!(table.len(), 1);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod gpu_tests {
+    use super::*;
+    use crate::test_utils::MockRenderer;
+    use bevy::render::render_resource::BufferSlice;
+    use std::fmt::Write;
+    use tests::*;
+    use wgpu::{BufferView, CommandBuffer};
+
+    /// Read data from GPU back into CPU memory.
+    ///
+    /// This call blocks until the data is available on CPU. Used for testing
+    /// only.
+    fn read_back_gpu<'a>(device: &RenderDevice, slice: BufferSlice<'a>) -> BufferView<'a> {
+        let (tx, rx) = futures::channel::oneshot::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).unwrap();
+        });
+        device.poll(wgpu::Maintain::Wait);
+        let result = futures::executor::block_on(async { rx.await });
+        assert!(result.is_ok());
+        slice.get_mapped_range()
+    }
+
+    /// Submit a command buffer to GPU and wait for completion.
+    ///
+    /// This call blocks until the GPU executed the command buffer. Used for
+    /// testing only.
+    fn submit_gpu_and_wait(
+        device: &RenderDevice,
+        queue: &RenderQueue,
+        command_buffer: CommandBuffer,
+    ) {
+        queue.submit([command_buffer]);
+        device.poll(wgpu::Maintain::Wait);
+        let (tx, rx) = futures::channel::oneshot::channel();
+        queue.on_submitted_work_done(move || {
+            tx.send(()).unwrap();
+        });
+        let _ = futures::executor::block_on(async { rx.await });
+    }
+
+    /// Convert a byte slice to a string of hexadecimal values separated by a
+    /// blank space.
+    fn to_hex_string(slice: &[u8]) -> String {
+        let len = slice.len();
+        let num_chars = len * 3 - 1;
+        let mut s = String::with_capacity(num_chars);
+        for i in 0..len - 1 {
+            write!(&mut s, "{:02x} ", slice[i]).unwrap();
+        }
+        write!(&mut s, "{:02x}", slice[len - 1]).unwrap();
+        debug_assert_eq!(s.len(), num_chars);
+        s
+    }
+
+    fn write_buffers_and_wait<T: Pod + ShaderSize>(
+        table: &BufferTable<T>,
+        device: &RenderDevice,
+        queue: &RenderQueue,
+    ) {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("test"),
+        });
+        table.write_buffer(&mut encoder);
+        let command_buffer = encoder.finish();
+        submit_gpu_and_wait(&device, &queue, command_buffer);
+        println!("Buffer written to GPU");
+    }
+
+    #[test]
+    fn table_write() {
+        let renderer = MockRenderer::new();
+        let device = renderer.device();
+        let queue = renderer.queue();
+
+        let item_align = device.limits().min_storage_buffer_offset_alignment as u64;
+        println!("min_storage_buffer_offset_alignment = {}", item_align);
+        let mut table = BufferTable::<GpuDummyComposed>::new(
+            BufferUsages::STORAGE | BufferUsages::MAP_READ,
+            NonZeroU64::new(item_align),
+            None,
+        );
+        let final_align = item_align.max(<GpuDummyComposed as ShaderSize>::SHADER_SIZE.get());
+        assert_eq!(table.aligned_size(), final_align as usize);
+
+        // Initial state
+        assert!(table.is_empty());
+        assert_eq!(table.len(), 0);
+        assert_eq!(table.capacity(), 0);
+        assert!(table.buffer.is_none());
+
+        // This has no effect while the table is empty
+        table.clear_previous_frame_resizes();
+        table.allocate_gpu(&device, &queue);
+        write_buffers_and_wait(&table, &device, &queue);
+        assert!(table.is_empty());
+        assert_eq!(table.len(), 0);
+        assert_eq!(table.capacity(), 0);
+        assert!(table.buffer.is_none());
+
+        // New frame
+        table.clear_previous_frame_resizes();
+
+        // Insert some entries
+        let len = 3;
+        for i in 0..len as u32 {
+            let row = table.insert(GpuDummyComposed {
+                tag: i + 1,
+                ..Default::default()
+            });
+            assert_eq!(row.0, i);
+        }
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len); // contract: could over-allocate...
+        assert!(table.buffer.is_none()); // not yet allocated on GPU
+
+        // Allocate GPU buffer for current requested state
+        table.allocate_gpu(&device, &queue);
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len);
+        let ab = table
+            .buffer
+            .as_ref()
+            .expect("GPU buffer should be allocated after allocate_gpu()");
+        assert!(ab.old_buffer.is_none()); // no previous copy
+        assert_eq!(ab.size, table.aligned_size() * len);
+        println!(
+            "Allocated buffer #{:?} of size {} bytes",
+            ab.buffer.id(),
+            ab.size
+        );
+        let ab_buffer = ab.buffer.clone();
+
+        // Another allocate_gpu() is a no-op
+        table.allocate_gpu(&device, &queue);
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len);
+        let ab = table
+            .buffer
+            .as_ref()
+            .expect("GPU buffer should be allocated after allocate_gpu()");
+        assert!(ab.old_buffer.is_none()); // no previous copy
+        assert_eq!(ab.size, table.aligned_size() * len);
+        assert_eq!(ab_buffer.id(), ab.buffer.id()); // same buffer
+
+        // Write buffer (CPU -> GPU)
+        write_buffers_and_wait(&table, &device, &queue);
+
+        {
+            // Read back (GPU -> CPU)
+            let buffer = table.buffer().expect("Buffer was not allocated").clone(); // clone() for lifetime
+            {
+                let slice = buffer.slice(..);
+                let view = read_back_gpu(&device, slice);
+                println!(
+                    "GPU data read back to CPU for validation: {} bytes",
+                    view.len()
+                );
+
+                // Validate content
+                assert_eq!(view.len(), final_align as usize * table.capacity());
+                for i in 0..len {
+                    let offset = i * final_align as usize;
+                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let src = &view[offset..offset + 16];
+                    println!("{}", to_hex_string(src));
+                    let dummy_composed: &[GpuDummyComposed] =
+                        cast_slice(&view[offset..offset + item_size]);
+                    assert_eq!(dummy_composed[0].tag, (i + 1) as u32);
+                }
+            }
+            buffer.unmap();
+        }
+
+        // New frame
+        table.clear_previous_frame_resizes();
+
+        // Insert more entries
+        let old_capacity = table.capacity();
+        let mut len = len as u32;
+        while table.capacity() == old_capacity {
+            let row = table.insert(GpuDummyComposed {
+                tag: len + 1,
+                ..Default::default()
+            });
+            assert_eq!(row.0, len);
+            len += 1;
+        }
+        println!(
+            "Added {} rows to grow capacity from {} to {}.",
+            len - 3,
+            old_capacity,
+            table.capacity()
+        );
+        let len = len as usize;
+
+        // This re-allocates a new GPU buffer because the capacity changed
+        table.allocate_gpu(&device, &queue);
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len);
+        let ab = table
+            .buffer
+            .as_ref()
+            .expect("GPU buffer should be allocated after allocate_gpu()");
+        assert_eq!(ab.size, table.aligned_size() * len);
+        assert!(ab.old_buffer.is_some()); // old buffer to copy
+        assert_ne!(ab.old_buffer.as_ref().unwrap().id(), ab.buffer.id());
+        println!(
+            "Allocated new buffer #{:?} of size {} bytes",
+            ab.buffer.id(),
+            ab.size
+        );
+
+        // Write buffer (CPU -> GPU)
+        write_buffers_and_wait(&table, &device, &queue);
+
+        {
+            // Read back (GPU -> CPU)
+            let buffer = table.buffer().expect("Buffer was not allocated").clone(); // clone() for lifetime
+            {
+                let slice = buffer.slice(..);
+                let view = read_back_gpu(&device, slice);
+                println!(
+                    "GPU data read back to CPU for validation: {} bytes",
+                    view.len()
+                );
+
+                // Validate content
+                assert_eq!(view.len(), final_align as usize * table.capacity());
+                for i in 0..len {
+                    let offset = i * final_align as usize;
+                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let src = &view[offset..offset + 16];
+                    println!("{}", to_hex_string(src));
+                    let dummy_composed: &[GpuDummyComposed] =
+                        cast_slice(&view[offset..offset + item_size]);
+                    assert_eq!(dummy_composed[0].tag, (i + 1) as u32);
+                }
+            }
+            buffer.unmap();
+        }
+
+        // New frame
+        table.clear_previous_frame_resizes();
+
+        // Delete the last allocated row
+        let old_capacity = table.capacity();
+        let len = len - 1;
+        table.remove(BufferTableId(len as u32));
+        println!(
+            "Removed last row to shrink capacity from {} to {}.",
+            old_capacity,
+            table.capacity()
+        );
+
+        // This doesn't do anything since we removed a row only
+        table.allocate_gpu(&device, &queue);
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len);
+        let ab = table
+            .buffer
+            .as_ref()
+            .expect("GPU buffer should be allocated after allocate_gpu()");
+        assert_eq!(ab.size, table.aligned_size() * (len + 1)); // GPU buffer kept its size
+        assert!(ab.old_buffer.is_none());
+
+        // Write buffer (CPU -> GPU)
+        write_buffers_and_wait(&table, &device, &queue);
+
+        {
+            // Read back (GPU -> CPU)
+            let buffer = table.buffer().expect("Buffer was not allocated").clone(); // clone() for lifetime
+            {
+                let slice = buffer.slice(..);
+                let view = read_back_gpu(&device, slice);
+                println!(
+                    "GPU data read back to CPU for validation: {} bytes",
+                    view.len()
+                );
+
+                // Validate content
+                assert!(view.len() >= final_align as usize * table.capacity()); // note the >=, the buffer is over-allocated
+                for i in 0..len {
+                    let offset = i * final_align as usize;
+                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let src = &view[offset..offset + 16];
+                    println!("{}", to_hex_string(src));
+                    let dummy_composed: &[GpuDummyComposed] =
+                        cast_slice(&view[offset..offset + item_size]);
+                    assert_eq!(dummy_composed[0].tag, (i + 1) as u32);
+                }
+            }
+            buffer.unmap();
+        }
+
+        // New frame
+        table.clear_previous_frame_resizes();
+
+        // Delete the first allocated row
+        let old_capacity = table.capacity();
+        let len = len - 1;
+        table.remove(BufferTableId(0));
+        println!(
+            "Removed first row to shrink capacity from {} to {}.",
+            old_capacity,
+            table.capacity()
+        );
+
+        // This doesn't do anything since we removed a row only
+        table.allocate_gpu(&device, &queue);
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len);
+        let ab = table
+            .buffer
+            .as_ref()
+            .expect("GPU buffer should be allocated after allocate_gpu()");
+        assert_eq!(ab.size, table.aligned_size() * (len + 2)); // GPU buffer kept its size
+        assert!(ab.old_buffer.is_none());
+
+        // Write buffer (CPU -> GPU)
+        write_buffers_and_wait(&table, &device, &queue);
+
+        {
+            // Read back (GPU -> CPU)
+            let buffer = table.buffer().expect("Buffer was not allocated").clone(); // clone() for lifetime
+            {
+                let slice = buffer.slice(..);
+                let view = read_back_gpu(&device, slice);
+                println!(
+                    "GPU data read back to CPU for validation: {} bytes",
+                    view.len()
+                );
+
+                // Validate content
+                assert!(view.len() >= final_align as usize * table.capacity()); // note the >=, the buffer is over-allocated
+                for i in 0..len {
+                    let offset = i * final_align as usize;
+                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let src = &view[offset..offset + 16];
+                    println!("{}", to_hex_string(src));
+                    if i > 0 {
+                        let dummy_composed: &[GpuDummyComposed] =
+                            cast_slice(&view[offset..offset + item_size]);
+                        assert_eq!(dummy_composed[0].tag, (i + 1) as u32);
+                    }
+                }
+            }
+            buffer.unmap();
+        }
+
+        // New frame
+        table.clear_previous_frame_resizes();
+
+        // Insert a row; this should get into row #0 in the buffer
+        let mut len = len as u32;
+        let row = table.insert(GpuDummyComposed {
+            tag: 1,
+            ..Default::default()
+        });
+        assert_eq!(row.0, 0);
+        len += 1;
+        println!(
+            "Added 1 row to grow capacity from {} to {}.",
+            old_capacity,
+            table.capacity()
+        );
+        let len = len as usize;
+
+        // This doesn't reallocate the GPU buffer since we used a free list entry
+        table.allocate_gpu(&device, &queue);
+        assert!(!table.is_empty());
+        assert_eq!(table.len(), len);
+        assert!(table.capacity() >= len);
+        let ab = table
+            .buffer
+            .as_ref()
+            .expect("GPU buffer should be allocated after allocate_gpu()");
+        assert_eq!(ab.size, table.aligned_size() * 4); // 4 == last time we grew
+        assert!(ab.old_buffer.is_none());
+
+        // Write buffer (CPU -> GPU)
+        write_buffers_and_wait(&table, &device, &queue);
+
+        {
+            // Read back (GPU -> CPU)
+            let buffer = table.buffer().expect("Buffer was not allocated").clone(); // clone() for lifetime
+            {
+                let slice = buffer.slice(..);
+                let view = read_back_gpu(&device, slice);
+                println!(
+                    "GPU data read back to CPU for validation: {} bytes",
+                    view.len()
+                );
+
+                // Validate content
+                assert!(view.len() >= final_align as usize * table.capacity());
+                for i in 0..len {
+                    let offset = i * final_align as usize;
+                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let src = &view[offset..offset + 16];
+                    println!("{}", to_hex_string(src));
+                    let dummy_composed: &[GpuDummyComposed] =
+                        cast_slice(&view[offset..offset + item_size]);
+                    assert_eq!(dummy_composed[0].tag, (i + 1) as u32);
+                }
+            }
+            buffer.unmap();
+        }
+    }
+}

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -1,6 +1,6 @@
 use bevy::{
     core::{cast_slice, Pod},
-    //log::trace,
+    log::trace,
     render::{
         render_resource::{
             Buffer, BufferAddress, BufferDescriptor, BufferUsages, CommandEncoder, ShaderSize,
@@ -164,7 +164,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
         } else {
             item_size
         };
-        println!(
+        trace!(
             "BufferTable: item_size={} aligned_size={}",
             item_size, aligned_size
         );
@@ -333,7 +333,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
         let size = self.aligned_size * self.capacity;
         let mut reallocated = false;
         if size > allocated_size {
-            println!(
+            trace!(
                 "reserve: increase capacity from {} to {} elements, new size {} bytes",
                 allocated_size / self.aligned_size,
                 self.capacity,
@@ -386,7 +386,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
                 let mut aligned_buffer: Vec<u8> = vec![0; self.aligned_size];
                 let src: &[u8] = cast_slice(std::slice::from_ref(&content));
                 let dst_range = ..self.item_size;
-                println!(
+                trace!(
                     "+ copy: index={} src={:?} dst={:?} byte_offset={} byte_size={}",
                     index,
                     src.as_ptr(),
@@ -421,7 +421,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
                     let mut aligned_buffer: Vec<u8> = vec![0; self.aligned_size];
                     let src: &[u8] = cast_slice(std::slice::from_ref(&content));
                     let dst_range = ..self.item_size;
-                    println!(
+                    trace!(
                         "+ copy: index={} src={:?} dst={:?} byte_offset={} byte_size={}",
                         index,
                         src.as_ptr(),
@@ -461,7 +461,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
             return;
         }
 
-        println!(
+        trace!(
             "write_buffer: pending_values.len={} item_size={} aligned_size={} buffer={:?}",
             self.pending_values.len(),
             self.item_size,
@@ -477,7 +477,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
         // which stays alive until the copy is done (but we don't need to care about
         // keeping it alive, wgpu does that for us).
         if let Some(old_buffer) = ab.old_buffer.as_ref() {
-            println!("Copy old buffer id {:?} of size {} bytes into newly-allocated buffer {:?} of size {} bytes.", old_buffer.id(), ab.old_size, ab.buffer.id(), ab.size);
+            trace!("Copy old buffer id {:?} of size {} bytes into newly-allocated buffer {:?} of size {} bytes.", old_buffer.id(), ab.old_size, ab.buffer.id(), ab.size);
             encoder.copy_buffer_to_buffer(old_buffer, 0, &ab.buffer, 0, ab.old_size as u64);
         }
     }

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -151,7 +151,7 @@ impl EffectBuffer {
         let indirect_label = if let Some(label) = label {
             format!("{}_indirect", label)
         } else {
-            "hanabi:effect_buffer_indirect".to_owned()
+            "hanabi:buffer:effect_indirect".to_owned()
         };
         let indirect_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some(&indirect_label),
@@ -462,7 +462,7 @@ impl EffectCache {
                     item_size,
                     //pipeline,
                     &self.device,
-                    Some(&format!("hanabi:effect_buffer{}", buffer_index)),
+                    Some(&format!("hanabi:buffer:effect{}_particles", buffer_index)),
                 );
                 let slice_ref = buffer.allocate_slice(capacity, item_size).unwrap();
                 if buffer_index >= self.buffers.len() {
@@ -495,6 +495,11 @@ impl EffectCache {
                 item_size: slice_ref.item_size,
             })
             .unwrap()
+    }
+
+    /// Get the zero-based index of the buffer. Used internally.
+    pub(crate) fn buffer_index(&self, id: EffectCacheId) -> Option<usize> {
+        self.effects.get(&id).map(|(buffer_index, _)| *buffer_index)
     }
 
     /// Remove an effect from the cache. If this was the last effect, drop the

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -68,7 +68,9 @@ impl SliceRef {
 /// Storage for a single kind of effects, sharing the same buffer(s).
 ///
 /// Currently only accepts a single unique item size (particle size), fixed at
-/// creation. Also currently only accepts instances of a unique of effect asset.
+/// creation. Also currently only accepts instances of a unique effect asset,
+/// although this restriction is purely for convenience and may be relaxed in
+/// the future to improve batching.
 pub struct EffectBuffer {
     /// GPU buffer holding all particles for the entire group of effects.
     particle_buffer: Buffer,
@@ -131,7 +133,10 @@ impl EffectBuffer {
         );
 
         let capacity = capacity.max(Self::MIN_CAPACITY);
-        debug_assert!(capacity > 0, "Attempted to create a zero-sized effect buffer.");
+        debug_assert!(
+            capacity > 0,
+            "Attempted to create a zero-sized effect buffer."
+        );
 
         let particle_capacity_bytes: BufferAddress = capacity as u64 * item_size as u64;
         let particle_buffer = render_device.create_buffer(&BufferDescriptor {
@@ -463,13 +468,9 @@ impl EffectCache {
                 if buffer_index >= self.buffers.len() {
                     self.buffers.push(Some(buffer));
                 } else {
-                    assert!(self.buffers[buffer_index].is_none());
+                    debug_assert!(self.buffers[buffer_index].is_none());
                     self.buffers[buffer_index] = Some(buffer);
                 }
-                // Newly-allocated buffers are not cleared to zero, and currently we eagerly render the entire buffer
-                // since we don't have an indirection buffer to tell us how many particles are alive. So clear the buffer
-                // to zero to mark all particles as invalid and prevent rendering them.
-                //queue.cle
                 Some((buffer_index, slice_ref))
             })
             .unwrap();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -46,10 +46,12 @@ use crate::{
 };
 
 mod aligned_buffer_vec;
+mod buffer_table;
 mod effect_cache;
 mod shader_cache;
 
 use aligned_buffer_vec::AlignedBufferVec;
+use buffer_table::BufferTable;
 pub(crate) use effect_cache::{EffectCache, EffectCacheId};
 
 pub use effect_cache::{EffectBuffer, EffectSlice};
@@ -187,12 +189,23 @@ struct GpuSpawnerParams {
 
 // FIXME - min_storage_buffer_offset_alignment
 #[repr(C)]
-#[derive(Debug, Default, Clone, Copy, Pod, Zeroable, ShaderType)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable, ShaderType)]
 pub struct GpuDispatchIndirect {
     pub x: u32,
     pub y: u32,
     pub z: u32,
     pub pong: u32,
+}
+
+impl Default for GpuDispatchIndirect {
+    fn default() -> Self {
+        Self {
+            x: 0,
+            y: 1,
+            z: 1,
+            pong: 0,
+        }
+    }
 }
 
 #[repr(C)]
@@ -243,7 +256,7 @@ impl FromWorld for DispatchIndirectPipeline {
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: false,
-                            min_binding_size: NonZeroU64::new(256), // FIXME - Some(GpuRenderIndirect::min_size()), with proper alignment for storage offset
+                            min_binding_size: Some(GpuRenderIndirect::min_size()),
                         },
                         count: None,
                     },
@@ -253,7 +266,7 @@ impl FromWorld for DispatchIndirectPipeline {
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Storage { read_only: false },
                             has_dynamic_offset: false,
-                            min_binding_size: NonZeroU64::new(256), // FIXME - Some(GpuDispatchIndirect::min_size()), with proper alignment for storage offset
+                            min_binding_size: Some(GpuDispatchIndirect::min_size()),
                         },
                         count: None,
                     },
@@ -343,7 +356,7 @@ impl FromWorld for ParticlesInitPipeline {
                     },
                     count: None,
                 }],
-                label: Some("hanabi:update_sim_params_layout"),
+                label: Some("hanabi:bind_group_layout:update_sim_params"),
             });
 
         trace!("GpuParticle: min_size={}", GpuParticle::min_size());
@@ -371,7 +384,7 @@ impl FromWorld for ParticlesInitPipeline {
                         count: None,
                     },
                 ],
-                label: Some("hanabi:init_particles_buffer_layout"),
+                label: Some("hanabi:buffer_layout:init_particles"),
             });
 
         trace!(
@@ -390,7 +403,7 @@ impl FromWorld for ParticlesInitPipeline {
                     },
                     count: None,
                 }],
-                label: Some("hanabi:init_spawner_buffer_layout"),
+                label: Some("hanabi:buffer_layout:init_spawner"),
             });
 
         trace!(
@@ -409,11 +422,11 @@ impl FromWorld for ParticlesInitPipeline {
                     },
                     count: None,
                 }],
-                label: Some("hanabi:init_render_indirect_layout"),
+                label: Some("hanabi:bind_group_layout:init_render_indirect"),
             });
 
         let pipeline_layout = render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
-            label: Some("hanabi:init_pipeline_layout"),
+            label: Some("hanabi:pipeline_layout:init"),
             bind_group_layouts: &[
                 &sim_params_layout,
                 &particles_buffer_layout,
@@ -1176,8 +1189,8 @@ pub(crate) struct EffectsMeta {
 
     sim_params_uniforms: UniformBuffer<SimParamsUniform>,
     spawner_buffer: AlignedBufferVec<GpuSpawnerParams>,
-    dispatch_indirect_buffer: AlignedBufferVec<GpuDispatchIndirect>,
-    render_dispatch_buffer: AlignedBufferVec<GpuRenderIndirect>,
+    dispatch_indirect_buffer: BufferTable<GpuDispatchIndirect>,
+    render_dispatch_buffer: BufferTable<GpuRenderIndirect>,
     /// Unscaled vertices of the mesh of a single particle, generally a quad.
     /// The mesh is later scaled during rendering by the "particle size".
     // FIXME - This is a per-effect thing, unless we merge all meshes into a single buffer (makes
@@ -1231,17 +1244,21 @@ impl EffectsMeta {
             spawner_buffer: AlignedBufferVec::new(
                 BufferUsages::STORAGE,
                 NonZeroU64::new(item_align),
-                Some("hanabi:buffer_spawner".to_string()),
+                Some("hanabi:buffer:spawner".to_string()),
             ),
-            dispatch_indirect_buffer: AlignedBufferVec::new(
+            dispatch_indirect_buffer: BufferTable::new(
+                BufferUsages::STORAGE | BufferUsages::INDIRECT,
+                // NOTE: Technically we're using an offset in dispatch_workgroups_indirect(), but
+                // `min_storage_buffer_offset_alignment` is documented as being for the offset in
+                // BufferBinding and the dynamic offset in set_bind_group(), so either the
+                // documentation is lacking or we don't need to align here.
+                NonZeroU64::new(item_align),
+                Some("hanabi:buffer:dispatch_indirect".to_string()),
+            ),
+            render_dispatch_buffer: BufferTable::new(
                 BufferUsages::STORAGE | BufferUsages::INDIRECT,
                 NonZeroU64::new(item_align),
-                Some("hanabi:buffer_dispatch_indirect".to_string()),
-            ),
-            render_dispatch_buffer: AlignedBufferVec::new(
-                BufferUsages::STORAGE | BufferUsages::INDIRECT,
-                NonZeroU64::new(item_align),
-                Some("hanabi:buffer_render_dispatch".to_string()),
+                Some("hanabi:buffer:render_dispatch".to_string()),
             ),
             vertices,
             indirect_dispatch_pipeline: None,
@@ -1344,51 +1361,39 @@ impl EffectsMeta {
             // FIXME - Kind of brittle since the EffectCache doesn't know about those
             let index = cache_id.0 as usize;
 
-            self //FIXME - Should be inside AlignedBufferVec<T>
+            let table_id = self
                 .dispatch_indirect_buffer
-                .reserve(128, &render_device);
-            while index >= self.dispatch_indirect_buffer.len() {
-                self.dispatch_indirect_buffer
-                    .push(GpuDispatchIndirect::default());
-            }
-            let di = &mut self.dispatch_indirect_buffer[index];
-            di.x = 0;
-            di.y = 1;
-            di.z = 1;
+                .insert(GpuDispatchIndirect::default());
+            // FIXME - Should have a single index and table bookeeping data structure, used
+            // by multiple buffers
+            assert_eq!(
+                table_id.0 as usize, index,
+                "Broken table invariant: buffer={} row={}",
+                index, table_id.0
+            );
 
-            // FIXME - Think about batching those writes...
-            // effects_meta
-            //     .dispatch_indirect_buffer
-            //     .write_element(index, &render_device, &render_queue);
-            self.dispatch_indirect_buffer
-                .write_buffer(&render_device, &render_queue);
-
-            self //FIXME - Should be inside AlignedBufferVec<T>
-                .render_dispatch_buffer
-                .reserve(128, &render_device);
-            while index >= self.render_dispatch_buffer.len() {
-                self.render_dispatch_buffer
-                    .push(GpuRenderIndirect::default());
-            }
-            let ri = &mut self.render_dispatch_buffer[index];
-            ri.vertex_count = 6; // TODO
-            ri.instance_count = 0;
-            ri.base_index = 0;
-            ri.vertex_offset = 0;
-            ri.base_instance = 0;
-            ri.alive_count = 0;
-            ri.dead_count = added_effect.capacity;
-            ri.max_spawn = added_effect.capacity;
-            ri.ping = 0;
-            ri.max_update = 0;
-
-            // FIXME - Think about batching those writes...
-            // effects_meta
-            //     .render_dispatch_buffer
-            //     .write_element(index, &render_device, &render_queue);
-            self.render_dispatch_buffer
-                .write_buffer(&render_device, &render_queue);
+            let table_id = self.render_dispatch_buffer.insert(GpuRenderIndirect {
+                vertex_count: 6, // TODO - Flexible vertex count and mesh particles
+                dead_count: added_effect.capacity,
+                max_spawn: added_effect.capacity,
+                ..default()
+            });
+            // FIXME - Should have a single index and table bookeeping data structure, used
+            // by multiple buffers
+            assert_eq!(
+                table_id.0 as usize, index,
+                "Broken table invariant: buffer={} row={}",
+                index, table_id.0
+            );
         }
+
+        // Once all changes are applied, immediately schedule any GPU buffer
+        // (re)allocation based on the new buffer size. The actual GPU buffer content
+        // will be written later.
+        self.dispatch_indirect_buffer
+            .allocate_gpu(&render_device, &render_queue);
+        self.render_dispatch_buffer
+            .allocate_gpu(&render_device, &render_queue);
     }
 }
 
@@ -1490,6 +1495,15 @@ pub(crate) fn prepare_effects(
         .write_buffer(&render_device, &render_queue);
 
     effects_meta.indirect_dispatch_pipeline = Some(dispatch_indirect_pipeline.pipeline.clone());
+
+    // Clear last frame's buffer resizes which may have occured during last frame,
+    // during `Node::run()` while the `BufferTable` could not be mutated.
+    effects_meta
+        .dispatch_indirect_buffer
+        .clear_previous_frame_resizes();
+    effects_meta
+        .render_dispatch_buffer
+        .clear_previous_frame_resizes();
 
     // Allocate new effects, deallocate removed ones
     let removed_effect_entities = std::mem::take(&mut extracted_effects.removed_effect_entities);
@@ -1778,7 +1792,7 @@ pub(crate) fn prepare_effects(
         assert_ne!(asset, Handle::<EffectAsset>::default());
         assert!(item_size > 0);
         trace!(
-            "Emit LAST batch: buffer #{} | spawner_base {} | spawn_count{} | slice {:?} | item_size {} | update_shader {:?} | render_shader {:?} | entities {}",
+            "Emit LAST batch: buffer #{} | spawner_base {} | spawn_count {} | slice {:?} | item_size {} | update_shader {:?} | render_shader {:?} | entities {}",
             current_buffer_index,
             spawner_base,
             spawn_count,
@@ -2732,6 +2746,16 @@ impl Node for VfxSimulateNode {
 
         let effects_meta = world.resource::<EffectsMeta>();
         let effect_bind_groups = world.resource::<EffectBindGroups>();
+        //let render_queue = world.resource::<RenderQueue>();
+
+        // Make sure to schedule any buffer copy from changed effects before accessing
+        // them
+        effects_meta
+            .dispatch_indirect_buffer
+            .write_buffer(&mut render_context.command_encoder);
+        effects_meta
+            .render_dispatch_buffer
+            .write_buffer(&mut render_context.command_encoder);
 
         // Compute init pass
         {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -160,6 +160,8 @@ impl MockRenderer {
                 // Request MAPPABLE_PRIMARY_BUFFERS to allow MAP_WRITE|COPY_DST.
                 // FIXME - Should use a separate buffer from primary to support more platforms.
                 features: wgpu::Features::MAPPABLE_PRIMARY_BUFFERS,
+                // Request downlevel_defaults() for maximum compatibility in testing. The actual
+                // Hanabi library uses the default requested mode of the app.
                 limits: wgpu::Limits::downlevel_defaults(),
             },
             None,


### PR DESCRIPTION
Fix the dispatch indirect and render dispatch buffers being overwritten on
re-allocating. The buffers are accessed both by the CPU to allocate new effects
and by the GPU to update existing effect. On re-allocating, the CPU to GPU copy
was overwriting all previous GPU changes, which resulted in all spawned effect
appearing to restart.

This change introduces a new `BufferTable` data structure with a free list,
which helps carefully interleave CPU-to-GPU upload writes and GPU-side
mutations so they never overwrite each other.

The `instancing` example has been updated to be interactive, allowing the user
to add more effects with SPACE and remove existing effects with DELETE. This
shows the bug is fixed and users can spawn and despawn effect instances without
affecting the other spawned instances.

Fixes #117