### PR TITLE
Upgrade examples to `bevy-inspector-egui` v0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ wgpu = "0.14.0"
 naga = "0.10"
 
 futures = "0.3"
-bevy-inspector-egui = "0.14"
+bevy-inspector-egui = "0.17"
 
 [[example]]
 name = "firework"

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -10,7 +10,7 @@ use bevy::{
     render::{camera::ScalingMode, render_resource::WgpuFeatures, settings::WgpuSettings},
     sprite::MaterialMesh2dBundle,
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -9,7 +9,7 @@ use bevy::{
         settings::WgpuSettings,
     },
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -6,7 +6,7 @@ use bevy::{
     prelude::*,
     render::{camera::Projection, render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -6,7 +6,7 @@ use bevy::{
     prelude::*,
     render::{render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -19,7 +19,7 @@ use bevy::{
     log::LogPlugin,
     prelude::*,
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -7,7 +7,7 @@ use bevy::{
     prelude::*,
     render::{camera::Projection, render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         //.add_plugin(LookTransformPlugin)
         //.add_plugin(OrbitCameraPlugin::default())
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -6,7 +6,7 @@ use bevy::{
         view::RenderLayers,
     },
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use std::f32::consts::PI;
 
 use bevy_hanabi::prelude::*;
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -1,5 +1,5 @@
 use bevy::{log::LogPlugin, prelude::*, render::mesh::shape::Cube};
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -20,7 +20,7 @@ fn main() {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .init_resource::<MyEffect>()
         .add_startup_system(setup)
         .add_system(keyboard_input_system)

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
     render::{mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -10,7 +10,7 @@ use bevy::{
     },
     window::{WindowId, WindowResized},
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -22,7 +22,7 @@ fn main() {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .add_system(update_camera_viewports)
         .run();

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -6,7 +6,7 @@ use bevy::{
     prelude::*,
     render::{mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings},
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -6,7 +6,7 @@ use bevy::{
         settings::{WgpuLimits, WgpuSettings},
     },
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -10,7 +10,7 @@ use bevy::{
         settings::WgpuSettings,
     },
 };
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .add_system(update)
         .run();


### PR DESCRIPTION
Upgrade the examples to use the newer v0.17 of `bevy-inspector-egui` which comes with built-in support for `Option<T>` for reflected type, allowing to reflect _e.g._ the `Spawner` of a `ParticleEffect` to be able to dynamically activate and deactivate it in examples.