### PR TITLE
Request `PRIMARY` backends in mock renderer

### DIFF
--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -273,7 +273,8 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
             self.active_size += 1;
             index as u32
         } else {
-            // Note: this is inefficient O(n) but we need to apply the same logic as the EffectCache because we rely on indices being in sync.
+            // Note: this is inefficient O(n) but we need to apply the same logic as the
+            // EffectCache because we rely on indices being in sync.
             self.free_indices.remove(0)
         } as usize;
         let allocated_size = self
@@ -322,7 +323,8 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
             self.active_size -= 1;
             self.capacity -= 1;
         } else {
-            // This is very inefficient but we need to apply the same logic as the EffectCache because we rely on indices being in sync.
+            // This is very inefficient but we need to apply the same logic as the
+            // EffectCache because we rely on indices being in sync.
             let pos = self
                 .free_indices
                 .binary_search(&index) // will fail

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1224,7 +1224,8 @@ pub(crate) struct EffectsMeta {
     vertices: BufferVec<GpuParticleVertex>,
     ///
     indirect_dispatch_pipeline: Option<ComputePipeline>,
-    /// Various GPU limits and aligned sizes lazily allocated and cached for convenience.
+    /// Various GPU limits and aligned sizes lazily allocated and cached for
+    /// convenience.
     gpu_limits: Option<GpuLimits>,
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -143,8 +143,10 @@ pub(crate) struct MockRenderer {
 impl MockRenderer {
     /// Create a new mock renderer with a default backend and adapter.
     pub fn new() -> Self {
-        // Create the WGPU adapter
-        let instance = wgpu::Instance::new(wgpu::Backends::all());
+        // Create the WGPU adapter. Use PRIMARY backends (Vulkan, Metal, DX12,
+        // Browser+WebGPU) to ensure we get a backend that supports compute and other
+        // modern features we might need.
+        let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
         let adapter =
             futures::executor::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::default(),


### PR DESCRIPTION
Ensure we get a modern implementation, normally Vulkan as we run CI on Linux agents, which supports the features we need for Hanabi like compute shaders. This prevent CI agents from failing some GPU tests.