### PR TITLE
Fix tarpaulin caching on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
             target/
           key: ${{ runner.os }}-cargo-build-all-stable-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
@@ -95,7 +97,7 @@ jobs:
         if: runner.os == 'linux'
       - name: Install cargo-tarpaulin
         run: |
-          RUST_BACKTRACE=1 cargo install --force --version 0.22.0 cargo-tarpaulin
+          RUST_BACKTRACE=1 cargo install --version 0.22.0 cargo-tarpaulin
       - name: Generate code coverage
         run: |
           RUST_BACKTRACE=1 cargo tarpaulin --engine llvm --verbose --timeout 120 --out Lcov --workspace --all-features


### PR DESCRIPTION
Properly cache `.crates.toml` and `.crates2.json` as recommended by the cargo team here: https://github.com/rust-lang/cargo/issues/11513. This ensures installed cargo binaries are cached, and restored correctly.

Remove the `--force` flag from the tarpaulin install, to use the cached version if available and speed up the coverage build.