### PR TITLE
Dynamic attribute-based particle layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a `SimulationSpace` enum with a single value `Global`, in preparation of future support for local-space particle simulation.
+- Added properties, named quantities associated with an `EffectAsset` and modifiable at runtime at assignable to values of modifiers. This enables dynamically modifying at runtime any property-based modifier value. Other non-property-based values are assumed to be constant, and are optimized by hard-coding them into the various shaders. Use `EffectAsset::with_property()` and `EffectAsset::add_property()` to define a new property before binding it to a modifier's value. The `spawn.rs` example demonstrates this with the acceleration of the `AccelModifier`.
+- Added particle `Attribute`s, individual items holding a single per-particle scalar or vector value. Composed together, the attributes form the particle layout, which defines at runtime the set of per-particle values used in the simulation. This change marks a transition from the previous design where the particle attributes were hard-coded to be the position, velocity, age, and lifetime of the particle. With this change, a collection of various attributes is available for modifiers to manipulate. This ensures flexibility in customizing while retaining a minimal per-particle memory footprint for a given effect. Note that [`Attribute`]s are all built-in; a custom [`Attribute`] cannot be used.
+
+### Changed
+
+- Effects no longer have a default particle lifetime of 5 seconds. Instead an explicit lifetime must be set with the `ParticleLifetimeModifier`. Failure to set the lifetime will trigger a warning at runtime, and particles will default to a lifetime of zero and instantly die.
+- Effects no longer have a default initial position similar to the `PositionSphereModifier`. Add a `PositionSphereModifier` explicitly to an effect to restore the previous behavior, with a center of `Vec3::ZERO`, a radius of `1.`, a dimension of `ShapeDimension::Volume`, and a speed of `2.`.
+- The acceleration of the `AccelModifier` is now property-based. To dynamically change the acceleration at runtime, assign its value to an effect property with `AccelModifier::via_property()`. Otherwise a constant value built with `AccelModifier::constant()` can be used, and will be optimized in the update shader. See the `spawn.rs` example.
+- All modifiers are now fully reflected (derive both `Reflect` and `FromReflect`) and de/serializable. They're serialized as enums, using the `typetag` crate.
+- `ShapeDimension` now derives `Debug` and is fully reflected (derives both `Reflect` and `FromReflect`) and de/serializable.
+- `Value<T>` now requires `T: FromReflect`, and itself derives both `Reflect` and `FromReflect`.
+- Consequence of `Value<T>` being fully reflected, several fields on `Spawner` are now fully reflected too and not ignored anymore.
+
+### Removed
+
+- Deleted `InitLayout`. Init modifiers are now directly applying themselves to the `InitContext`.
+
 ## [0.5.3] 2023-02-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ShapeDimension` now derives `Debug` and is fully reflected (derives both `Reflect` and `FromReflect`) and de/serializable.
 - `Value<T>` now requires `T: FromReflect`, and itself derives both `Reflect` and `FromReflect`.
 - Consequence of `Value<T>` being fully reflected, several fields on `Spawner` are now fully reflected too and not ignored anymore.
+- The conforming to sphere feature of `ForceFieldModifier` is now applied before the Euler integration updating the particle position. This may result is tiny deviations from the previous behavior, as the particle position will not strictly conform to the sphere at the end of the step. However the delta should be very small, and no visible difference is expected in practice.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a `SimulationSpace` enum with a single value `Global`, in preparation of future support for local-space particle simulation.
+- Added `InitAgeModifier` to initialize the age of particles to a specific (possibly random) value instead of the default `0.0`.
 - Added properties, named quantities associated with an `EffectAsset` and modifiable at runtime at assignable to values of modifiers. This enables dynamically modifying at runtime any property-based modifier value. Other non-property-based values are assumed to be constant, and are optimized by hard-coding them into the various shaders. Use `EffectAsset::with_property()` and `EffectAsset::add_property()` to define a new property before binding it to a modifier's value. The `spawn.rs` example demonstrates this with the acceleration of the `AccelModifier`.
 - Added particle `Attribute`s, individual items holding a single per-particle scalar or vector value. Composed together, the attributes form the particle layout, which defines at runtime the set of per-particle values used in the simulation. This change marks a transition from the previous design where the particle attributes were hard-coded to be the position, velocity, age, and lifetime of the particle. With this change, a collection of various attributes is available for modifiers to manipulate. This ensures flexibility in customizing while retaining a minimal per-particle memory footprint for a given effect. Note that [`Attribute`]s are all built-in; a custom [`Attribute`] cannot be used.
 
 ### Changed
 
-- Effects no longer have a default particle lifetime of 5 seconds. Instead an explicit lifetime must be set with the `ParticleLifetimeModifier`. Failure to set the lifetime will trigger a warning at runtime, and particles will default to a lifetime of zero and instantly die.
+- The `ParticleLifetimeModifier` was renamed to `InitLifetimeModifer` for clarity, and its `lifetime` field is now a `Value<f32>` to allow randomizing per particle.
+- Effects no longer have a default particle lifetime of 5 seconds. Instead an explicit lifetime must be set with the `InitLifetimeModifer`. Failure to set the lifetime will trigger a warning at runtime, and particles will default to a lifetime of zero and instantly die.
 - Effects no longer have a default initial position similar to the `PositionSphereModifier`. Add a `PositionSphereModifier` explicitly to an effect to restore the previous behavior, with a center of `Vec3::ZERO`, a radius of `1.`, a dimension of `ShapeDimension::Volume`, and a speed of `2.`.
 - The acceleration of the `AccelModifier` is now property-based. To dynamically change the acceleration at runtime, assign its value to an effect property with `AccelModifier::via_property()`. Otherwise a constant value built with `AccelModifier::constant()` can be used, and will be optimized in the update shader. See the `spawn.rs` example.
 - All modifiers are now fully reflected (derive both `Reflect` and `FromReflect`) and de/serializable. They're serialized as enums, using the `typetag` crate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unrelease]
+
+### Fixed
+
+- Fix simulate compute jobs running once per view instead of once per frame. (#102)
+
 ## [0.5.1] 2022-12-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Deleted `InitLayout`. Init modifiers are now directly applying themselves to the `InitContext`.
+- Deleted `InitLayout` and `UpdateLayout`. Init and update modifiers are now directly applying themselves to the `InitContext` and `UpdateContext`, respectively. The `RenderLayout` is retained, as render modifiers are not yet transitioned to the new attribute-based API.
 
 ## [0.5.3] 2023-02-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 ron = "0.8"
 bitflags = "1.3"
+typetag = "0.2"
 
 [dependencies.bevy]
 version = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.5.3"
+version = "0.6.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Hanabi GPU particle system for the Bevy game engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ wgpu = "0.14.0"
 naga = "0.10"
 
 futures = "0.3"
-bevy-inspector-egui = "0.14"
+bevy-inspector-egui = "0.15"
 
 [[example]]
 name = "firework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8"
 rand_pcg = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-ron = "0.7"
+ron = "0.8"
 bitflags = "1.3"
 
 [dependencies.bevy]

--- a/README.md
+++ b/README.md
@@ -53,39 +53,39 @@ Create an `EffectAsset` describing a visual effect:
 fn setup(mut effects: ResMut<Assets<EffectAsset>>) {
     // Define a color gradient from red to transparent black
     let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec4::new(1., 0., 0., 1.));
-    gradient.add_key(1.0, Vec4::splat(0.));
+    gradient.add_key(0.0, Vec4::new(1., 0., 0., 1.)); // Red
+    gradient.add_key(1.0, ZERO); // Transparent black
 
     // Create the effect asset
     let effect = effects.add(EffectAsset {
-        name: "MyEffect".to_string(),
-        // Maximum number of particles alive at a time
-        capacity: 32768,
-        // Spawn at a rate of 5 particles per second
-        spawner: Spawner::rate(5.0.into()),
-        ..Default::default()
-    }
-    // On spawn, randomly initialize the position of the particle
-    // to be over the surface of a sphere of radius 2 units, with
-    // a radial initial velocity of 6 units/sec away from the
-    // sphere center.
-    .init(PositionSphereModifier {
-        center: Vec3::ZERO,
-        radius: 2.,
-        dimension: ShapeDimension::Surface,
-        speed: 6.0.into(),
-    })
-    // Also initialize the total lifetime of the particle, that is
-    // the time for which it's simulated and rendered. This modifier
-    // is mandatory, otherwise the particles won't show up.
-    .init(ParticleLifetimeModifier { lifetime: 10. })
-    // Every frame, add a gravity-like acceleration downward
-    .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
-    // Render the particles with a color gradient over their
-    // lifetime. This maps the gradient key 0 to the particle spawn
-    // time, and the gradient key 1 to the particle death (here, 10s).
-    .render(ColorOverLifetimeModifier { gradient })
-);
+            name: "MyEffect".to_string(),
+            // Maximum number of particles alive at a time
+            capacity: 32768,
+            // Spawn at a rate of 5 particles per second
+            spawner: Spawner::rate(5.0.into()),
+            ..Default::default()
+        }
+        // On spawn, randomly initialize the position of the particle
+        // to be over the surface of a sphere of radius 2 units, with
+        // a radial initial velocity of 6 units/sec away from the
+        // sphere center.
+        .init(PositionSphereModifier {
+            center: Vec3::ZERO,
+            radius: 2.,
+            dimension: ShapeDimension::Surface,
+            speed: 6.0.into(),
+        })
+        // Also initialize the total lifetime of the particle, that is
+        // the time for which it's simulated and rendered. This modifier
+        // is mandatory, otherwise the particles won't show up.
+        .init(ParticleLifetimeModifier { lifetime: 10. })
+        // Every frame, add a gravity-like acceleration downward
+        .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
+        // Render the particles with a color gradient over their
+        // lifetime. This maps the gradient key 0 to the particle spawn
+        // time, and the gradient key 1 to the particle death (here, 10s).
+        .render(ColorOverLifetimeModifier { gradient })
+    );
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn setup(mut effects: ResMut<Assets<EffectAsset>>) {
     // Define a color gradient from red to transparent black
     let mut gradient = Gradient::new();
     gradient.add_key(0.0, Vec4::new(1., 0., 0., 1.)); // Red
-    gradient.add_key(1.0, ZERO); // Transparent black
+    gradient.add_key(1.0, Vec4::ZERO); // Transparent black
 
     // Create the effect asset
     let effect = effects.add(EffectAsset {

--- a/README.md
+++ b/README.md
@@ -51,38 +51,41 @@ Create an `EffectAsset` describing a visual effect:
 
 ```rust
 fn setup(mut effects: ResMut<Assets<EffectAsset>>) {
-    // Define a color gradient
+    // Define a color gradient from red to transparent black
     let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec4::new(1., 0., 0., 1.)); // Red
-    gradient.add_key(1.0, Vec4::ZERO); // Transparent black
+    gradient.add_key(0.0, Vec4::new(1., 0., 0., 1.));
+    gradient.add_key(1.0, Vec4::splat(0.));
 
     // Create the effect asset
     let effect = effects.add(EffectAsset {
-            name: "MyEffect".to_string(),
-            // Maximum number of particles alive at a time
-            capacity: 32768,
-            // Spawn at a rate of 5 particles per second
-            spawner: Spawner::rate(5.0.into()),
-            ..Default::default()
-        }
-        // On spawn, randomly initialize the position and velocity
-        // of the particle over a sphere of radius 2 units, with a
-        // radial initial velocity of 6 units/sec away from the
-        // sphere center.
-        .init(PositionSphereModifier {
-            center: Vec3::ZERO,
-            radius: 2.,
-            dimension: ShapeDimension::Surface,
-            speed: 6.0.into(),
-        })
-        // Every frame, add a gravity-like acceleration downward
-        .update(AccelModifier {
-            accel: Vec3::new(0., -3., 0.),
-        })
-        // Render the particles with a color gradient over their
-        // lifetime.
-        .render(ColorOverLifetimeModifier { gradient })
-    );
+        name: "MyEffect".to_string(),
+        // Maximum number of particles alive at a time
+        capacity: 32768,
+        // Spawn at a rate of 5 particles per second
+        spawner: Spawner::rate(5.0.into()),
+        ..Default::default()
+    }
+    // On spawn, randomly initialize the position of the particle
+    // to be over the surface of a sphere of radius 2 units, with
+    // a radial initial velocity of 6 units/sec away from the
+    // sphere center.
+    .init(PositionSphereModifier {
+        center: Vec3::ZERO,
+        radius: 2.,
+        dimension: ShapeDimension::Surface,
+        speed: 6.0.into(),
+    })
+    // Also initialize the total lifetime of the particle, that is
+    // the time for which it's simulated and rendered. This modifier
+    // is mandatory, otherwise the particles won't show up.
+    .init(ParticleLifetimeModifier { lifetime: 10. })
+    // Every frame, add a gravity-like acceleration downward
+    .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
+    // Render the particles with a color gradient over their
+    // lifetime. This maps the gradient key 0 to the particle spawn
+    // time, and the gradient key 1 to the particle death (here, 10s).
+    .render(ColorOverLifetimeModifier { gradient })
+);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn setup(mut effects: ResMut<Assets<EffectAsset>>) {
         // Also initialize the total lifetime of the particle, that is
         // the time for which it's simulated and rendered. This modifier
         // is mandatory, otherwise the particles won't show up.
-        .init(ParticleLifetimeModifier { lifetime: 10. })
+        .init(InitLifetimeModifier { lifetime: 10_f32.into() })
         // Every frame, add a gravity-like acceleration downward
         .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
         // Render the particles with a color gradient over their
@@ -258,6 +258,7 @@ The image on the left has the `BillboardModifier` enabled.
   - [x] Random velocity (partial; linked to emitter type)
   - [ ] Constant color
   - [ ] Random color
+  - [x] Constant/random age and lifetime
 - Update
   - [x] Motion integration
   - [x] Apply forces

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -86,6 +86,7 @@ fn setup(
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(SizeOverLifetimeModifier {
             gradient: Gradient::constant(Vec2::splat(0.02)),
         })

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -104,6 +104,7 @@ fn setup(
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(SizeOverLifetimeModifier {
             gradient: Gradient::constant(Vec2::splat(0.02)),
         })

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -75,7 +75,7 @@ fn setup(
             dimension: ShapeDimension::Volume,
         })
         .render(ParticleTextureModifier {
-            texture: texture_handle,
+            texture: texture_handle.id(),
         })
         .render(BillboardModifier {})
         .render(ColorOverLifetimeModifier { gradient })

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -74,6 +74,7 @@ fn setup(
             speed: Value::Uniform((0.7, 0.5)),
             dimension: ShapeDimension::Volume,
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(ParticleTextureModifier {
             texture: texture_handle,
         })

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -75,7 +75,7 @@ fn setup(
             dimension: ShapeDimension::Volume,
         })
         .render(ParticleTextureModifier {
-            texture: texture_handle.id(),
+            texture: texture_handle.clone(),
         })
         .render(BillboardModifier {})
         .render(ColorOverLifetimeModifier { gradient })

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -75,7 +75,7 @@ fn setup(
             dimension: ShapeDimension::Volume,
         })
         .render(ParticleTextureModifier {
-            texture: texture_handle.clone(),
+            texture: texture_handle,
         })
         .render(BillboardModifier {})
         .render(ColorOverLifetimeModifier { gradient })

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -68,6 +68,7 @@ fn setup(
             speed: Value::Uniform((1.0, 1.5)),
             dimension: ShapeDimension::Surface,
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(ParticleTextureModifier {
             texture: texture_handle.clone(),
         })

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
         .add_plugins(DefaultPlugins.set(LogPlugin {
             level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,firework=trace".to_string(),
+            filter: "bevy_hanabi=trace,firework=trace".to_string(),
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -81,9 +81,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         })
         .init(ParticleLifetimeModifier { lifetime: 1. })
         .update(LinearDragModifier { drag: 5. })
-        .update(AccelModifier {
-            accel: Vec3::new(0., -8., 0.),
-        })
+        .update(AccelModifier::constant(Vec3::new(0., -8., 0.)))
         .render(ColorOverLifetimeModifier {
             gradient: color_gradient1,
         })

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -70,7 +70,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         EffectAsset {
             name: "firework".to_string(),
             capacity: 32768,
-            spawner: Spawner::burst(500.0.into(), 2.0.into()),
+            spawner: Spawner::burst(2500.0.into(), 2.0.into()),
             ..Default::default()
         }
         .init(PositionSphereModifier {
@@ -79,7 +79,15 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
             speed: 70_f32.into(),
             center: Vec3::ZERO,
         })
-        .init(ParticleLifetimeModifier { lifetime: 1. })
+        .init(InitLifetimeModifier {
+            // Give a bit of variation by randomizing the lifetime per particle
+            lifetime: Value::Uniform((0.8, 1.2)),
+        })
+        .init(InitAgeModifier {
+            // Give a bit of variation by randomizing the age per particle. This will control the
+            // starting color and size of particles.
+            age: Value::Uniform((0.0, 0.4)),
+        })
         .update(LinearDragModifier { drag: 5. })
         .update(AccelModifier::constant(Vec3::new(0., -8., 0.)))
         .render(ColorOverLifetimeModifier {

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
         .add_plugins(DefaultPlugins.set(LogPlugin {
             level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=trace,firework=trace".to_string(),
+            filter: "bevy_hanabi=warn,firework=trace".to_string(),
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -123,6 +123,7 @@ fn setup(
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .update(ForceFieldModifier::new(vec![
             ForceFieldSource {
                 position: attractor2_position,

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .insert_resource(options)
         .add_plugins(DefaultPlugins.set(LogPlugin {
             level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=trace,spawn=trace".to_string(),
+            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -73,6 +73,13 @@ fn setup(
             spawner: Spawner::rate(1000.0.into()),
             ..Default::default()
         }
+        .init(PositionSphereModifier {
+            center: Vec3::ZERO,
+            radius: 1.,
+            dimension: ShapeDimension::Volume,
+            speed: 2.0.into(),
+        })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(ParticleTextureModifier {
             texture: texture_handle.clone(),
         })

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .insert_resource(options)
         .add_plugins(DefaultPlugins.set(LogPlugin {
             level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+            filter: "bevy_hanabi=trace,spawn=trace".to_string(),
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -59,9 +59,7 @@ fn make_effect(color: Color) -> EffectAsset {
         speed: 6.0.into(),
     })
     .init(ParticleLifetimeModifier { lifetime: 5. })
-    .update(AccelModifier {
-        accel: Vec3::new(0., -3., 0.),
-    })
+    .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
     .render(ColorOverLifetimeModifier {
         gradient: color_gradient,
     })

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -58,6 +58,7 @@ fn make_effect(color: Color) -> EffectAsset {
         dimension: ShapeDimension::Surface,
         speed: 6.0.into(),
     })
+    .init(ParticleLifetimeModifier { lifetime: 5. })
     .update(AccelModifier {
         accel: Vec3::new(0., -3., 0.),
     })

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -76,9 +76,7 @@ fn setup(
             speed: 2.0.into(),
         })
         .init(ParticleLifetimeModifier { lifetime: 5. })
-        .update(AccelModifier {
-            accel: Vec3::new(0., 5., 0.),
-        })
+        .update(AccelModifier::constant(Vec3::new(0., 5., 0.)))
         .render(ColorOverLifetimeModifier { gradient }),
     );
 

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -75,6 +75,7 @@ fn setup(
             dimension: ShapeDimension::Volume,
             speed: 2.0.into(),
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .update(AccelModifier {
             accel: Vec3::new(0., 5., 0.),
         })

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -173,6 +173,7 @@ fn setup(
             speed: 2.0.into(),
         })
         .init(InitSizeModifier {
+            // At spawn time, assign each particle a random size between 0.3 and 0.7
             size: Value::<f32>::Uniform((0.3, 0.7)).into(),
         })
         .update(AccelModifier {

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -84,6 +84,7 @@ fn setup(
             dimension: ShapeDimension::Surface,
             speed: 6.0.into(),
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .update(AccelModifier {
             accel: Vec3::new(0., -3., 0.),
         })
@@ -117,7 +118,7 @@ fn setup(
         });
 
     let mut gradient2 = Gradient::new();
-    gradient2.add_key(0.0, Vec4::new(0.0, 0.0, 1.0, 1.0));
+    gradient2.add_key(0.0, Vec4::new(0.0, 0.7, 0.0, 1.0));
     gradient2.add_key(1.0, Vec4::splat(0.0));
 
     let effect2 = effects.add(
@@ -127,6 +128,13 @@ fn setup(
             spawner: Spawner::once(1000.0.into(), true),
             ..Default::default()
         }
+        .init(PositionSphereModifier {
+            center: Vec3::ZERO,
+            radius: 5.,
+            dimension: ShapeDimension::Volume,
+            speed: 2.0.into(),
+        })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(ColorOverLifetimeModifier {
             gradient: gradient2,
         }),
@@ -172,6 +180,7 @@ fn setup(
             dimension: ShapeDimension::Volume,
             speed: 2.0.into(),
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .init(InitSizeModifier {
             // At spawn time, assign each particle a random size between 0.3 and 0.7
             size: Value::<f32>::Uniform((0.3, 0.7)).into(),

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -78,6 +78,7 @@ fn setup(
             spawner: Spawner::rate(5.0.into()),
             ..Default::default()
         }
+        .with_property("my_accel", graph::Value::Float3(Vec3::new(0., -3., 0.)))
         .init(PositionSphereModifier {
             center: Vec3::ZERO,
             radius: 2.,
@@ -85,9 +86,7 @@ fn setup(
             speed: 6.0.into(),
         })
         .init(ParticleLifetimeModifier { lifetime: 5. })
-        .update(AccelModifier {
-            accel: Vec3::new(0., -3., 0.),
-        })
+        .update(AccelModifier::via_property("my_accel"))
         .render(ColorOverLifetimeModifier {
             gradient: color_gradient1,
         })
@@ -185,9 +184,7 @@ fn setup(
             // At spawn time, assign each particle a random size between 0.3 and 0.7
             size: Value::<f32>::Uniform((0.3, 0.7)).into(),
         })
-        .update(AccelModifier {
-            accel: Vec3::new(0., 5., 0.),
-        })
+        .update(AccelModifier::constant(Vec3::new(0., 5., 0.)))
         .render(ColorOverLifetimeModifier {
             gradient: gradient3,
         }),

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -172,6 +172,9 @@ fn setup(
             dimension: ShapeDimension::Volume,
             speed: 2.0.into(),
         })
+        .init(InitSizeModifier {
+            size: Value::<f32>::Uniform((0.3, 0.7)).into(),
+        })
         .update(AccelModifier {
             accel: Vec3::new(0., 5., 0.),
         })

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -109,6 +109,7 @@ fn setup(
             dimension: ShapeDimension::Surface,
             ..Default::default()
         })
+        .init(ParticleLifetimeModifier { lifetime: 5. })
         .render(SizeOverLifetimeModifier {
             gradient: Gradient::constant(Vec2::splat(0.05)),
         })

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -13,5 +13,6 @@ cargo r --example instancing --no-default-features --features="bevy/bevy_winit b
 REM 3D + PNG
 cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
 cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
+cargo r --example billboard --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d"
 REM 2D
 cargo r --example 2d --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+unstable_features = true
+wrap_comments=true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-unstable_features = true
-wrap_comments=true

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,7 +1,7 @@
 use bevy::{
     asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
     math::{Vec2, Vec3, Vec4},
-    reflect::{Reflect, TypeUuid},
+    reflect::{FromReflect, Reflect, TypeUuid},
     render::texture::Image,
     utils::{BoxedFuture, HashSet},
 };
@@ -62,7 +62,7 @@ pub struct RenderLayout {
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
-#[derive(Debug, Default, Clone, TypeUuid, Reflect, Serialize, Deserialize /* FromReflect, */)]
+#[derive(Debug, Default, Clone, TypeUuid, Reflect, Serialize, Deserialize, FromReflect)]
 #[uuid = "249aefa4-9b8e-48d3-b167-3adf6c081c34"]
 pub struct EffectAsset {
     /// Display name of the effect.

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -80,7 +80,15 @@ pub struct EffectAsset {
     // TODO - Can't manage to implement FromReflect for BoxedModifier in a nice way yet
     pub modifiers: Vec<BoxedModifier>,
     /// Properties of the effect.
-    pub(crate) properties: Vec<Property>,
+    ///
+    /// Properties must have a unique name. Manually adding two or more
+    /// properties with the same name will result in an invalid asset and
+    /// undefined behavior are runtime. Prefer using the [`with_property()`] and
+    /// [`add_property()`] methods for safety.
+    ///
+    /// [`with_property()`]: crate::EffectAsset::with_property
+    /// [`add_property()`]: crate::EffectAsset::add_property
+    pub properties: Vec<Property>,
 }
 
 impl EffectAsset {
@@ -106,7 +114,7 @@ impl EffectAsset {
     }
 
     /// Get the list of existing properties.
-    pub(crate) fn properties(&self) -> &[Property] {
+    pub fn properties(&self) -> &[Property] {
         &self.properties
     }
 
@@ -179,7 +187,7 @@ impl EffectAsset {
         }
 
         // For legacy compatibility reasons, and because both the motion integration and
-        // the particle aging are currently non-optional, add some default attributes.
+        // the particle aging are currently mandatory, add some default attributes.
         set.insert(Attribute::POSITION);
         set.insert(Attribute::AGE);
         set.insert(Attribute::VELOCITY);

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -284,7 +284,8 @@ mod tests {
         //.init(PositionCircleModifier::default())
         .init(PositionSphereModifier::default())
         //.init(PositionCone3dModifier::default())
-        .init(ParticleLifetimeModifier::default())
+        .init(InitAgeModifier::default())
+        .init(InitLifetimeModifier::default())
         //.update(AccelModifier::default())
         .update(LinearDragModifier::default())
         .update(ForceFieldModifier::default())
@@ -297,7 +298,8 @@ mod tests {
 
         let mut init_context = InitContext::default();
         PositionSphereModifier::default().apply(&mut init_context);
-        ParticleLifetimeModifier::default().apply(&mut init_context);
+        InitAgeModifier::default().apply(&mut init_context);
+        InitLifetimeModifier::default().apply(&mut init_context);
         //assert_eq!(effect., init_context.init_code);
 
         let mut update_context = UpdateContext::default();

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -235,6 +235,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn property() {
+        let mut effect = EffectAsset {
+            name: "Effect".into(),
+            capacity: 4096,
+            spawner: Spawner::rate(30.0.into()),
+            ..Default::default()
+        }
+        .with_property("my_prop", 345_u32.into());
+
+        effect.add_property(
+            "other_prop",
+            graph::Value::Float3(Vec3::new(3., -7.5, 42.42)),
+        );
+
+        assert!(effect
+            .properties()
+            .iter()
+            .find(|p| p.name() == "my_prop")
+            .is_some());
+        assert!(effect
+            .properties()
+            .iter()
+            .find(|p| p.name() == "other_prop")
+            .is_some());
+        assert!(effect
+            .properties()
+            .iter()
+            .find(|p| p.name() == "do_not_exist")
+            .is_none());
+
+        let layout = effect.property_layout();
+        assert_eq!(layout.size(), 16);
+        assert_eq!(layout.align(), 16);
+        assert_eq!(layout.offset("my_prop"), Some(12));
+        assert_eq!(layout.offset("other_prop"), Some(0));
+        assert_eq!(layout.offset("unknown"), None);
+    }
+
+    #[test]
     fn test_apply_modifiers() {
         let effect = EffectAsset {
             name: "Effect".into(),
@@ -262,7 +301,7 @@ mod tests {
         //assert_eq!(effect., init_context.init_code);
 
         let mut update_context = UpdateContext::default();
-        //AccelModifier::default().apply(&mut update_context);
+        AccelModifier::constant(Vec3::ONE).apply(&mut update_context);
         LinearDragModifier::default().apply(&mut update_context);
         ForceFieldModifier::default().apply(&mut update_context);
         //assert_eq!(effect.update_layout, update_layout);

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -62,7 +62,7 @@ pub struct RenderLayout {
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
-#[derive(Default, Clone, TypeUuid, Reflect, Serialize, Deserialize, FromReflect)]
+#[derive(Default, Clone, TypeUuid, Reflect, FromReflect, Serialize, Deserialize)]
 #[uuid = "249aefa4-9b8e-48d3-b167-3adf6c081c34"]
 pub struct EffectAsset {
     /// Display name of the effect.
@@ -107,7 +107,8 @@ pub struct EffectAsset {
     /// Particle simulation space.
     pub simulation_space: SimulationSpace,
     /// Modifiers defining the effect.
-    #[reflect(ignore)] // TODO
+    #[reflect(ignore)]
+    // TODO - Can't manage to implement FromReflect for BoxedModifier in a nice way yet
     pub modifiers: Vec<BoxedModifier>,
     /// Properties of the effect.
     pub properties: Vec<Property>,

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,7 +1,8 @@
 use bevy::{
-    asset::{AssetLoader, HandleId, LoadContext, LoadedAsset},
+    asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
     math::{Vec2, Vec3, Vec4},
     reflect::{Reflect, TypeUuid},
+    render::texture::Image,
     utils::{BoxedFuture, HashSet},
 };
 use serde::{Deserialize, Serialize};
@@ -53,7 +54,7 @@ pub struct RenderLayout {
     /// If set, defines the PARTICLE_TEXTURE shader key and extend the vertex
     /// format to contain UV coordinates. Also make available the image as a
     /// 2D texture and sampler in the render shaders.
-    pub particle_texture: Option<HandleId>, // Handle<Image>
+    pub particle_texture: Option<Handle<Image>>,
     /// Optional color gradient used to vary the particle color over its
     /// lifetime.
     pub lifetime_color_gradient: Option<Gradient<Vec4>>,

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -111,11 +111,11 @@ pub struct EffectAsset {
     // TODO - Can't manage to implement FromReflect for BoxedModifier in a nice way yet
     pub modifiers: Vec<BoxedModifier>,
     /// Properties of the effect.
-    pub properties: Vec<Property>,
+    pub(crate) properties: Vec<Property>,
 }
 
 impl EffectAsset {
-    /// Add a new [`Property`] to the asset.
+    /// Add a new property to the asset.
     ///
     /// # Panics
     ///
@@ -125,7 +125,7 @@ impl EffectAsset {
         self
     }
 
-    /// Add a new [`Property`] to the asset.
+    /// Add a new property to the asset.
     ///
     /// # Panics
     ///
@@ -137,7 +137,7 @@ impl EffectAsset {
     }
 
     /// Get the list of existing properties.
-    pub fn properties(&self) -> &[Property] {
+    pub(crate) fn properties(&self) -> &[Property] {
         &self.properties
     }
 
@@ -145,7 +145,7 @@ impl EffectAsset {
     ///
     /// # Panics
     ///
-    /// Panics if the modifier references a [`Property`] which doesn't exist.
+    /// Panics if the modifier references a property which doesn't exist.
     /// You should declare an effect property first with [`with_property()`]
     /// or [`add_property()`], before adding any modifier referencing it.
     ///
@@ -164,7 +164,7 @@ impl EffectAsset {
     ///
     /// # Panics
     ///
-    /// Panics if the modifier references a [`Property`] which doesn't exist.
+    /// Panics if the modifier references a property which doesn't exist.
     /// You should declare an effect property first with [`with_property()`]
     /// or [`add_property()`], before adding any modifier referencing it.
     ///
@@ -183,7 +183,7 @@ impl EffectAsset {
     ///
     /// # Panics
     ///
-    /// Panics if the modifier references a [`Property`] which doesn't exist.
+    /// Panics if the modifier references a property which doesn't exist.
     /// You should declare an effect property first with [`with_property()`]
     /// or [`add_property()`], before adding any modifier referencing it.
     ///

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -275,17 +275,17 @@ mod tests {
         assert_eq!(effect.render_layout, render_layout);
     }
 
-    // #[test]
-    // fn test_serde_ron() {
-    //     let effect = EffectAsset {
-    //         name: "Effect".into(),
-    //         capacity: 4096,
-    //         spawner: Spawner::rate(30.0.into()),
-    //         ..Default::default()
-    //     };
+    #[test]
+    fn test_serde_ron() {
+        let effect = EffectAsset {
+            name: "Effect".into(),
+            capacity: 4096,
+            spawner: Spawner::rate(30.0.into()),
+            ..Default::default()
+        };
 
-    //     let s = ron::to_string(&effect).unwrap();
-    //     let effect_serde: EffectAsset = ron::from_str(&s).unwrap();
-    //     assert_eq!(effect, effect_serde);
-    // }
+        let s = ron::to_string(&effect).unwrap();
+        let _effect_serde: EffectAsset = ron::from_str(&s).unwrap();
+        //assert_eq!(effect, effect_serde);
+    }
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -169,6 +169,13 @@ impl EffectAsset {
             }
         }
 
+        // For legacy compatibility reasons, and because both the motion integration and
+        // the particle aging are currently non-optional, add some default attributes.
+        set.insert(Attribute::POSITION);
+        set.insert(Attribute::AGE);
+        set.insert(Attribute::VELOCITY);
+        set.insert(Attribute::LIFETIME);
+
         // Build the layout
         let mut layout = ParticleLayout::new();
         for attr in set {

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,6 +1,6 @@
 use bevy::{
     asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
-    math::{Vec2, Vec3, Vec4},
+    math::{Vec2, Vec4},
     reflect::{FromReflect, Reflect, TypeUuid},
     render::texture::Image,
     utils::{BoxedFuture, HashSet},
@@ -9,33 +9,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     graph::Value,
-    modifier::{
-        init::InitModifier,
-        render::RenderModifier,
-        update::{ForceFieldSource, UpdateModifier},
-    },
+    modifier::{init::InitModifier, render::RenderModifier, update::UpdateModifier},
     Attribute, BoxedModifier, Gradient, ParticleLayout, Property, PropertyLayout, SimulationSpace,
     Spawner,
 };
-
-/// Struct containing snippets of WSGL code that can be used
-/// to update the particles every frame on the GPU.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct UpdateLayout {
-    /// Constant acceleration to apply to all particles.
-    /// Generally used to simulate some kind of gravity.
-    pub accel: Vec3,
-    /// Linear drag coefficient.
-    ///
-    /// Amount of (linear) drag force applied to the particles each frame, as a
-    /// fraction of the particle's acceleration. Higher values slow down the
-    /// particle in a shorter amount of time. Defaults to zero (disabled; no
-    /// drag force).
-    pub drag_coefficient: f32,
-    /// Array of force field components with a maximum number of components
-    /// determined by [`ForceFieldSource::MAX_SOURCES`].
-    pub force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
-}
 
 /// Struct containing data and snippets of WSGL code that can be used
 /// to render the particles every frame on the GPU.
@@ -80,14 +57,6 @@ pub struct EffectAsset {
     pub capacity: u32,
     /// Spawner.
     pub spawner: Spawner,
-    /// Layout describing the particle update code.
-    ///
-    /// The update layout determines how all alive particles are updated each
-    /// frame. Compatible layouts increase the chance of batching together
-    /// effects.
-    #[serde(skip)] // TODO
-    #[reflect(ignore)] // TODO?
-    pub update_layout: UpdateLayout,
     /// Layout describing the particle rendering code.
     ///
     /// The render layout determines how alive particles are rendered.

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,6 +1,5 @@
 use bevy::{
     asset::{AssetLoader, HandleId, LoadContext, LoadedAsset},
-    ecs::{reflect::ReflectResource, system::Resource},
     math::{Vec2, Vec3, Vec4},
     reflect::{Reflect, TypeUuid},
     utils::{BoxedFuture, HashSet},
@@ -13,7 +12,7 @@ use crate::{
         render::RenderModifier,
         update::{ForceFieldSource, UpdateModifier},
     },
-    Gradient, Modifiers, ParticleLayout, Spawner,
+    Attribute, Gradient, Modifiers, ParticleLayout, Spawner,
 };
 
 /// Struct containing snippets of WSGL code that can be used
@@ -24,6 +23,8 @@ pub struct InitLayout {
     pub position_code: String,
     /// WSGL code to set the initial lifetime of the particle.
     pub lifetime_code: String,
+    /// Optional per-particle size code.
+    pub size_code: Option<String>,
 }
 
 /// Struct containing snippets of WSGL code that can be used
@@ -70,14 +71,13 @@ pub struct RenderLayout {
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Resource, Reflect, TypeUuid)]
-#[reflect(Resource)]
+#[derive(Debug, Default, Clone, PartialEq, TypeUuid, Reflect, Serialize, Deserialize)]
 #[uuid = "249aefa4-9b8e-48d3-b167-3adf6c081c34"]
 pub struct EffectAsset {
     /// Display name of the effect.
     ///
     /// This has no internal use, and is mostly for the user to identify an
-    /// effect or for display is some tool UI.
+    /// effect or for display in some tool UI.
     pub name: String,
     /// Maximum number of concurrent particles.
     ///

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -503,9 +503,12 @@ impl ParticleLayout {
     /// assert_eq!(layout.size(), 12);
     /// ```
     pub fn size(&self) -> u32 {
-        assert!(!self.layout.is_empty());
-        let last_attr = self.layout.last().unwrap();
-        last_attr.offset + last_attr.attribute.size() as u32
+        if self.layout.is_empty() {
+            0
+        } else {
+            let last_attr = self.layout.last().unwrap();
+            last_attr.offset + last_attr.attribute.size() as u32
+        }
     }
 
     /// Get the alignment of the layout in bytes.

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -544,6 +544,20 @@ impl ParticleLayout {
         &self.layout
     }
 
+    /// Check if the layout contains the specified [`Attribute`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let layout = AttributeLayout::new();
+    /// let has_size = layout.contains(Attribute::SIZE);
+    /// ```
+    pub fn contains(&self, attribute: &'static Attribute) -> bool {
+        self.layout
+            .iter()
+            .any(|&entry| entry.attribute.name() == attribute.name())
+    }
+
     /// Generate the WGSL attribute code corresponding to the layout.
     pub fn generate_code(&self) -> String {
         //assert!(self.layout.is_sorted_by_key(|entry| entry.offset));

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -562,8 +562,12 @@ impl ParticleLayout {
     /// # Example
     ///
     /// ```
-    /// # let layout = AttributeLayout::new();
+    /// # use bevy_hanabi::*;
+    /// let layout = ParticleLayout::new()
+    ///     .add(Attribute::SIZE)
+    ///     .build();
     /// let has_size = layout.contains(Attribute::SIZE);
+    /// assert!(has_size);
     /// ```
     pub fn contains(&self, attribute: &'static Attribute) -> bool {
         self.layout

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,0 +1,648 @@
+use std::{borrow::Cow, num::NonZeroU64};
+
+use crate::{next_multiple_of, ToWgslString};
+
+/// Type of an [`Attribute`]'s value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ValueType {
+    /// Single `f32` value.
+    Float,
+    /// Vector of two `f32` values (`vec2<f32>`). Equivalent to `Vec2` on the
+    /// CPU side.
+    Float2,
+    /// Vector of three `f32` values (`vec3<f32>`). Equivalent to `Vec3` on the
+    /// CPU side.
+    Float3,
+    /// Vector of four `f32` values (`vec4<f32>`). Equivalent to `Vec4` on the
+    /// CPU side.
+    Float4,
+    /// Single `u32` value.
+    Uint,
+}
+
+impl ValueType {
+    /// Size of a value of this type, in bytes.
+    pub fn size(&self) -> usize {
+        match self {
+            ValueType::Float => 4,
+            ValueType::Float2 => 8,
+            ValueType::Float3 => 12,
+            ValueType::Float4 => 16,
+            ValueType::Uint => 4,
+        }
+    }
+
+    /// Alignment of a value of this type, in bytes.
+    ///
+    /// This corresponds to the alignment of a variable of that type when part
+    /// of a struct in WGSL.
+    pub fn align(&self) -> usize {
+        match self {
+            ValueType::Float => 4,
+            ValueType::Float2 => 8,
+            ValueType::Float3 => 16,
+            ValueType::Float4 => 16,
+            ValueType::Uint => 4,
+        }
+    }
+}
+
+impl ToWgslString for ValueType {
+    fn to_wgsl_string(&self) -> String {
+        match self {
+            ValueType::Float => "f32",
+            ValueType::Float2 => "vec2<f32>",
+            ValueType::Float3 => "vec3<f32>",
+            ValueType::Float4 => "vec4<f32>",
+            ValueType::Uint => "u32",
+        }
+        .to_string()
+    }
+}
+
+/// An attribute of a particle simulated for an effect.
+///
+/// Effects are composed of many simulated particles. Each particle is in turn
+/// composed of a set of attributes, which are used to simulate and render it.
+/// Common attributes include the particle's position, its age, or its color.
+/// See [`Attribute::ALL`] for a list of supported attributes. Custom attributes
+/// are not supported.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Attribute {
+    name: Cow<'static, str>,
+    value_type: ValueType,
+}
+
+impl Attribute {
+    /// The particle position in [simulation space].
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float3`] representing the XYZ coordinates of the position.
+    ///
+    /// [simulation space]: crate::SimulationSpace
+    pub const POSITION: &'static Attribute =
+        &Attribute::new(Cow::Borrowed("position"), ValueType::Float3);
+
+    /// The particle velocity in [simulation space].
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float3`] representing the XYZ coordinates of the velocity.
+    ///
+    /// [simulation space]: crate::SimulationSpace
+    pub const VELOCITY: &'static Attribute =
+        &Attribute::new(Cow::Borrowed("velocity"), ValueType::Float3);
+
+    /// The age of the particle.
+    ///
+    /// When the age of the particle exceeds its lifetime (either a per-effect
+    /// constant value, or a per-particle value stored in the
+    /// [`Attribute::LIFETIME`] attribute), the particle dies and is not
+    /// simulated nor rendered anymore.
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float`]
+    pub const AGE: &'static Attribute = &Attribute::new(Cow::Borrowed("age"), ValueType::Float);
+
+    /// The lifetime of the particle.
+    ///
+    /// This attribute stores a per-particle lifetime, which compared to the
+    /// particle's age allows determining if the particle needs to be
+    /// simulated and rendered. This requires the [`Attribute::AGE`]
+    /// attribute to be used too.
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float`]
+    pub const LIFETIME: &'static Attribute =
+        &Attribute::new(Cow::Borrowed("lifetime"), ValueType::Float);
+
+    /// The particle's base color.
+    ///
+    /// This attribute stores a per-particle color, which can be used for
+    /// various purposes, generally as the base color for rendering the
+    /// particle.
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Uint`] representing the RGBA components of the color
+    /// encoded as 0xAABBGGRR, with a single byte per component.
+    pub const COLOR: &'static Attribute = &Attribute::new(Cow::Borrowed("color"), ValueType::Uint);
+
+    /// The particle's base color (HDR).
+    ///
+    /// This attribute stores a per-particle HDR color, which can be used for
+    /// various purposes, generally as the base color for rendering the
+    /// particle.
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float4`] representing the RGBA components of the color.
+    /// Values are not clamped, and can be outside the \[0:1\] range to
+    /// represent HDR values.
+    pub const HDR_COLOR: &'static Attribute =
+        &Attribute::new(Cow::Borrowed("hdr_color"), ValueType::Float4);
+
+    /// The particle's transparency (alpha).
+    ///
+    /// Type: [`ValueType::Float`]
+    pub const ALPHA: &'static Attribute = &Attribute::new(Cow::Borrowed("alpha"), ValueType::Float);
+
+    /// The particle's uniform size.
+    ///
+    /// The particle is uniformly scaled by this size.
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float`]
+    pub const SIZE: &'static Attribute = &Attribute::new(Cow::Borrowed("size"), ValueType::Float);
+
+    /// The particle's 2D size, for quad rendering.
+    ///
+    /// The particle, when drawn as a quad, is scaled along its local X and Y
+    /// axes by these values.
+    ///
+    /// # Type
+    ///
+    /// [`ValueType::Float2`] representing the XY sizes of the particle.
+    pub const SIZE2: &'static Attribute =
+        &Attribute::new(Cow::Borrowed("size2"), ValueType::Float2);
+
+    /// Collection of all the existing particle attributes.
+    pub const ALL: [&'static Attribute; 9] = [
+        Attribute::POSITION,
+        Attribute::VELOCITY,
+        Attribute::AGE,
+        Attribute::LIFETIME,
+        Attribute::COLOR,
+        Attribute::HDR_COLOR,
+        Attribute::ALPHA,
+        Attribute::SIZE,
+        Attribute::SIZE2,
+    ];
+
+    /// Retrieve an attribute by its name.
+    ///
+    /// See [`Attribute::ALL`] for the list of attributes, and the
+    /// [`Attribute::name()`] method of each attribute for their name.
+    pub fn from_name<'a>(name: &'a str) -> Option<&'static Attribute> {
+        Attribute::ALL
+            .iter()
+            .find(|&&attr| attr.name() == name)
+            .copied()
+    }
+
+    /// Create a new attribute.
+    const fn new(name: Cow<'static, str>, value_type: ValueType) -> Self {
+        Self { name, value_type }
+    }
+
+    /// The attribute's name.
+    ///
+    /// The name of an attribute is unique, and corresponds to the name of the
+    /// variable in the generated WGSL code.
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    /// The attribute's type.
+    pub fn value_type(&self) -> ValueType {
+        self.value_type
+    }
+
+    /// Size of this attribute, in bytes.
+    ///
+    /// This is a shortcut for [`ValueType::size()`].
+    pub fn size(&self) -> usize {
+        self.value_type.size()
+    }
+
+    /// Alignment of this attribute, in bytes.
+    ///
+    /// This is a shortcut for [`ValueType::align()`].
+    pub fn align(&self) -> usize {
+        self.value_type.align()
+    }
+}
+
+/// Layout for a single [`Attribute`] inside a [`ParticleLayout`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct AttributeLayout {
+    pub attribute: &'static Attribute,
+    pub offset: u32,
+}
+
+impl std::fmt::Debug for AttributeLayout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // "(+offset) name: type"
+        f.write_fmt(format_args!(
+            "(+{}) {}: {}",
+            self.offset,
+            self.attribute.name(),
+            self.attribute.value_type().to_wgsl_string(),
+        ))
+    }
+}
+
+/// Builder helper to create a new [`ParticleLayout`].
+///
+/// Use [`ParticleLayout::new()`] to create a new empty builder.
+#[derive(Debug, Default, Clone)]
+pub struct ParticleLayoutBuilder {
+    layout: Vec<AttributeLayout>,
+}
+
+impl ParticleLayoutBuilder {
+    /// Add a new attribute to the layout builder.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// let mut builder = ParticleLayout::new();
+    /// builder.add(Attribute::POSITION);
+    /// ```
+    pub fn add(mut self, attribute: &'static Attribute) -> Self {
+        self.layout.push(AttributeLayout {
+            attribute,
+            offset: 0, // fixed up by build()
+        });
+        self
+    }
+
+    /// Finalize the builder pattern and build the layout from the existing
+    /// attributes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// let layout = ParticleLayout::new()
+    ///     .add(Attribute::POSITION)
+    ///     .build();
+    /// ```
+    pub fn build(mut self) -> ParticleLayout {
+        // Remove duplicates
+        self.layout.sort_unstable_by_key(|la| la.attribute.name());
+        self.layout.dedup_by_key(|la| la.attribute.name());
+
+        // Sort by size
+        self.layout.sort_unstable_by_key(|la| la.attribute.size());
+
+        let mut layout = vec![];
+        let mut offset = 0;
+
+        // Enqueue all Float4, which are already aligned
+        let index4 = self
+            .layout
+            .partition_point(|attr| attr.attribute.size() < 16);
+        for i in index4..self.layout.len() {
+            let mut attr = self.layout[i];
+            attr.offset = offset;
+            offset += 16;
+            layout.push(attr);
+        }
+
+        // Enqueue paired { Float3 + Float1 }
+        let index2 = self
+            .layout
+            .partition_point(|attr| attr.attribute.size() < 8);
+        let num1 = index2;
+        let index3 = self
+            .layout
+            .partition_point(|attr| attr.attribute.size() < 12);
+        let num2 = (index2..index3).len();
+        let num3 = (index3..index4).len();
+        let num_pairs = num1.min(num3);
+        for i in 0..num_pairs {
+            // Float3
+            let mut attr = self.layout[index3 + i];
+            attr.offset = offset;
+            offset += 12;
+            layout.push(attr);
+
+            // Float
+            let mut attr = self.layout[i];
+            attr.offset = offset;
+            offset += 4;
+            layout.push(attr);
+        }
+        let index1 = num_pairs;
+        let index3 = index3 + num_pairs;
+        let num1 = num1 - num_pairs;
+        let num3 = num3 - num_pairs;
+
+        // Enqueue paired { Float2 + Float2 }
+        for i in 0..(num2 / 2) {
+            for j in 0..2 {
+                let mut attr = self.layout[index2 + i * 2 + j];
+                attr.offset = offset;
+                offset += 8;
+                layout.push(attr);
+            }
+        }
+        let index2 = index2 + (num2 / 2) * 2;
+        let num2 = num2 % 2;
+
+        // Enqueue { Float3, Float2 } or { Float2, Float1 }
+        if num3 > num1 {
+            // Float1 is done, some Float3 left, and at most one Float2
+            debug_assert_eq!(num1, 0);
+
+            // Try 3/3/2, fallback to 3/2
+            let num3head = if num2 > 0 {
+                debug_assert_eq!(num2, 1);
+                let num3head = num3.min(2);
+                for i in 0..num3head {
+                    let mut attr = self.layout[index3 + i];
+                    attr.offset = offset;
+                    offset += 12;
+                    layout.push(attr);
+                }
+                let mut attr = self.layout[index2];
+                attr.offset = offset;
+                offset += 8;
+                layout.push(attr);
+                num3head
+            } else {
+                0
+            };
+
+            // End with remaining Float3
+            for i in num3head..num3 {
+                let mut attr = self.layout[index3 + i];
+                attr.offset = offset;
+                offset += 12;
+                layout.push(attr);
+            }
+        } else {
+            // Float3 is done, some Float1 left, and at most one Float2
+            debug_assert_eq!(num3, 0);
+
+            // Emit the single Float2 now if any
+            if num2 > 0 {
+                debug_assert_eq!(num2, 1);
+                let mut attr = self.layout[index2];
+                attr.offset = offset;
+                offset += 8;
+                layout.push(attr);
+            }
+
+            // End with remaining Float1
+            for i in 0..num1 {
+                let mut attr = self.layout[index1 + i];
+                attr.offset = offset;
+                offset += 4;
+                layout.push(attr);
+            }
+        }
+
+        ParticleLayout { layout }
+    }
+}
+
+impl From<&ParticleLayout> for ParticleLayoutBuilder {
+    fn from(layout: &ParticleLayout) -> Self {
+        Self {
+            layout: layout.layout.clone(),
+        }
+    }
+}
+
+/// Particle layout of an effect.
+///
+/// The particle layout describes the set of attributes used by the particles of
+/// an effect, and the relative positioning of those attributes inside the
+/// particle GPU buffer.
+///
+/// Effects with a compatible particle layout can be simulated or rendered
+/// together in a single call, therefore it is recommended to minimize the
+/// layout variations across effects and attempt to reuse the same layout for
+/// multiple effects, which can be benefical for performance.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ParticleLayout {
+    layout: Vec<AttributeLayout>,
+}
+
+impl std::fmt::Debug for ParticleLayout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Output a compact list of all layout entries
+        f.debug_list().entries(self.layout.iter()).finish()
+    }
+}
+
+impl Default for ParticleLayout {
+    fn default() -> Self {
+        // Default layout: { position, age, velocity, lifetime }
+        ParticleLayout::new()
+            .add(Attribute::POSITION)
+            .add(Attribute::AGE)
+            .add(Attribute::VELOCITY)
+            .add(Attribute::LIFETIME)
+            .build()
+    }
+}
+
+impl ParticleLayout {
+    /// Create an empty finalized layout.
+    ///
+    /// The layout is immutable. This is mostly used as a placeholder while a
+    /// valid layout is not available yet. To create a new non-finalized layout
+    /// which can be mutated, use [`ParticleLayout::new()`] instead.
+    pub fn empty() -> ParticleLayout {
+        Self { layout: vec![] }
+    }
+
+    /// Create a new empty layout.
+    ///
+    /// This returns a builder for the particle layout. Use
+    /// [`ParticleLayoutBuilder::build()`] to finalize the builder and create
+    /// the actual (immutable) [`ParticleLayout`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// let layout = ParticleLayout::new()
+    ///     .add(Attribute::POSITION)
+    ///     .add(Attribute::AGE)
+    ///     .add(Attribute::LIFETIME)
+    ///     .build();
+    /// ```
+    pub fn new() -> ParticleLayoutBuilder {
+        ParticleLayoutBuilder::default()
+    }
+
+    /// Build a new particle layout from the current one merged with a new set
+    /// of attributes.
+    pub fn merged_with(
+        &self,
+        //attributes: impl IntoIterator<Item = &'static Attribute>,
+        attributes: &[&'static Attribute],
+    ) -> ParticleLayout {
+        let mut builder = ParticleLayoutBuilder::from(self);
+        //for attr in attributes.into_iter() {
+        for attr in attributes {
+            builder = builder.add(*attr);
+        }
+        builder.build()
+    }
+
+    /// Get the size of the layout in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// let layout = ParticleLayout::new()
+    ///     .add(Attribute::POSITION) // vec3<f32>
+    ///     .build();
+    /// assert_eq!(layout.size(), 12);
+    /// ```
+    pub fn size(&self) -> u32 {
+        assert!(!self.layout.is_empty());
+        let last_attr = self.layout.last().unwrap();
+        last_attr.offset + last_attr.attribute.size() as u32
+    }
+
+    /// Get the alignment of the layout in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// let layout = ParticleLayout::new()
+    ///     .add(Attribute::POSITION) // vec3<f32>
+    ///     .build();
+    /// assert_eq!(layout.align(), 16);
+    /// ```
+    pub fn align(&self) -> usize {
+        self.layout
+            .iter()
+            .map(|attr| attr.attribute.value_type().align())
+            .max()
+            .unwrap()
+    }
+
+    /// Minimum binding size in bytes.
+    ///
+    /// This corresponds to the stride of the attribute struct in WGSL when
+    /// contained inside an array.
+    pub fn min_binding_size(&self) -> NonZeroU64 {
+        let size = self.size() as usize;
+        let align = self.align();
+        NonZeroU64::new(next_multiple_of(size, align) as u64).unwrap()
+    }
+
+    /// Generate the WGSL attribute code corresponding to the layout.
+    pub fn generate_code(&self) -> String {
+        //assert!(self.layout.is_sorted_by_key(|entry| entry.offset));
+        self.layout
+            .iter()
+            .map(|entry| {
+                format!(
+                    "    {}: {},",
+                    entry.attribute.name(),
+                    entry.attribute.value_type().to_wgsl_string()
+                )
+            })
+            .fold(String::new(), |mut a, b| {
+                a.reserve(b.len() + 1);
+                a.push_str(&b);
+                a.push('\n');
+                a
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_name() {
+        for attr in Attribute::ALL {
+            assert_eq!(Attribute::from_name(attr.name()), Some(attr));
+        }
+    }
+
+    #[test]
+    fn test_layout_build() {
+        // empty
+        let layout = ParticleLayout::new().build();
+        assert_eq!(layout.layout.len(), 0);
+        assert_eq!(layout.generate_code(), String::new());
+
+        // single
+        for attr in Attribute::ALL {
+            let layout = ParticleLayout::new().add(attr).build();
+            assert_eq!(layout.layout.len(), 1);
+            let attr0 = &layout.layout[0];
+            assert_eq!(attr0.offset, 0);
+            assert_eq!(
+                layout.generate_code(),
+                format!(
+                    "    {}: {},\n",
+                    attr0.attribute.name(),
+                    attr0.attribute.value_type.to_wgsl_string()
+                )
+            );
+        }
+
+        let f1 = Attribute::SIZE;
+        let f2 = Attribute::SIZE2;
+        let f3 = Attribute::POSITION;
+        let f4 = Attribute::HDR_COLOR;
+
+        // homogenous
+        for attr in [f1, f2, f3, f4] {
+            let mut layout = ParticleLayout::new();
+            for _ in 0..7 {
+                layout = layout.add(attr);
+            }
+            let layout = layout.build();
+            assert_eq!(layout.layout.len(), 7);
+            for i in 0..7 {
+                let attr_i = &layout.layout[i];
+                assert_eq!(attr_i.offset as usize, i * attr.size());
+            }
+        }
+
+        // [3 1 3 2]
+        {
+            let mut layout = ParticleLayout::new();
+            for attr in &[f1, f3, f2, f3] {
+                layout = layout.add(attr);
+            }
+            let layout = layout.build();
+            assert_eq!(layout.layout.len(), 4);
+            let mut i = 0;
+            for (off, a) in &[(0, f3), (12, f1), (16, f3), (28, f2)] {
+                let attr_i = layout.layout[i];
+                assert_eq!(attr_i.offset, *off as u32);
+                assert_eq!(&attr_i.attribute, a);
+                i += 1;
+            }
+        }
+
+        // [4 3 1 2 2 3]
+        {
+            let mut layout = ParticleLayout::new();
+            for attr in &[f4, f1, f3, f2, f2, f3] {
+                layout = layout.add(attr);
+            }
+            let layout = layout.build();
+            assert_eq!(layout.layout.len(), 6);
+            let mut i = 0;
+            for (off, a) in &[(0, f4), (16, f3), (28, f1), (32, f2), (40, f2), (48, f3)] {
+                let attr_i = layout.layout[i];
+                assert_eq!(attr_i.offset, *off as u32);
+                assert_eq!(&attr_i.attribute, a);
+                i += 1;
+            }
+        }
+    }
+}

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -230,7 +230,7 @@ impl Attribute {
 
 /// Layout for a single [`Attribute`] inside a [`ParticleLayout`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct AttributeLayout {
+pub(crate) struct AttributeLayout {
     pub attribute: &'static Attribute,
     pub offset: u32,
 }
@@ -538,6 +538,10 @@ impl ParticleLayout {
         let size = self.size() as usize;
         let align = self.align();
         NonZeroU64::new(next_multiple_of(size, align) as u64).unwrap()
+    }
+
+    pub(crate) fn attributes(&self) -> &[AttributeLayout] {
+        &self.layout
     }
 
     /// Generate the WGSL attribute code corresponding to the layout.

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -129,7 +129,7 @@ impl Attribute {
     /// # Type
     ///
     /// [`ValueType::Uint`] representing the RGBA components of the color
-    /// encoded as 0xAABBGGRR, with a single byte per component.
+    /// encoded as `0xAABBGGRR`, with a single byte per component.
     pub const COLOR: &'static Attribute = &Attribute::new(Cow::Borrowed("color"), ValueType::Uint);
 
     /// The particle's base color (HDR).
@@ -188,6 +188,14 @@ impl Attribute {
     ///
     /// See [`Attribute::ALL`] for the list of attributes, and the
     /// [`Attribute::name()`] method of each attribute for their name.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// let attr = Attribute::from_name("position").unwrap();
+    /// assert_eq!(attr, Attribute::POSITION);
+    /// ```
     pub fn from_name<'a>(name: &'a str) -> Option<&'static Attribute> {
         Attribute::ALL
             .iter()
@@ -196,6 +204,7 @@ impl Attribute {
     }
 
     /// Create a new attribute.
+    #[inline]
     pub(crate) const fn new(name: Cow<'static, str>, value_type: ValueType) -> Self {
         Self { name, value_type }
     }
@@ -204,25 +213,29 @@ impl Attribute {
     ///
     /// The name of an attribute is unique, and corresponds to the name of the
     /// variable in the generated WGSL code.
+    #[inline]
     pub fn name(&self) -> &str {
         self.name.as_ref()
     }
 
     /// The attribute's type.
+    #[inline]
     pub fn value_type(&self) -> ValueType {
         self.value_type
     }
 
     /// Size of this attribute, in bytes.
     ///
-    /// This is a shortcut for [`ValueType::size()`].
+    /// This is a shortcut for `value_type().size()`.
+    #[inline]
     pub fn size(&self) -> usize {
         self.value_type.size()
     }
 
     /// Alignment of this attribute, in bytes.
     ///
-    /// This is a shortcut for [`ValueType::align()`].
+    /// This is a shortcut for `value_type().align()`.
+    #[inline]
     pub fn align(&self) -> usize {
         self.value_type.align()
     }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,7 +1,9 @@
 use bevy::{
     math::{Quat, Vec2, Vec3, Vec3A, Vec4},
+    reflect::{FromReflect, Reflect},
     utils::FloatOrd,
 };
+use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 
 /// Describes a type that can be linearly interpolated between two keys.
@@ -54,8 +56,8 @@ impl Lerp for Quat {
 }
 
 /// A single key point for a [`Gradient`].
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct GradientKey<T: Lerp> {
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+pub struct GradientKey<T: Lerp + FromReflect> {
     /// Ratio in \[0:1\] where the key is located.
     ratio: f32,
 
@@ -66,7 +68,7 @@ pub struct GradientKey<T: Lerp> {
     pub value: T,
 }
 
-impl<T: Lerp> GradientKey<T> {
+impl<T: Lerp + FromReflect> GradientKey<T> {
     /// Get the ratio where the key point is located, in \[0:1\].
     pub fn ratio(&self) -> f32 {
         self.ratio
@@ -78,12 +80,12 @@ impl<T: Lerp> GradientKey<T> {
 /// The gradient can be sampled anywhere, and will return a linear interpolation
 /// of the values of its closest keys. Sampling before 0 or after 1 returns a
 /// constant value equal to the one of the closest bound.
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct Gradient<T: Lerp> {
+#[derive(Debug, Default, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+pub struct Gradient<T: Lerp + FromReflect> {
     keys: Vec<GradientKey<T>>,
 }
 
-impl<T: Default + Lerp> Gradient<T> {
+impl<T: Default + Lerp + FromReflect> Gradient<T> {
     /// Create a new empty gradient.
     pub fn new() -> Self {
         Self::default()
@@ -98,7 +100,7 @@ impl<T: Default + Lerp> Gradient<T> {
     }
 }
 
-impl<T: Lerp> Gradient<T> {
+impl<T: Lerp + FromReflect> Gradient<T> {
     /// Add a key point to the gradient.
     ///
     /// If one or more duplicate ratios already exist, append the new key after

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -27,9 +27,22 @@ pub enum Value {
 }
 
 impl Value {
+    /// Get the value as a binary blob ready for GPU upload.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Value::Float(f) => bytemuck::cast_slice::<f32, u8>(std::slice::from_ref(f)),
+            Value::Float2(v) => bytemuck::cast_slice::<Vec2, u8>(std::slice::from_ref(v)),
+            Value::Float3(v) => bytemuck::cast_slice::<Vec3, u8>(std::slice::from_ref(v)),
+            Value::Float4(v) => bytemuck::cast_slice::<Vec4, u8>(std::slice::from_ref(v)),
+            Value::Uint(u) => bytemuck::cast_slice::<u32, u8>(std::slice::from_ref(u)),
+        }
+    }
+}
+
+impl Value {
     /// Type of the value.
     pub fn value_type(&self) -> ValueType {
-        match *self {
+        match self {
             Value::Float(_) => ValueType::Float,
             Value::Float2(_) => ValueType::Float2,
             Value::Float3(_) => ValueType::Float3,
@@ -41,7 +54,7 @@ impl Value {
 
 impl ToWgslString for Value {
     fn to_wgsl_string(&self) -> String {
-        match *self {
+        match self {
             Value::Float(f) => f.to_wgsl_string(),
             Value::Float2(v2) => v2.to_wgsl_string(),
             Value::Float3(v3) => v3.to_wgsl_string(),

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,0 +1,184 @@
+//! Effect graph and language definition.
+
+use std::fmt::Debug;
+
+use bevy::{
+    math::{Vec2, Vec3, Vec4},
+    reflect::{FromReflect, Reflect},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{ToWgslString, ValueType};
+
+/// Variant storage for a simple value.
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Value {
+    /// Single `f32` value.
+    Float(f32),
+    /// Vector of two `f32` values (`vec2<f32>`).
+    Float2(Vec2),
+    /// Vector of three `f32` values (`vec3<f32>`).
+    Float3(Vec3),
+    /// Vector of four `f32` values (`vec4<f32>`).
+    Float4(Vec4),
+    /// Single `u32` value.
+    Uint(u32),
+}
+
+impl Value {
+    /// Type of the value.
+    pub fn value_type(&self) -> ValueType {
+        match *self {
+            Value::Float(_) => ValueType::Float,
+            Value::Float2(_) => ValueType::Float2,
+            Value::Float3(_) => ValueType::Float3,
+            Value::Float4(_) => ValueType::Float4,
+            Value::Uint(_) => ValueType::Uint,
+        }
+    }
+}
+
+impl ToWgslString for Value {
+    fn to_wgsl_string(&self) -> String {
+        match *self {
+            Value::Float(f) => f.to_wgsl_string(),
+            Value::Float2(v2) => v2.to_wgsl_string(),
+            Value::Float3(v3) => v3.to_wgsl_string(),
+            Value::Float4(v4) => v4.to_wgsl_string(),
+            Value::Uint(u) => u.to_wgsl_string(),
+        }
+    }
+}
+
+impl From<f32> for Value {
+    fn from(f: f32) -> Self {
+        Self::Float(f)
+    }
+}
+
+impl From<Vec2> for Value {
+    fn from(v: Vec2) -> Self {
+        Self::Float2(v)
+    }
+}
+
+impl From<Vec3> for Value {
+    fn from(v: Vec3) -> Self {
+        Self::Float3(v)
+    }
+}
+
+impl From<Vec4> for Value {
+    fn from(v: Vec4) -> Self {
+        Self::Float4(v)
+    }
+}
+
+impl From<u32> for Value {
+    fn from(u: u32) -> Self {
+        Self::Uint(u)
+    }
+}
+
+/// Language expression producing a value.
+#[typetag::serde]
+pub trait Expr: Debug + ToWgslString + Send + Sync + 'static {
+    /// Is the expression resulting in a compile-time constant?
+    fn is_const(&self) -> bool {
+        false
+    }
+
+    /// The type of the value produced by the expression.
+    fn value_type(&self) -> ValueType;
+
+    /// Create a boxed clone of self.
+    fn boxed_clone(&self) -> BoxedExpr;
+}
+
+/// Boxed [`Expr`] for storing an expression.
+pub type BoxedExpr = Box<dyn Expr>;
+
+impl Clone for BoxedExpr {
+    fn clone(&self) -> Self {
+        self.boxed_clone()
+    }
+}
+
+impl ToWgslString for BoxedExpr {
+    fn to_wgsl_string(&self) -> String {
+        let d: &dyn Expr = self.as_ref();
+        d.to_wgsl_string()
+    }
+}
+
+/// A literal constant expression like `3.0` or `vec3<f32>(1.0, 2.0, 3.0)`.
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+pub struct Literal {
+    value: Value,
+}
+
+impl Literal {
+    /// Create a new literal expression from a [`Value`].
+    pub fn new<V>(value: V) -> Self
+    where
+        Value: From<V>,
+    {
+        Self {
+            value: value.into(),
+        }
+    }
+}
+
+impl ToWgslString for Literal {
+    fn to_wgsl_string(&self) -> String {
+        self.value.to_wgsl_string()
+    }
+}
+
+#[typetag::serde]
+impl Expr for Literal {
+    fn is_const(&self) -> bool {
+        true
+    }
+
+    fn value_type(&self) -> ValueType {
+        self.value.value_type()
+    }
+
+    fn boxed_clone(&self) -> BoxedExpr {
+        Box::new(Literal { value: self.value })
+    }
+}
+
+impl From<Value> for Literal {
+    fn from(value: Value) -> Self {
+        Self { value }
+    }
+}
+
+impl From<&Value> for Literal {
+    fn from(value: &Value) -> Self {
+        Self { value: *value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde() {
+        let l: Literal = Value::Float(3.0).into();
+        let s = ron::to_string(&l).unwrap();
+        println!("literal: {:?}", s);
+        let l_serde: Literal = ron::from_str(&s).unwrap();
+        assert_eq!(l_serde, l);
+
+        let b: BoxedExpr = Box::new(l);
+        let s = ron::to_string(&b).unwrap();
+        println!("boxed literal: {:?}", s);
+        let b_serde: BoxedExpr = ron::from_str(&s).unwrap();
+        assert!(b_serde.is_const());
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,4 +1,10 @@
 //! Effect graph and language definition.
+//!
+//! This module contains the elements used to build a effect graph, a fully
+//! customizable description of a visual effect.
+//!
+//! Currently effect graphs are not yet available; only some preview elements
+//! exist. So this module is a bit empty and of little interest.
 
 use std::fmt::Debug;
 
@@ -91,55 +97,5 @@ impl From<Vec4> for Value {
 impl From<u32> for Value {
     fn from(u: u32) -> Self {
         Self::Uint(u)
-    }
-}
-
-/// A literal constant expression like `3.0` or `vec3<f32>(1.0, 2.0, 3.0)`.
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
-pub struct Literal {
-    value: Value,
-}
-
-impl Literal {
-    /// Create a new literal expression from a [`Value`].
-    pub fn new<V>(value: V) -> Self
-    where
-        Value: From<V>,
-    {
-        Self {
-            value: value.into(),
-        }
-    }
-}
-
-impl ToWgslString for Literal {
-    fn to_wgsl_string(&self) -> String {
-        self.value.to_wgsl_string()
-    }
-}
-
-impl From<Value> for Literal {
-    fn from(value: Value) -> Self {
-        Self { value }
-    }
-}
-
-impl From<&Value> for Literal {
-    fn from(value: &Value) -> Self {
-        Self { value: *value }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn serde() {
-        let l: Literal = Value::Float(3.0).into();
-        let s = ron::to_string(&l).unwrap();
-        println!("literal: {:?}", s);
-        let l_serde: Literal = ron::from_str(&s).unwrap();
-        assert_eq!(l_serde, l);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ mod test_utils;
 use properties::{Property, PropertyInstance};
 use render::EffectCacheId;
 
-pub use asset::{EffectAsset, RenderLayout, UpdateLayout};
+pub use asset::{EffectAsset, RenderLayout};
 pub use attributes::*;
 pub use bundle::ParticleEffectBundle;
 pub use gradient::{Gradient, GradientKey};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,7 +688,7 @@ fn tick_spawners(
 
             // Generate the shader code for the initializing shader
             let mut init_context = InitContext::default();
-            for m in asset.modifiers.iter().filter_map(|m| m.init()) {
+            for m in asset.modifiers.iter().filter_map(|m| m.as_init()) {
                 m.apply(&mut init_context);
             }
             // Warn in debug if the shader doesn't initialize the particle lifetime
@@ -702,7 +702,7 @@ fn tick_spawners(
 
             // Generate the shader code for the update shader
             let mut update_context = UpdateContext::default();
-            for m in asset.modifiers.iter().filter_map(|m| m.update()) {
+            for m in asset.modifiers.iter().filter_map(|m| m.as_update()) {
                 m.apply(&mut update_context);
             }
             // Append Euler integration (TODO - Do we want to make this explicit?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,11 +486,6 @@ const PARTICLES_INIT_SHADER_TEMPLATE: &str = include_str!("render/vfx_init.wgsl"
 const PARTICLES_UPDATE_SHADER_TEMPLATE: &str = include_str!("render/vfx_update.wgsl");
 const PARTICLES_RENDER_SHADER_TEMPLATE: &str = include_str!("render/vfx_render.wgsl");
 
-const DEFAULT_FORCE_FIELD_CODE: &str = r##"
-    (*particle).velocity = (*particle).velocity + (spawner.accel * sim_params.dt);
-    (*particle).position = (*particle).position + (*particle).velocity * sim_params.dt;
-"##;
-
 const FORCE_FIELD_CODE: &str = include_str!("render/force_field_code.wgsl");
 
 const ENABLED_BILLBOARD_CODE: &str = r##"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,8 @@ pub struct ParticleEffect {
 
     // bunch of stuff that should move, which we store here temporarily between tick_spawners()
     // ticking the spawner and the extract/prepare/queue render stages consuming them.
+    #[reflect(ignore)]
+    force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
     spawn_count: u32,
     init_code: String,
     init_extra: String,
@@ -385,6 +387,7 @@ impl ParticleEffect {
             configured_render_shader: None,
             properties: vec![],
             //
+            force_field: [ForceFieldSource::default(); ForceFieldSource::MAX_SOURCES],
             spawn_count: 0,
             init_code: String::default(),
             init_extra: String::default(),
@@ -700,8 +703,9 @@ fn tick_spawners(
                 m.apply(&mut update_context);
             }
             // Append Euler integration (TODO - Do we want to make this explicit?)
+            // Note the prepended "\n" to prevent appending to a comment line.
             update_context.update_code +=
-                &format!("(*particle).position += (*particle).velocity * sim_params.dt;\n");
+                &format!("\n(*particle).position += (*particle).velocity * sim_params.dt;\n");
 
             // Generate the shader code for the color over lifetime gradient.
             // TODO - Move that to a pre-pass, not each frame!
@@ -792,6 +796,7 @@ fn tick_spawners(
             effect.init_extra = init_context.init_extra;
             effect.update_code = update_context.update_code;
             effect.update_extra = update_context.update_extra;
+            effect.force_field = update_context.force_field;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //!     // Also initialize the total lifetime of the particle, that is
 //!     // the time for which it's simulated and rendered. This modifier
 //!     // is mandatory, otherwise the particles won't show up.
-//!     .init(ParticleLifetimeModifier { lifetime: 10. })
+//!     .init(InitLifetimeModifier { lifetime: 10_f32.into() })
 //!     // Every frame, add a gravity-like acceleration downward
 //!     .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
 //!     // Render the particles with a color gradient over their
@@ -697,7 +697,7 @@ fn tick_spawners(
                 .init_code
                 .contains(&format!("particle.{}", Attribute::LIFETIME.name()))
             {
-                warn!("Effect '{}' does not initialize the particle lifetime; particles will have a default lifetime of zero, and will immediately die after spawning. Add a modifier like ParticleLifetimeModifier to initialize the lifetime to a non-zero value.", asset.name);
+                warn!("Effect '{}' does not initialize the particle lifetime; particles will have a default lifetime of zero, and will immediately die after spawning. Add an InitLifetimeModifier to initialize the lifetime to a non-zero value.", asset.name);
             }
 
             // Generate the shader code for the update shader

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod spawn;
 #[cfg(test)]
 mod test_utils;
 
-use properties::PropertyInstance;
+use properties::{Property, PropertyInstance};
 use render::EffectCacheId;
 
 pub use asset::{EffectAsset, RenderLayout, UpdateLayout};
@@ -145,7 +145,7 @@ pub use bundle::ParticleEffectBundle;
 pub use gradient::{Gradient, GradientKey};
 pub use modifier::*;
 pub use plugin::HanabiPlugin;
-pub use properties::{Property, PropertyLayout};
+pub use properties::PropertyLayout;
 pub use render::ShaderCache;
 pub use spawn::{DimValue, Random, Spawner, Value};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,7 +687,7 @@ fn tick_spawners(
 
             // Generate the shader code for the initializing shader
             let mut init_context = InitContext::default();
-            for m in asset.modifiers.iter().filter_map(|m| m.init_modifier()) {
+            for m in asset.modifiers.iter().filter_map(|m| m.init()) {
                 m.apply(&mut init_context);
             }
             // Warn in debug if the shader doesn't initialize the particle lifetime
@@ -701,7 +701,7 @@ fn tick_spawners(
 
             // Generate the shader code for the update shader
             let mut update_context = UpdateContext::default();
-            for m in asset.modifiers.iter().filter_map(|m| m.update_modifier()) {
+            for m in asset.modifiers.iter().filter_map(|m| m.update()) {
                 m.apply(&mut update_context);
             }
             // Warn if the shader doesn't update the particle position or velocity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@
 //! can disable default features and re-enable only one of the two modes.
 //!
 //! ```toml
-//! ## Example: enable only 3D integration
-//! bevy_hanabi = { version = "0.4", default-features = false, features = ["3d"] }
+//! # Example: enable only 3D integration
+//! bevy_hanabi = { version = "0.5", default-features = false, features = ["3d"] }
 //! ```
 //!
 //! # Example
@@ -85,12 +85,17 @@
 //!         dimension: ShapeDimension::Surface,
 //!         speed: 6.0.into(),
 //!     })
+//!     // Also initialize the total lifetime of the particle, that is
+//!     // the time for which it's simulated and rendered. This modifier
+//!     // is mandatory, otherwise the particles won't show up.
+//!     .init(ParticleLifetimeModifier { lifetime: 10. })
 //!     // Every frame, add a gravity-like acceleration downward
 //!     .update(AccelModifier {
 //!         accel: Vec3::new(0., -3., 0.),
 //!     })
 //!     // Render the particles with a color gradient over their
-//!     // lifetime.
+//!     // lifetime. This maps the gradient key 0 to the particle spawn
+//!     // time, and the gradient key 1 to the particle death (here, 10s).
 //!     .render(ColorOverLifetimeModifier { gradient })
 //!     );
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,8 +453,8 @@ const PARTICLES_UPDATE_SHADER_TEMPLATE: &str = include_str!("render/vfx_update.w
 const PARTICLES_RENDER_SHADER_TEMPLATE: &str = include_str!("render/vfx_render.wgsl");
 
 const DEFAULT_FORCE_FIELD_CODE: &str = r##"
-    vVel = vVel + (spawner.accel * sim_params.dt);
-    vPos = vPos + vVel * sim_params.dt;
+    (*particle).velocity = (*particle).velocity + (spawner.accel * sim_params.dt);
+    (*particle).position = (*particle).position + (*particle).velocity * sim_params.dt;
 "##;
 
 const FORCE_FIELD_CODE: &str = include_str!("render/force_field_code.wgsl");
@@ -473,7 +473,7 @@ const DISABLED_BILLBOARD_CODE: &str = r##"
     let world_position = vec4<f32>(particle.position + vpos, 1.0);
 "##;
 
-const DRAG_CODE: &str = r##"vVel = vVel * max(0., (1. - {{DRAG}} * sim_params.dt));
+const DRAG_CODE: &str = r##"(*particle).velocity = (*particle).velocity * max(0., (1. - {{DRAG}} * sim_params.dt));
 "##;
 
 /// Trait to convert any data structure to its equivalent shader code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,16 +704,6 @@ fn tick_spawners(
             for m in asset.modifiers.iter().filter_map(|m| m.update()) {
                 m.apply(&mut update_context);
             }
-            // Warn if the shader doesn't update the particle position or velocity
-            if !update_context
-                .update_code
-                .contains(&format!("(*particle).{}", Attribute::VELOCITY.name()))
-                && !update_context
-                    .update_code
-                    .contains(&format!("(*particle).{}", Attribute::POSITION.name()))
-            {
-                warn!("Effect '{}' does not update the particle position nor velocity; particles will have their spawn position and velocity forever. Add a modifier like AccelModifier to animate the particles.", asset.name);
-            }
             // Append Euler integration (TODO - Do we want to make this explicit?)
             update_context.update_code +=
                 &format!("(*particle).position += (*particle).velocity * sim_params.dt;\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,7 @@
 //!     // is mandatory, otherwise the particles won't show up.
 //!     .init(ParticleLifetimeModifier { lifetime: 10. })
 //!     // Every frame, add a gravity-like acceleration downward
-//!     .update(AccelModifier {
-//!         accel: Vec3::new(0., -3., 0.),
-//!     })
+//!     .update(AccelModifier::constant(Vec3::new(0., -3., 0.)))
 //!     // Render the particles with a color gradient over their
 //!     // lifetime. This maps the gradient key 0 to the particle spawn
 //!     // time, and the gradient key 1 to the particle death (here, 10s).

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -371,6 +371,8 @@ impl InitModifier for ParticleLifetimeModifier {
 /// The particle is initialized with a fixed or randomly distributed size value,
 /// and will retain that size unless another modifier (like
 /// [`SizeOverLifetimeModifier`]) changes its size after spawning.
+///
+/// [`SizeOverLifetimeModifier`]: crate::SizeOverLifetimeModifier
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitSizeModifier {
     /// The size to initialize each particle with.

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -2,14 +2,12 @@
 
 use bevy::prelude::*;
 
-use crate::{asset::InitLayout, modifier::ShapeDimension, Attribute, ToWgslString, Value};
+use crate::{
+    asset::InitLayout, modifier::ShapeDimension, Attribute, Modifier, ToWgslString, Value,
+};
 
 /// Trait to customize the initializing of newly spawned particles.
-pub trait InitModifier {
-    /// Get the list of dependent attributes required for this modifier to be
-    /// used.
-    fn attributes(&self) -> &[&'static Attribute];
-
+pub trait InitModifier: Modifier {
     /// Apply the modifier to the init layout of the effect instance.
     fn apply(&self, init_layout: &mut InitLayout);
 }
@@ -42,11 +40,13 @@ impl Default for PositionCircleModifier {
     }
 }
 
-impl InitModifier for PositionCircleModifier {
+impl Modifier for PositionCircleModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+}
 
+impl InitModifier for PositionCircleModifier {
     fn apply(&self, init_layout: &mut InitLayout) {
         let (tangent, bitangent) = self.axis.any_orthonormal_pair();
 
@@ -104,11 +104,13 @@ pub struct PositionSphereModifier {
     pub dimension: ShapeDimension,
 }
 
-impl InitModifier for PositionSphereModifier {
+impl Modifier for PositionSphereModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+}
 
+impl InitModifier for PositionSphereModifier {
     fn apply(&self, init_layout: &mut InitLayout) {
         let radius_code = match self.dimension {
             ShapeDimension::Surface => {
@@ -181,11 +183,13 @@ pub struct PositionCone3dModifier {
     pub dimension: ShapeDimension,
 }
 
-impl InitModifier for PositionCone3dModifier {
+impl Modifier for PositionCone3dModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+}
 
+impl InitModifier for PositionCone3dModifier {
     fn apply(&self, init_layout: &mut InitLayout) {
         if matches!(self.dimension, ShapeDimension::Surface) {
             unimplemented!("TODO");
@@ -263,11 +267,13 @@ pub struct ParticleLifetimeModifier {
     pub lifetime: f32,
 }
 
-impl InitModifier for ParticleLifetimeModifier {
+impl Modifier for ParticleLifetimeModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::AGE, Attribute::LIFETIME]
     }
+}
 
+impl InitModifier for ParticleLifetimeModifier {
     fn apply(&self, init_layout: &mut InitLayout) {
         init_layout.lifetime_code = format!(
             r##"

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -81,7 +81,10 @@ impl Default for PositionCircleModifier {
     }
 }
 
-impl_mod_init!(PositionCircleModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
+impl_mod_init!(
+    PositionCircleModifier,
+    &[Attribute::POSITION, Attribute::VELOCITY]
+);
 
 #[typetag::serde]
 impl InitModifier for PositionCircleModifier {
@@ -145,7 +148,10 @@ pub struct PositionSphereModifier {
     pub dimension: ShapeDimension,
 }
 
-impl_mod_init!(PositionSphereModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
+impl_mod_init!(
+    PositionSphereModifier,
+    &[Attribute::POSITION, Attribute::VELOCITY]
+);
 
 #[typetag::serde]
 impl InitModifier for PositionSphereModifier {
@@ -225,7 +231,10 @@ pub struct PositionCone3dModifier {
     pub dimension: ShapeDimension,
 }
 
-impl_mod_init!(PositionCone3dModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
+impl_mod_init!(
+    PositionCone3dModifier,
+    &[Attribute::POSITION, Attribute::VELOCITY]
+);
 
 #[typetag::serde]
 impl InitModifier for PositionCone3dModifier {
@@ -297,7 +306,10 @@ impl Default for ParticleLifetimeModifier {
     }
 }
 
-impl_mod_init!(ParticleLifetimeModifier, &[Attribute::AGE, Attribute::LIFETIME]);
+impl_mod_init!(
+    ParticleLifetimeModifier,
+    &[Attribute::AGE, Attribute::LIFETIME]
+);
 
 #[typetag::serde]
 impl InitModifier for ParticleLifetimeModifier {

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -25,6 +25,34 @@ pub trait InitModifier: Modifier {
     fn apply(&self, context: &mut InitContext);
 }
 
+/// Macro to implement the [`Modifier`] trait for an init modifier.
+macro_rules! impl_mod_init {
+    ($t:ty, $attrs:expr) => {
+        #[typetag::serde]
+        impl Modifier for $t {
+            fn context(&self) -> ModifierContext {
+                ModifierContext::Init
+            }
+
+            fn init(&self) -> Option<&dyn InitModifier> {
+                Some(self)
+            }
+
+            fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+                Some(self)
+            }
+
+            fn attributes(&self) -> &[&'static Attribute] {
+                $attrs
+            }
+
+            fn boxed_clone(&self) -> BoxedModifier {
+                Box::new(*self)
+            }
+        }
+    };
+}
+
 /// An initialization modifier spawning particles on a circle/disc.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct PositionCircleModifier {
@@ -53,28 +81,7 @@ impl Default for PositionCircleModifier {
     }
 }
 
-#[typetag::serde]
-impl Modifier for PositionCircleModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Init
-    }
-
-    fn init(&self) -> Option<&dyn InitModifier> {
-        Some(self)
-    }
-
-    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::POSITION, Attribute::VELOCITY]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_init!(PositionCircleModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
 
 #[typetag::serde]
 impl InitModifier for PositionCircleModifier {
@@ -138,28 +145,7 @@ pub struct PositionSphereModifier {
     pub dimension: ShapeDimension,
 }
 
-#[typetag::serde]
-impl Modifier for PositionSphereModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Init
-    }
-
-    fn init(&self) -> Option<&dyn InitModifier> {
-        Some(self)
-    }
-
-    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::POSITION, Attribute::VELOCITY]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_init!(PositionSphereModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
 
 #[typetag::serde]
 impl InitModifier for PositionSphereModifier {
@@ -239,28 +225,7 @@ pub struct PositionCone3dModifier {
     pub dimension: ShapeDimension,
 }
 
-#[typetag::serde]
-impl Modifier for PositionCone3dModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Init
-    }
-
-    fn init(&self) -> Option<&dyn InitModifier> {
-        Some(self)
-    }
-
-    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::POSITION, Attribute::VELOCITY]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_init!(PositionCone3dModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
 
 #[typetag::serde]
 impl InitModifier for PositionCone3dModifier {
@@ -332,28 +297,7 @@ impl Default for ParticleLifetimeModifier {
     }
 }
 
-#[typetag::serde]
-impl Modifier for ParticleLifetimeModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Init
-    }
-
-    fn init(&self) -> Option<&dyn InitModifier> {
-        Some(self)
-    }
-
-    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::AGE, Attribute::LIFETIME]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_init!(ParticleLifetimeModifier, &[Attribute::AGE, Attribute::LIFETIME]);
 
 #[typetag::serde]
 impl InitModifier for ParticleLifetimeModifier {

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -34,11 +34,11 @@ macro_rules! impl_mod_init {
                 ModifierContext::Init
             }
 
-            fn init(&self) -> Option<&dyn InitModifier> {
+            fn as_init(&self) -> Option<&dyn InitModifier> {
                 Some(self)
             }
 
-            fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+            fn as_init_mut(&mut self) -> Option<&mut dyn InitModifier> {
                 Some(self)
             }
 
@@ -333,11 +333,11 @@ impl Modifier for InitSizeModifier {
         ModifierContext::Init
     }
 
-    fn init(&self) -> Option<&dyn InitModifier> {
+    fn as_init(&self) -> Option<&dyn InitModifier> {
         Some(self)
     }
 
-    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+    fn as_init_mut(&mut self) -> Option<&mut dyn InitModifier> {
         Some(self)
     }
 

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -3,7 +3,10 @@
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{modifier::ShapeDimension, Attribute, DimValue, Modifier, ToWgslString, Value};
+use crate::{
+    modifier::ShapeDimension, Attribute, BoxedModifier, DimValue, Modifier, ModifierContext,
+    ToWgslString, Value,
+};
 
 /// Particle initializing shader code generation context.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -16,6 +19,7 @@ pub struct InitContext {
 }
 
 /// Trait to customize the initializing of newly spawned particles.
+#[typetag::serde]
 pub trait InitModifier: Modifier {
     /// Append the initializing code.
     fn apply(&self, context: &mut InitContext);
@@ -49,12 +53,30 @@ impl Default for PositionCircleModifier {
     }
 }
 
+#[typetag::serde]
 impl Modifier for PositionCircleModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Init
+    }
+
+    fn init(&self) -> Option<&dyn InitModifier> {
+        Some(self)
+    }
+
+    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl InitModifier for PositionCircleModifier {
     fn apply(&self, context: &mut InitContext) {
         let (tangent, bitangent) = self.axis.any_orthonormal_pair();
@@ -116,12 +138,30 @@ pub struct PositionSphereModifier {
     pub dimension: ShapeDimension,
 }
 
+#[typetag::serde]
 impl Modifier for PositionSphereModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Init
+    }
+
+    fn init(&self) -> Option<&dyn InitModifier> {
+        Some(self)
+    }
+
+    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl InitModifier for PositionSphereModifier {
     fn apply(&self, context: &mut InitContext) {
         let radius_code = match self.dimension {
@@ -199,12 +239,30 @@ pub struct PositionCone3dModifier {
     pub dimension: ShapeDimension,
 }
 
+#[typetag::serde]
 impl Modifier for PositionCone3dModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Init
+    }
+
+    fn init(&self) -> Option<&dyn InitModifier> {
+        Some(self)
+    }
+
+    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl InitModifier for PositionCone3dModifier {
     fn apply(&self, context: &mut InitContext) {
         context.init_extra += &format!(
@@ -274,12 +332,30 @@ impl Default for ParticleLifetimeModifier {
     }
 }
 
+#[typetag::serde]
 impl Modifier for ParticleLifetimeModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Init
+    }
+
+    fn init(&self) -> Option<&dyn InitModifier> {
+        Some(self)
+    }
+
+    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::AGE, Attribute::LIFETIME]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl InitModifier for ParticleLifetimeModifier {
     fn apply(&self, context: &mut InitContext) {
         context.init_code += &format!(
@@ -305,7 +381,20 @@ pub struct InitSizeModifier {
     pub size: DimValue,
 }
 
+#[typetag::serde]
 impl Modifier for InitSizeModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Init
+    }
+
+    fn init(&self) -> Option<&dyn InitModifier> {
+        Some(self)
+    }
+
+    fn init_mut(&mut self) -> Option<&mut dyn InitModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         match self.size {
             DimValue::D1(_) => &[Attribute::SIZE],
@@ -313,8 +402,13 @@ impl Modifier for InitSizeModifier {
             _ => panic!("Invalid dimension for InitSizeModifier; only 1D and 2D values are valid."),
         }
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl InitModifier for InitSizeModifier {
     fn apply(&self, context: &mut InitContext) {
         context.init_code += &format!(

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -18,7 +18,7 @@ pub struct InitContext {
 /// Trait to customize the initializing of newly spawned particles.
 pub trait InitModifier: Modifier {
     /// Append the initializing code.
-    fn init(&self, context: &mut InitContext);
+    fn apply(&self, context: &mut InitContext);
 }
 
 /// An initialization modifier spawning particles on a circle/disc.
@@ -56,7 +56,7 @@ impl Modifier for PositionCircleModifier {
 }
 
 impl InitModifier for PositionCircleModifier {
-    fn init(&self, context: &mut InitContext) {
+    fn apply(&self, context: &mut InitContext) {
         let (tangent, bitangent) = self.axis.any_orthonormal_pair();
 
         let radius_code = match self.dimension {
@@ -123,7 +123,7 @@ impl Modifier for PositionSphereModifier {
 }
 
 impl InitModifier for PositionSphereModifier {
-    fn init(&self, context: &mut InitContext) {
+    fn apply(&self, context: &mut InitContext) {
         let radius_code = match self.dimension {
             ShapeDimension::Surface => {
                 // Constant radius
@@ -206,7 +206,7 @@ impl Modifier for PositionCone3dModifier {
 }
 
 impl InitModifier for PositionCone3dModifier {
-    fn init(&self, context: &mut InitContext) {
+    fn apply(&self, context: &mut InitContext) {
         context.init_extra += &format!(
             r##"fn position_cone3d(particle: ptr<function, Particle>) {{
     // Truncated cone height
@@ -281,7 +281,7 @@ impl Modifier for ParticleLifetimeModifier {
 }
 
 impl InitModifier for ParticleLifetimeModifier {
-    fn init(&self, context: &mut InitContext) {
+    fn apply(&self, context: &mut InitContext) {
         context.init_code += &format!(
             "particle.{} = {};\n",
             Attribute::LIFETIME.name(),
@@ -316,7 +316,7 @@ impl Modifier for InitSizeModifier {
 }
 
 impl InitModifier for InitSizeModifier {
-    fn init(&self, context: &mut InitContext) {
+    fn apply(&self, context: &mut InitContext) {
         context.init_code += &format!(
             "particle.{} = {};\n",
             Attribute::SIZE.name(),
@@ -343,7 +343,7 @@ mod tests {
         ];
         for modifier in modifiers.iter() {
             let mut context = InitContext::default();
-            modifier.init(&mut context);
+            modifier.apply(&mut context);
 
             let code = format!(
                 r##"fn rand() -> f32 {{

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -288,11 +288,17 @@ impl InitModifier for ParticleLifetimeModifier {
 }
 
 /// Modifier to initialize the per-particle size attribute.
+///
+/// The particle is initialized with a fixed or randomly distributed size value,
+/// and will retain that size unless another modifier (like
+/// [`SizeOverLifetimeModifier`]) changes its size after spawning.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitSizeModifier {
     /// The size to initialize each particle with.
     ///
-    /// Only [`DimValue::D1`] and [`DimValue::D2`] are valid.
+    /// Only [`DimValue::D1`] and [`DimValue::D2`] are valid. The former
+    /// requires the [`Attribute::SIZE`] attribute in the particle layout, while
+    /// the latter requires the [`Attribute::SIZE2`] attribute.
     pub size: DimValue,
 }
 

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -1,6 +1,7 @@
 //! Modifiers to initialize particles when they spawn.
 
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     asset::InitLayout, modifier::ShapeDimension, Attribute, Modifier, ToWgslString, Value,
@@ -13,7 +14,7 @@ pub trait InitModifier: Modifier {
 }
 
 /// An initialization modifier spawning particles on a circle/disc.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct PositionCircleModifier {
     /// The circle center, relative to the emitter position.
     pub center: Vec3,
@@ -92,7 +93,7 @@ impl InitModifier for PositionCircleModifier {
 }
 
 /// An initialization modifier spawning particles on a sphere.
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct PositionSphereModifier {
     /// The sphere center, relative to the emitter position.
     pub center: Vec3,
@@ -168,7 +169,7 @@ impl InitModifier for PositionSphereModifier {
 ///
 /// The particle velocity is initialized to a random speed along the direction
 /// going from the cone apex to the particle position.
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct PositionCone3dModifier {
     /// The cone height along its axis, between the base and top radii.
     pub height: f32,
@@ -261,7 +262,7 @@ impl InitModifier for PositionCone3dModifier {
 ///
 /// Particles with a lifetime are aged each frame by the frame's delta time, and
 /// are despawned once their age is greater than or equal to their lifetime.
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ParticleLifetimeModifier {
     /// The lifetime of all particles when they spawn, in seconds.
     pub lifetime: f32,

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -30,6 +30,8 @@ pub use init::*;
 pub use render::*;
 pub use update::*;
 
+use crate::Attribute;
+
 /// The dimension of a shape to consider.
 ///
 /// The exact meaning depends on the context where this enum is used.
@@ -45,4 +47,11 @@ impl Default for ShapeDimension {
     fn default() -> Self {
         Self::Surface
     }
+}
+
+/// Trait describing a modifier customizing an effect pipeline.
+pub trait Modifier {
+    /// Get the list of dependent attributes required for this modifier to be
+    /// used.
+    fn attributes(&self) -> &[&'static Attribute];
 }

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -141,3 +141,40 @@ impl_modifier!(ParticleTexture, ParticleTextureModifier);
 impl_modifier!(ColorOverLifetime, ColorOverLifetimeModifier);
 impl_modifier!(SizeOverLifetime, SizeOverLifetimeModifier);
 impl_modifier!(Billboard, BillboardModifier);
+
+#[cfg(test)]
+mod tests {
+    use bevy::prelude::*;
+
+    use super::*;
+
+    fn make_test_modifier() -> Modifiers {
+        PositionSphereModifier {
+            center: Vec3::ZERO,
+            radius: 1.5,
+            speed: 3.5.into(),
+            dimension: ShapeDimension::Surface,
+        }
+        .into()
+    }
+
+    #[test]
+    fn reflect() {
+        let m = make_test_modifier();
+
+        // Reflect
+        let reflect: &dyn Reflect = &m;
+        assert!(reflect.is::<Modifiers>());
+        let m_reflect = reflect.downcast_ref::<Modifiers>().unwrap();
+        assert_eq!(*m_reflect, m);
+    }
+
+    #[test]
+    fn serde() {
+        let m = make_test_modifier();
+        let s = ron::to_string(&m).unwrap();
+        println!("modifier: {:?}", s);
+        let m_serde: Modifiers = ron::from_str(&s).unwrap();
+        assert_eq!(m, m_serde);
+    }
+}

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -162,7 +162,10 @@ mod tests {
 
         let rm: &dyn Reflect = m.as_reflect();
         let rm_serde: &dyn Reflect = m_serde.as_reflect();
-        assert_eq!(rm.get_type_info().type_id(), rm_serde.get_type_info().type_id());
+        assert_eq!(
+            rm.get_type_info().type_id(),
+            rm_serde.get_type_info().type_id()
+        );
 
         assert!(rm_serde.is::<PositionSphereModifier>());
         let rm_reflect = rm_serde.downcast_ref::<PositionSphereModifier>().unwrap();

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -102,6 +102,7 @@ pub trait Modifier: Reflect + Send + Sync + 'static {
 
     /// Attempt to resolve any property reference to the actual property in the
     /// effect.
+    /// WARNING - For internal use only.
     fn resolve_properties(&mut self, _properties: &[Property]) {}
 
     /// Clone self.

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -22,6 +22,9 @@
 //! [`UpdateModifier`]: crate::modifier::update::UpdateModifier
 //! [`RenderModifier`]: crate::modifier::render::RenderModifier
 
+use bevy::reflect::{FromReflect, Reflect};
+use serde::{Deserialize, Serialize};
+
 pub mod init;
 pub mod render;
 pub mod update;
@@ -35,7 +38,7 @@ use crate::Attribute;
 /// The dimension of a shape to consider.
 ///
 /// The exact meaning depends on the context where this enum is used.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect, Serialize, Deserialize)]
 pub enum ShapeDimension {
     /// Consider the surface of the shape only.
     Surface,
@@ -54,4 +57,125 @@ pub trait Modifier {
     /// Get the list of dependent attributes required for this modifier to be
     /// used.
     fn attributes(&self) -> &[&'static Attribute];
+}
+
+/// Enumeration of all the possible modifiers.
+///
+/// This is mainly a workaround for the impossibility to currently serialize and
+/// deserialize some trait object in Bevy, which makes it impossible to directly
+/// hold a `Box<dyn Modifier>` in an `EffectAsset`. Instead, we use an enum to
+/// explicitly list the types and make the field a sized one that can be
+/// serialized and deserialized.
+#[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Modifiers {
+    /// [`PositionCircleModifier`].
+    PositionCircle(PositionCircleModifier),
+    /// [`PositionSphereModifier`].
+    PositionSphere(PositionSphereModifier),
+    /// [`PositionCone3dModifier`].
+    PositionCone3d(PositionCone3dModifier),
+    /// [`ParticleLifetimeModifier`].
+    ParticleLifetime(ParticleLifetimeModifier),
+
+    /// [`AccelModifier`].
+    Accel(AccelModifier),
+    /// [`ForceFieldModifier`].
+    ForceField(ForceFieldModifier),
+    /// [`LinearDragModifier`].
+    LinearDrag(LinearDragModifier),
+
+    /// [`ParticleTextureModifier`].
+    ParticleTexture(ParticleTextureModifier),
+    /// [`ColorOverLifetimeModifier`].
+    ColorOverLifetime(ColorOverLifetimeModifier),
+    /// [`SizeOverLifetimeModifier`].
+    SizeOverLifetime(SizeOverLifetimeModifier),
+    /// [`BillboardModifier`].
+    Billboard(BillboardModifier),
+}
+
+impl Modifiers {
+    /// Cast the enum value to the [`Modifier`] trait.
+    pub fn modifier(&self) -> &dyn Modifier {
+        match self {
+            Modifiers::PositionCircle(modifier) => modifier,
+            Modifiers::PositionSphere(modifier) => modifier,
+            Modifiers::PositionCone3d(modifier) => modifier,
+            Modifiers::ParticleLifetime(modifier) => modifier,
+            Modifiers::Accel(modifier) => modifier,
+            Modifiers::ForceField(modifier) => modifier,
+            Modifiers::LinearDrag(modifier) => modifier,
+            Modifiers::ParticleTexture(modifier) => modifier,
+            Modifiers::ColorOverLifetime(modifier) => modifier,
+            Modifiers::SizeOverLifetime(modifier) => modifier,
+            Modifiers::Billboard(modifier) => modifier,
+        }
+    }
+}
+
+impl From<PositionCircleModifier> for Modifiers {
+    fn from(modifier: PositionCircleModifier) -> Self {
+        Self::PositionCircle(modifier)
+    }
+}
+
+impl From<PositionSphereModifier> for Modifiers {
+    fn from(modifier: PositionSphereModifier) -> Self {
+        Self::PositionSphere(modifier)
+    }
+}
+
+impl From<PositionCone3dModifier> for Modifiers {
+    fn from(modifier: PositionCone3dModifier) -> Self {
+        Self::PositionCone3d(modifier)
+    }
+}
+
+impl From<ParticleLifetimeModifier> for Modifiers {
+    fn from(modifier: ParticleLifetimeModifier) -> Self {
+        Self::ParticleLifetime(modifier)
+    }
+}
+
+impl From<AccelModifier> for Modifiers {
+    fn from(modifier: AccelModifier) -> Self {
+        Self::Accel(modifier)
+    }
+}
+
+impl From<ForceFieldModifier> for Modifiers {
+    fn from(modifier: ForceFieldModifier) -> Self {
+        Self::ForceField(modifier)
+    }
+}
+
+impl From<LinearDragModifier> for Modifiers {
+    fn from(modifier: LinearDragModifier) -> Self {
+        Self::LinearDrag(modifier)
+    }
+}
+
+impl From<ParticleTextureModifier> for Modifiers {
+    fn from(modifier: ParticleTextureModifier) -> Self {
+        Self::ParticleTexture(modifier)
+    }
+}
+
+impl From<ColorOverLifetimeModifier> for Modifiers {
+    fn from(modifier: ColorOverLifetimeModifier) -> Self {
+        Self::ColorOverLifetime(modifier)
+    }
+}
+
+impl From<SizeOverLifetimeModifier> for Modifiers {
+    fn from(modifier: SizeOverLifetimeModifier) -> Self {
+        Self::SizeOverLifetime(modifier)
+    }
+}
+
+impl From<BillboardModifier> for Modifiers {
+    fn from(modifier: BillboardModifier) -> Self {
+        Self::Billboard(modifier)
+    }
 }

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -114,6 +114,19 @@ impl Modifiers {
             Modifiers::Billboard(modifier) => modifier,
         }
     }
+
+    /// Cast the enum value to an [`InitModifier`] if possible.
+    pub fn init_modifier(&self) -> Option<&dyn InitModifier> {
+        match self {
+            Modifiers::PositionCircle(modifier) => Some(modifier),
+            Modifiers::PositionSphere(modifier) => Some(modifier),
+            Modifiers::PositionCone3d(modifier) => Some(modifier),
+            Modifiers::ParticleLifetime(modifier) => Some(modifier),
+            Modifiers::InitSize(modifier) => Some(modifier),
+
+            _ => None,
+        }
+    }
 }
 
 /// Implement `From<T> for Modifiers` for a [`Modifier`] type.

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -38,18 +38,15 @@ use crate::Attribute;
 /// The dimension of a shape to consider.
 ///
 /// The exact meaning depends on the context where this enum is used.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Reflect, FromReflect, Serialize, Deserialize,
+)]
 pub enum ShapeDimension {
     /// Consider the surface of the shape only.
+    #[default]
     Surface,
     /// Consider the entire shape volume.
     Volume,
-}
-
-impl Default for ShapeDimension {
-    fn default() -> Self {
-        Self::Surface
-    }
 }
 
 /// Trait describing a modifier customizing an effect pipeline.
@@ -77,6 +74,8 @@ pub enum Modifiers {
     PositionCone3d(PositionCone3dModifier),
     /// [`ParticleLifetimeModifier`].
     ParticleLifetime(ParticleLifetimeModifier),
+    /// [`InitSizeModifier`]
+    InitSize(InitSizeModifier),
 
     /// [`AccelModifier`].
     Accel(AccelModifier),
@@ -103,9 +102,12 @@ impl Modifiers {
             Modifiers::PositionSphere(modifier) => modifier,
             Modifiers::PositionCone3d(modifier) => modifier,
             Modifiers::ParticleLifetime(modifier) => modifier,
+            Modifiers::InitSize(modifier) => modifier,
+
             Modifiers::Accel(modifier) => modifier,
             Modifiers::ForceField(modifier) => modifier,
             Modifiers::LinearDrag(modifier) => modifier,
+
             Modifiers::ParticleTexture(modifier) => modifier,
             Modifiers::ColorOverLifetime(modifier) => modifier,
             Modifiers::SizeOverLifetime(modifier) => modifier,
@@ -114,68 +116,28 @@ impl Modifiers {
     }
 }
 
-impl From<PositionCircleModifier> for Modifiers {
-    fn from(modifier: PositionCircleModifier) -> Self {
-        Self::PositionCircle(modifier)
-    }
+/// Implement `From<T> for Modifiers` for a [`Modifier`] type.
+macro_rules! impl_modifier {
+    ($e:ident, $t:ty) => {
+        impl From<$t> for $crate::Modifiers {
+            fn from(modifier: $t) -> Self {
+                Self::$e(modifier)
+            }
+        }
+    };
 }
 
-impl From<PositionSphereModifier> for Modifiers {
-    fn from(modifier: PositionSphereModifier) -> Self {
-        Self::PositionSphere(modifier)
-    }
-}
+impl_modifier!(PositionCircle, PositionCircleModifier);
+impl_modifier!(PositionSphere, PositionSphereModifier);
+impl_modifier!(PositionCone3d, PositionCone3dModifier);
+impl_modifier!(ParticleLifetime, ParticleLifetimeModifier);
+impl_modifier!(InitSize, InitSizeModifier);
 
-impl From<PositionCone3dModifier> for Modifiers {
-    fn from(modifier: PositionCone3dModifier) -> Self {
-        Self::PositionCone3d(modifier)
-    }
-}
+impl_modifier!(Accel, AccelModifier);
+impl_modifier!(ForceField, ForceFieldModifier);
+impl_modifier!(LinearDrag, LinearDragModifier);
 
-impl From<ParticleLifetimeModifier> for Modifiers {
-    fn from(modifier: ParticleLifetimeModifier) -> Self {
-        Self::ParticleLifetime(modifier)
-    }
-}
-
-impl From<AccelModifier> for Modifiers {
-    fn from(modifier: AccelModifier) -> Self {
-        Self::Accel(modifier)
-    }
-}
-
-impl From<ForceFieldModifier> for Modifiers {
-    fn from(modifier: ForceFieldModifier) -> Self {
-        Self::ForceField(modifier)
-    }
-}
-
-impl From<LinearDragModifier> for Modifiers {
-    fn from(modifier: LinearDragModifier) -> Self {
-        Self::LinearDrag(modifier)
-    }
-}
-
-impl From<ParticleTextureModifier> for Modifiers {
-    fn from(modifier: ParticleTextureModifier) -> Self {
-        Self::ParticleTexture(modifier)
-    }
-}
-
-impl From<ColorOverLifetimeModifier> for Modifiers {
-    fn from(modifier: ColorOverLifetimeModifier) -> Self {
-        Self::ColorOverLifetime(modifier)
-    }
-}
-
-impl From<SizeOverLifetimeModifier> for Modifiers {
-    fn from(modifier: SizeOverLifetimeModifier) -> Self {
-        Self::SizeOverLifetime(modifier)
-    }
-}
-
-impl From<BillboardModifier> for Modifiers {
-    fn from(modifier: BillboardModifier) -> Self {
-        Self::Billboard(modifier)
-    }
-}
+impl_modifier!(ParticleTexture, ParticleTextureModifier);
+impl_modifier!(ColorOverLifetime, ColorOverLifetimeModifier);
+impl_modifier!(SizeOverLifetime, SizeOverLifetimeModifier);
+impl_modifier!(Billboard, BillboardModifier);

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -62,7 +62,7 @@ pub enum ModifierContext {
 
 /// Trait describing a modifier customizing an effect pipeline.
 #[typetag::serde]
-pub trait Modifier: Send + Sync + 'static {
+pub trait Modifier: Reflect + Send + Sync + 'static {
     /// Get the context this modifier applies to.
     fn context(&self) -> ModifierContext;
 

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -2,10 +2,14 @@
 
 use bevy::prelude::*;
 
-use crate::{Gradient, RenderLayout};
+use crate::{Attribute, Gradient, RenderLayout};
 
 /// Trait to customize the rendering of alive particles each frame.
 pub trait RenderModifier {
+    /// Get the list of dependent attributes required for this modifier to be
+    /// used.
+    fn attributes(&self) -> &[&'static Attribute];
+
     /// Apply the modifier to the render layout of the effect instance.
     fn apply(&self, render_layout: &mut RenderLayout);
 }
@@ -18,6 +22,10 @@ pub struct ParticleTextureModifier {
 }
 
 impl RenderModifier for ParticleTextureModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[]
+    }
+
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.particle_texture = Some(self.texture.clone());
     }
@@ -32,6 +40,10 @@ pub struct ColorOverLifetimeModifier {
 }
 
 impl RenderModifier for ColorOverLifetimeModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[]
+    }
+
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.lifetime_color_gradient = Some(self.gradient.clone());
     }
@@ -46,6 +58,10 @@ pub struct SizeOverLifetimeModifier {
 }
 
 impl RenderModifier for SizeOverLifetimeModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[]
+    }
+
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.lifetime_size_gradient = Some(self.gradient.clone());
     }
@@ -56,6 +72,10 @@ impl RenderModifier for SizeOverLifetimeModifier {
 pub struct BillboardModifier;
 
 impl RenderModifier for BillboardModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[Attribute::POSITION]
+    }
+
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.billboard = true;
     }

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -2,14 +2,10 @@
 
 use bevy::prelude::*;
 
-use crate::{Attribute, Gradient, RenderLayout};
+use crate::{Attribute, Gradient, Modifier, RenderLayout};
 
 /// Trait to customize the rendering of alive particles each frame.
-pub trait RenderModifier {
-    /// Get the list of dependent attributes required for this modifier to be
-    /// used.
-    fn attributes(&self) -> &[&'static Attribute];
-
+pub trait RenderModifier: Modifier {
     /// Apply the modifier to the render layout of the effect instance.
     fn apply(&self, render_layout: &mut RenderLayout);
 }
@@ -21,11 +17,13 @@ pub struct ParticleTextureModifier {
     pub texture: Handle<Image>,
 }
 
-impl RenderModifier for ParticleTextureModifier {
+impl Modifier for ParticleTextureModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[]
     }
+}
 
+impl RenderModifier for ParticleTextureModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.particle_texture = Some(self.texture.clone());
     }
@@ -39,11 +37,13 @@ pub struct ColorOverLifetimeModifier {
     pub gradient: Gradient<Vec4>,
 }
 
-impl RenderModifier for ColorOverLifetimeModifier {
+impl Modifier for ColorOverLifetimeModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[]
     }
+}
 
+impl RenderModifier for ColorOverLifetimeModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.lifetime_color_gradient = Some(self.gradient.clone());
     }
@@ -57,11 +57,13 @@ pub struct SizeOverLifetimeModifier {
     pub gradient: Gradient<Vec2>,
 }
 
-impl RenderModifier for SizeOverLifetimeModifier {
+impl Modifier for SizeOverLifetimeModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[]
     }
+}
 
+impl RenderModifier for SizeOverLifetimeModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.lifetime_size_gradient = Some(self.gradient.clone());
     }
@@ -71,11 +73,13 @@ impl RenderModifier for SizeOverLifetimeModifier {
 #[derive(Default, Clone, Copy)]
 pub struct BillboardModifier;
 
-impl RenderModifier for BillboardModifier {
+impl Modifier for BillboardModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION]
     }
+}
 
+impl RenderModifier for BillboardModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.billboard = true;
     }

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -3,9 +3,10 @@
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{Attribute, Gradient, Modifier, RenderLayout};
+use crate::{Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, RenderLayout};
 
 /// Trait to customize the rendering of alive particles each frame.
+#[typetag::serde]
 pub trait RenderModifier: Modifier {
     /// Apply the modifier to the render layout of the effect instance.
     fn apply(&self, render_layout: &mut RenderLayout);
@@ -22,12 +23,30 @@ pub struct ParticleTextureModifier {
     pub texture: Handle<Image>,
 }
 
+#[typetag::serde]
 impl Modifier for ParticleTextureModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Render
+    }
+
+    fn render(&self) -> Option<&dyn RenderModifier> {
+        Some(self)
+    }
+
+    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[] // TODO - should require some UV maybe?
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(self.clone())
+    }
 }
 
+#[typetag::serde]
 impl RenderModifier for ParticleTextureModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.particle_texture = Some(self.texture.clone());
@@ -42,12 +61,30 @@ pub struct ColorOverLifetimeModifier {
     pub gradient: Gradient<Vec4>,
 }
 
+#[typetag::serde]
 impl Modifier for ColorOverLifetimeModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Render
+    }
+
+    fn render(&self) -> Option<&dyn RenderModifier> {
+        Some(self)
+    }
+
+    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(self.clone())
+    }
 }
 
+#[typetag::serde]
 impl RenderModifier for ColorOverLifetimeModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.lifetime_color_gradient = Some(self.gradient.clone());
@@ -62,12 +99,30 @@ pub struct SizeOverLifetimeModifier {
     pub gradient: Gradient<Vec2>,
 }
 
+#[typetag::serde]
 impl Modifier for SizeOverLifetimeModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Render
+    }
+
+    fn render(&self) -> Option<&dyn RenderModifier> {
+        Some(self)
+    }
+
+    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(self.clone())
+    }
 }
 
+#[typetag::serde]
 impl RenderModifier for SizeOverLifetimeModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.lifetime_size_gradient = Some(self.gradient.clone());
@@ -78,12 +133,30 @@ impl RenderModifier for SizeOverLifetimeModifier {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct BillboardModifier;
 
+#[typetag::serde]
 impl Modifier for BillboardModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Render
+    }
+
+    fn render(&self) -> Option<&dyn RenderModifier> {
+        Some(self)
+    }
+
+    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl RenderModifier for BillboardModifier {
     fn apply(&self, render_layout: &mut RenderLayout) {
         render_layout.billboard = true;

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -1,6 +1,7 @@
 //! Modifiers to influence the rendering of each particle.
 
-use bevy::prelude::*;
+use bevy::{asset::HandleId, prelude::*};
+use serde::{Deserialize, Serialize};
 
 use crate::{Attribute, Gradient, Modifier, RenderLayout};
 
@@ -11,10 +12,18 @@ pub trait RenderModifier: Modifier {
 }
 
 /// A modifier modulating each particle's color by sampling a texture.
-#[derive(Default, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ParticleTextureModifier {
     /// The texture image to modulate the particle color with.
-    pub texture: Handle<Image>,
+    pub texture: HandleId,
+}
+
+impl Default for ParticleTextureModifier {
+    fn default() -> Self {
+        Self {
+            texture: HandleId::default::<Image>(),
+        }
+    }
 }
 
 impl Modifier for ParticleTextureModifier {
@@ -31,7 +40,7 @@ impl RenderModifier for ParticleTextureModifier {
 
 /// A modifier modulating each particle's color over its lifetime with a
 /// gradient curve.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ColorOverLifetimeModifier {
     /// The color gradient defining the particle color based on its lifetime.
     pub gradient: Gradient<Vec4>,
@@ -51,7 +60,7 @@ impl RenderModifier for ColorOverLifetimeModifier {
 
 /// A modifier modulating each particle's size over its lifetime with a gradient
 /// curve.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct SizeOverLifetimeModifier {
     /// The size gradient defining the particle size based on its lifetime.
     pub gradient: Gradient<Vec2>,
@@ -70,7 +79,7 @@ impl RenderModifier for SizeOverLifetimeModifier {
 }
 
 /// Reorients the vertices to always face the camera when rendering.
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct BillboardModifier;
 
 impl Modifier for BillboardModifier {
@@ -93,10 +102,8 @@ mod tests {
 
     #[test]
     fn mod_particle_texture() {
-        let texture = Handle::weak(HandleId::default::<Image>());
-        let modifier = ParticleTextureModifier {
-            texture: texture.clone(),
-        };
+        let texture = HandleId::default::<Image>();
+        let modifier = ParticleTextureModifier { texture };
 
         let mut layout = RenderLayout::default();
         modifier.apply(&mut layout);

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -12,6 +12,34 @@ pub trait RenderModifier: Modifier {
     fn apply(&self, render_layout: &mut RenderLayout);
 }
 
+/// Macro to implement the [`Modifier`] trait for a render modifier.
+macro_rules! impl_mod_render {
+    ($t:ty, $attrs:expr) => {
+        #[typetag::serde]
+        impl Modifier for $t {
+            fn context(&self) -> ModifierContext {
+                ModifierContext::Render
+            }
+
+            fn render(&self) -> Option<&dyn RenderModifier> {
+                Some(self)
+            }
+
+            fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+                Some(self)
+            }
+
+            fn attributes(&self) -> &[&'static Attribute] {
+                $attrs
+            }
+
+            fn boxed_clone(&self) -> BoxedModifier {
+                Box::new(self.clone())
+            }
+        }
+    };
+}
+
 /// A modifier modulating each particle's color by sampling a texture.
 #[derive(Default, Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ParticleTextureModifier {
@@ -23,28 +51,7 @@ pub struct ParticleTextureModifier {
     pub texture: Handle<Image>,
 }
 
-#[typetag::serde]
-impl Modifier for ParticleTextureModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Render
-    }
-
-    fn render(&self) -> Option<&dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[] // TODO - should require some UV maybe?
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(self.clone())
-    }
-}
+impl_mod_render!(ParticleTextureModifier, &[]); // TODO - should require some UV maybe?
 
 #[typetag::serde]
 impl RenderModifier for ParticleTextureModifier {
@@ -61,28 +68,7 @@ pub struct ColorOverLifetimeModifier {
     pub gradient: Gradient<Vec4>,
 }
 
-#[typetag::serde]
-impl Modifier for ColorOverLifetimeModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Render
-    }
-
-    fn render(&self) -> Option<&dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(self.clone())
-    }
-}
+impl_mod_render!(ColorOverLifetimeModifier, &[]);
 
 #[typetag::serde]
 impl RenderModifier for ColorOverLifetimeModifier {
@@ -99,28 +85,7 @@ pub struct SizeOverLifetimeModifier {
     pub gradient: Gradient<Vec2>,
 }
 
-#[typetag::serde]
-impl Modifier for SizeOverLifetimeModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Render
-    }
-
-    fn render(&self) -> Option<&dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(self.clone())
-    }
-}
+impl_mod_render!(SizeOverLifetimeModifier, &[]);
 
 #[typetag::serde]
 impl RenderModifier for SizeOverLifetimeModifier {
@@ -133,28 +98,7 @@ impl RenderModifier for SizeOverLifetimeModifier {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct BillboardModifier;
 
-#[typetag::serde]
-impl Modifier for BillboardModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Render
-    }
-
-    fn render(&self) -> Option<&dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::POSITION]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_render!(BillboardModifier, &[Attribute::POSITION]);
 
 #[typetag::serde]
 impl RenderModifier for BillboardModifier {

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -21,11 +21,11 @@ macro_rules! impl_mod_render {
                 ModifierContext::Render
             }
 
-            fn render(&self) -> Option<&dyn RenderModifier> {
+            fn as_render(&self) -> Option<&dyn RenderModifier> {
                 Some(self)
             }
 
-            fn render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+            fn as_render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
                 Some(self)
             }
 

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -1,6 +1,6 @@
 //! Modifiers to influence the rendering of each particle.
 
-use bevy::{asset::HandleId, prelude::*};
+use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{Attribute, Gradient, Modifier, RenderLayout};
@@ -12,23 +12,19 @@ pub trait RenderModifier: Modifier {
 }
 
 /// A modifier modulating each particle's color by sampling a texture.
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ParticleTextureModifier {
     /// The texture image to modulate the particle color with.
-    pub texture: HandleId,
-}
-
-impl Default for ParticleTextureModifier {
-    fn default() -> Self {
-        Self {
-            texture: HandleId::default::<Image>(),
-        }
-    }
+    #[serde(skip)]
+    // TODO - Clarify if Modifier needs to be serializable, or we need another on-disk
+    // representation... NOTE - Need to keep a strong handle here, nothing else will keep that
+    // texture loaded currently.
+    pub texture: Handle<Image>,
 }
 
 impl Modifier for ParticleTextureModifier {
     fn attributes(&self) -> &[&'static Attribute] {
-        &[]
+        &[] // TODO - should require some UV maybe?
     }
 }
 
@@ -96,14 +92,14 @@ impl RenderModifier for BillboardModifier {
 
 #[cfg(test)]
 mod tests {
-    use bevy::asset::HandleId;
-
     use super::*;
 
     #[test]
     fn mod_particle_texture() {
-        let texture = HandleId::default::<Image>();
-        let modifier = ParticleTextureModifier { texture };
+        let texture = Handle::<Image>::default();
+        let modifier = ParticleTextureModifier {
+            texture: texture.clone(),
+        };
 
         let mut layout = RenderLayout::default();
         modifier.apply(&mut layout);

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -5,10 +5,14 @@
 
 use bevy::prelude::*;
 
-use crate::UpdateLayout;
+use crate::{Attribute, UpdateLayout};
 
 /// Trait to customize the updating of existing particles each frame.
 pub trait UpdateModifier {
+    /// Get the list of dependent attributes required for this modifier to be
+    /// used.
+    fn attributes(&self) -> &[&'static Attribute];
+
     /// Apply the modifier to the update layout of the effect instance.
     fn apply(&self, update_layout: &mut UpdateLayout);
 }
@@ -23,6 +27,10 @@ pub struct AccelModifier {
 }
 
 impl UpdateModifier for AccelModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[Attribute::VELOCITY]
+    }
+
     fn apply(&self, layout: &mut UpdateLayout) {
         layout.accel = self.accel;
     }
@@ -139,6 +147,10 @@ impl ForceFieldModifier {
 }
 
 impl UpdateModifier for ForceFieldModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[Attribute::POSITION, Attribute::VELOCITY]
+    }
+
     fn apply(&self, layout: &mut UpdateLayout) {
         layout.force_field = self.sources;
     }
@@ -161,6 +173,10 @@ impl LinearDragModifier {
 }
 
 impl UpdateModifier for LinearDragModifier {
+    fn attributes(&self) -> &[&'static Attribute] {
+        &[Attribute::VELOCITY]
+    }
+
     fn apply(&self, layout: &mut UpdateLayout) {
         layout.drag_coefficient = self.drag;
     }

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -32,6 +32,34 @@ pub trait UpdateModifier: Modifier {
     fn apply(&self, context: &mut UpdateContext);
 }
 
+/// Macro to implement the [`Modifier`] trait for an update modifier.
+macro_rules! impl_mod_update {
+    ($t:ty, $attrs:expr) => {
+        #[typetag::serde]
+        impl Modifier for $t {
+            fn context(&self) -> ModifierContext {
+                ModifierContext::Update
+            }
+
+            fn update(&self) -> Option<&dyn UpdateModifier> {
+                Some(self)
+            }
+
+            fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
+                Some(self)
+            }
+
+            fn attributes(&self) -> &[&'static Attribute] {
+                $attrs
+            }
+
+            fn boxed_clone(&self) -> BoxedModifier {
+                Box::new(*self)
+            }
+        }
+    };
+}
+
 /// Constant value or reference to a named property.
 ///
 /// This enumeration either directly stores a constant value assigned at
@@ -246,28 +274,7 @@ impl ForceFieldModifier {
     }
 }
 
-#[typetag::serde]
-impl Modifier for ForceFieldModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Update
-    }
-
-    fn update(&self) -> Option<&dyn UpdateModifier> {
-        Some(self)
-    }
-
-    fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::POSITION, Attribute::VELOCITY]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_update!(ForceFieldModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
 
 #[typetag::serde]
 impl UpdateModifier for ForceFieldModifier {
@@ -295,28 +302,7 @@ impl LinearDragModifier {
     }
 }
 
-#[typetag::serde]
-impl Modifier for LinearDragModifier {
-    fn context(&self) -> ModifierContext {
-        ModifierContext::Update
-    }
-
-    fn update(&self) -> Option<&dyn UpdateModifier> {
-        Some(self)
-    }
-
-    fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
-        Some(self)
-    }
-
-    fn attributes(&self) -> &[&'static Attribute] {
-        &[Attribute::VELOCITY]
-    }
-
-    fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(*self)
-    }
-}
+impl_mod_update!(LinearDragModifier, &[Attribute::VELOCITY]);
 
 #[typetag::serde]
 impl UpdateModifier for LinearDragModifier {

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -5,14 +5,10 @@
 
 use bevy::prelude::*;
 
-use crate::{Attribute, UpdateLayout};
+use crate::{Attribute, Modifier, UpdateLayout};
 
 /// Trait to customize the updating of existing particles each frame.
-pub trait UpdateModifier {
-    /// Get the list of dependent attributes required for this modifier to be
-    /// used.
-    fn attributes(&self) -> &[&'static Attribute];
-
+pub trait UpdateModifier: Modifier {
     /// Apply the modifier to the update layout of the effect instance.
     fn apply(&self, update_layout: &mut UpdateLayout);
 }
@@ -26,11 +22,13 @@ pub struct AccelModifier {
     pub accel: Vec3,
 }
 
-impl UpdateModifier for AccelModifier {
+impl Modifier for AccelModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::VELOCITY]
     }
+}
 
+impl UpdateModifier for AccelModifier {
     fn apply(&self, layout: &mut UpdateLayout) {
         layout.accel = self.accel;
     }
@@ -146,11 +144,13 @@ impl ForceFieldModifier {
     }
 }
 
-impl UpdateModifier for ForceFieldModifier {
+impl Modifier for ForceFieldModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+}
 
+impl UpdateModifier for ForceFieldModifier {
     fn apply(&self, layout: &mut UpdateLayout) {
         layout.force_field = self.sources;
     }
@@ -172,11 +172,13 @@ impl LinearDragModifier {
     }
 }
 
-impl UpdateModifier for LinearDragModifier {
+impl Modifier for LinearDragModifier {
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::VELOCITY]
     }
+}
 
+impl UpdateModifier for LinearDragModifier {
     fn apply(&self, layout: &mut UpdateLayout) {
         layout.drag_coefficient = self.drag;
     }

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -11,13 +11,18 @@ use crate::{
 };
 
 /// Particle update shader code generation context.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)] // Eq
 pub struct UpdateContext {
     /// Main particle update code, which needs to update the fields of the
     /// `particle` struct instance.
     pub update_code: String,
     /// Extra functions emitted at top level, which `update_code` can call.
     pub update_extra: String,
+
+    //TEMP
+    /// Array of force field components with a maximum number of components
+    /// determined by [`ForceFieldSource::MAX_SOURCES`].
+    pub force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
 }
 
 /// Trait to customize the updating of existing particles each frame.
@@ -264,8 +269,11 @@ impl Modifier for ForceFieldModifier {
 
 #[typetag::serde]
 impl UpdateModifier for ForceFieldModifier {
-    fn apply(&self, _context: &mut UpdateContext) {
-        //layout.force_field = self.sources;
+    fn apply(&self, context: &mut UpdateContext) {
+        context.update_code += include_str!("../render/force_field_code.wgsl");
+
+        //TEMP
+        context.force_field = self.sources;
     }
 }
 

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -355,7 +355,8 @@ mod tests {
         modifier.apply(&mut context);
 
         // force_field_code.wgsl is too big
-        //assert!(context.update_code.contains(&include_str!("../render/force_field_code.wgsl")));
+        //assert!(context.update_code.contains(&include_str!("../render/
+        // force_field_code.wgsl")));
     }
 
     #[test]

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -6,7 +6,9 @@
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{graph::Value, Attribute, Modifier, Property, ToWgslString};
+use crate::{
+    graph::Value, Attribute, BoxedModifier, Modifier, ModifierContext, Property, ToWgslString,
+};
 
 /// Particle update shader code generation context.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -19,6 +21,7 @@ pub struct UpdateContext {
 }
 
 /// Trait to customize the updating of existing particles each frame.
+#[typetag::serde]
 pub trait UpdateModifier: Modifier {
     /// Append the update code.
     fn apply(&self, context: &mut UpdateContext);
@@ -82,9 +85,26 @@ impl AccelModifier {
     }
 }
 
+#[typetag::serde]
 impl Modifier for AccelModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Update
+    }
+
+    fn update(&self) -> Option<&dyn UpdateModifier> {
+        Some(self)
+    }
+
+    fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::VELOCITY]
+    }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(self.clone())
     }
 
     fn resolve_properties(&mut self, properties: &[Property]) {
@@ -99,6 +119,7 @@ impl Modifier for AccelModifier {
     }
 }
 
+#[typetag::serde]
 impl UpdateModifier for AccelModifier {
     fn apply(&self, context: &mut UpdateContext) {
         context.update_code += &format!(
@@ -218,12 +239,30 @@ impl ForceFieldModifier {
     }
 }
 
+#[typetag::serde]
 impl Modifier for ForceFieldModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Update
+    }
+
+    fn update(&self) -> Option<&dyn UpdateModifier> {
+        Some(self)
+    }
+
+    fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::POSITION, Attribute::VELOCITY]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl UpdateModifier for ForceFieldModifier {
     fn apply(&self, _context: &mut UpdateContext) {
         //layout.force_field = self.sources;
@@ -246,12 +285,30 @@ impl LinearDragModifier {
     }
 }
 
+#[typetag::serde]
 impl Modifier for LinearDragModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Update
+    }
+
+    fn update(&self) -> Option<&dyn UpdateModifier> {
+        Some(self)
+    }
+
+    fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
+        Some(self)
+    }
+
     fn attributes(&self) -> &[&'static Attribute] {
         &[Attribute::VELOCITY]
     }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
 }
 
+#[typetag::serde]
 impl UpdateModifier for LinearDragModifier {
     fn apply(&self, context: &mut UpdateContext) {
         context.update_code += &format!(

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -4,6 +4,7 @@
 //! update compute shader.
 
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{Attribute, Modifier, UpdateLayout};
 
@@ -15,7 +16,7 @@ pub trait UpdateModifier: Modifier {
 
 /// A modifier to apply a constant acceleration to all particles each frame.
 /// Used to simulate gravity.
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct AccelModifier {
     /// The constant acceleration to apply to all particles in the effect each
     /// frame.
@@ -40,7 +41,7 @@ impl UpdateModifier for AccelModifier {
 /// position, with a decreasing intensity the further away from the source the
 /// particle is. This force is added to the one(s) of all the other active
 /// sources of a [`ForceFieldModifier`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ForceFieldSource {
     /// Position of the source.
     pub position: Vec3,
@@ -91,7 +92,7 @@ impl ForceFieldSource {
 /// field is made up of [`ForceFieldSource`]s.
 ///
 /// The maximum number of sources is [`ForceFieldSource::MAX_SOURCES`].
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ForceFieldModifier {
     /// Array of force field sources.
     ///
@@ -158,7 +159,7 @@ impl UpdateModifier for ForceFieldModifier {
 
 /// A modifier to apply a linear drag force to all particles each frame. The
 /// force slows down the particles without changing their direction.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct LinearDragModifier {
     /// Drag coefficient. Higher values increase the drag force, and
     /// consequently decrease the particle's speed faster.

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -41,11 +41,11 @@ macro_rules! impl_mod_update {
                 ModifierContext::Update
             }
 
-            fn update(&self) -> Option<&dyn UpdateModifier> {
+            fn as_update(&self) -> Option<&dyn UpdateModifier> {
                 Some(self)
             }
 
-            fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
+            fn as_update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
                 Some(self)
             }
 
@@ -126,11 +126,11 @@ impl Modifier for AccelModifier {
         ModifierContext::Update
     }
 
-    fn update(&self) -> Option<&dyn UpdateModifier> {
+    fn as_update(&self) -> Option<&dyn UpdateModifier> {
         Some(self)
     }
 
-    fn update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
+    fn as_update_mut(&mut self) -> Option<&mut dyn UpdateModifier> {
         Some(self)
     }
 

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -274,7 +274,10 @@ impl ForceFieldModifier {
     }
 }
 
-impl_mod_update!(ForceFieldModifier, &[Attribute::POSITION, Attribute::VELOCITY]);
+impl_mod_update!(
+    ForceFieldModifier,
+    &[Attribute::POSITION, Attribute::VELOCITY]
+);
 
 #[typetag::serde]
 impl UpdateModifier for ForceFieldModifier {

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -45,6 +45,8 @@ pub enum ValueOrProperty {
     Property(String),
     /// Reference to a named property the value is derived from, resolved to the
     /// index of that property in the owning [`EffectAsset`].
+    ///
+    /// [`EffectAsset`]: crate::EffectAsset
     ResolvedProperty((usize, String)),
 }
 

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -331,75 +331,32 @@ impl UpdateModifier for LinearDragModifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    //use crate::test_utils::*;
 
-    // #[test]
-    // fn mod_accel() {
-    //     let accel = Vec3 {
-    //         x: 1.,
-    //         y: 2.,
-    //         z: 3.,
-    //     };
-    //     let modifier = AccelModifier { accel };
+    #[test]
+    fn mod_accel() {
+        let accel = Vec3::new(1., 2., 3.);
+        let modifier = AccelModifier::constant(accel);
 
-    //     let mut layout = UpdateLayout::default();
-    //     modifier.apply(&mut layout);
+        let mut context = UpdateContext::default();
+        modifier.apply(&mut context);
 
-    //     assert_eq!(layout.accel, accel);
-    // }
+        assert!(context.update_code.contains(&accel.to_wgsl_string()));
+    }
 
-    // #[test]
-    // fn mod_force_field() {
-    //     let position = Vec3 {
-    //         x: 1.,
-    //         y: 2.,
-    //         z: 3.,
-    //     };
-    //     let mut sources = [ForceFieldSource::default(); 16];
-    //     sources[0].position = position;
-    //     sources[0].mass = 1.;
-    //     let modifier = ForceFieldModifier { sources };
+    #[test]
+    fn mod_force_field() {
+        let position = Vec3::new(1., 2., 3.);
+        let mut sources = [ForceFieldSource::default(); 16];
+        sources[0].position = position;
+        sources[0].mass = 1.;
+        let modifier = ForceFieldModifier { sources };
 
-    //     let mut layout = UpdateLayout::default();
-    //     modifier.apply(&mut layout);
+        let mut context = UpdateContext::default();
+        modifier.apply(&mut context);
 
-    //     assert!(layout.force_field[0]
-    //         .position
-    //         .abs_diff_eq(sources[0].position, 1e-5));
-    // }
-
-    // #[test]
-    // fn mod_force_field_new() {
-    //     let modifier = ForceFieldModifier::new((0..10).map(|i| {
-    //         let position = Vec3 {
-    //             x: i as f32,
-    //             y: 0.,
-    //             z: 0.,
-    //         };
-    //         ForceFieldSource {
-    //             position,
-    //             mass: 1.,
-    //             ..default()
-    //         }
-    //     }));
-
-    //     let mut context = UpdateContext::default();
-    //     modifier.apply(&mut context);
-
-    //     for i in 0..16 {
-    //         assert!(layout.force_field[i].position.abs_diff_eq(
-    //             Vec3 {
-    //                 x: if i < 10 { i as f32 } else { 0. },
-    //                 y: 0.,
-    //                 z: 0.,
-    //             },
-    //             1e-5
-    //         ));
-
-    //         let mass = if i < 10 { 1. } else { 0. };
-    //         assert_approx_eq!(layout.force_field[i].mass, mass);
-    //     }
-    // }
+        // force_field_code.wgsl is too big
+        //assert!(context.update_code.contains(&include_str!("../render/force_field_code.wgsl")));
+    }
 
     #[test]
     #[should_panic]

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -24,7 +24,7 @@ pub struct Property {
 
 impl Property {
     /// Create a new property.
-    pub fn new(name: impl Into<String>, default_value: Value) -> Self {
+    pub(crate) fn new(name: impl Into<String>, default_value: Value) -> Self {
         Self {
             name: name.into(),
             default_value,
@@ -123,7 +123,7 @@ impl PropertyLayout {
     }
 
     /// Create a new collection from an iterator.
-    pub fn new<'a>(iter: impl Iterator<Item = &'a Property>) -> Self {
+    pub(crate) fn new<'a>(iter: impl Iterator<Item = &'a Property>) -> Self {
         let mut properties = iter.collect::<Vec<_>>();
 
         // Sort by size

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -359,11 +359,5 @@ mod tests {
         println!("property: {:?}", s);
         let p_serde: Property = ron::from_str(&s).unwrap();
         assert_eq!(p_serde, p);
-
-        // let b: BoxedExpr = Box::new(p);
-        // let s = ron::to_string(&b).unwrap();
-        // println!("boxed property: {:?}", s);
-        // let b_serde: BoxedExpr = ron::from_str(&s).unwrap();
-        // assert!(!b_serde.is_const());
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,0 +1,341 @@
+//! Effect properties.
+//!
+//! Properties are named variables mutable at runtime. Use properties to ensure
+//! a value from a modifier can be dynamically mutated while the effect is
+//! instantiated, without having to destroy and re-create a new effect. Using
+//! properties is a bit more costly than using a hard-coded constant, so avoid
+//! using properties if a value doesn't need to change dynamically at runtime,
+//! or changes very infrequently. In general any value accepting a property
+//! reference also alternatively accepts a constant.
+
+use std::num::NonZeroU64;
+
+use bevy::reflect::{FromReflect, Reflect};
+use serde::{Deserialize, Serialize};
+
+use crate::{graph::Value, next_multiple_of, ToWgslString, ValueType};
+
+/// Effect property.
+#[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+pub struct Property {
+    name: String,
+    default_value: Value,
+}
+
+impl Property {
+    /// Create a new property.
+    pub fn new(name: impl Into<String>, default_value: Value) -> Self {
+        Self {
+            name: name.into(),
+            default_value,
+        }
+    }
+
+    /// The property name.
+    ///
+    /// The name of a property is unique within a given effect, and corresponds
+    /// to the name of the variable in the generated WGSL code.
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    /// The property type.
+    pub fn value_type(&self) -> ValueType {
+        self.default_value.value_type()
+    }
+
+    /// The property size, in bytes.
+    ///
+    /// This is a shortcut for `self.value_type().size()`.
+    pub fn size(&self) -> usize {
+        self.default_value.value_type().size()
+    }
+}
+
+impl ToWgslString for Property {
+    fn to_wgsl_string(&self) -> String {
+        format!("properties.{}", self.name)
+    }
+}
+
+#[derive(Clone)]
+struct PropertyLayoutEntry {
+    property: Property,
+    offset: u32,
+}
+
+impl PartialEq for PropertyLayoutEntry {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare property's name and type, but not default value
+        self.property.name() == other.property.name()
+            && self.property.value_type() == other.property.value_type()
+            && self.offset == other.offset
+    }
+}
+
+impl Eq for PropertyLayoutEntry {}
+
+impl std::hash::Hash for PropertyLayoutEntry {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hash property's name and type, but not default value
+        self.property.name().hash(state);
+        self.property.value_type().hash(state);
+        self.offset.hash(state);
+    }
+}
+
+impl std::fmt::Debug for PropertyLayoutEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // "(+offset) name: type"
+        f.write_fmt(format_args!(
+            "(+{}) {}: {}",
+            self.offset,
+            self.property.name(),
+            self.property.value_type().to_wgsl_string(),
+        ))
+    }
+}
+
+/// Layout of properties for an effect.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct PropertyLayout {
+    layout: Vec<PropertyLayoutEntry>,
+}
+
+impl PropertyLayout {
+    /// Create a new empty property layout.
+    pub fn empty() -> Self {
+        Self { layout: vec![] }
+    }
+
+    /// Create a new collection from an iterator.
+    pub fn new<'a>(iter: impl Iterator<Item = &'a Property>) -> Self {
+        let mut properties = iter.collect::<Vec<_>>();
+
+        // Sort by size
+        properties.sort_unstable_by_key(|prop| prop.size());
+        let properties = properties; // un-mut
+
+        let mut layout = vec![];
+        let mut offset = 0;
+
+        // Enqueue all Float4, which are already aligned
+        let index4 = properties.partition_point(|prop| prop.size() < 16);
+        for i in index4..properties.len() {
+            let prop = properties[i];
+            let entry = PropertyLayoutEntry {
+                property: prop.clone(),
+                offset,
+            };
+            offset += 16;
+            layout.push(entry);
+        }
+
+        // Enqueue paired { Float3 + Float1 }
+        let index2 = properties.partition_point(|prop| prop.size() < 8);
+        let num1 = index2;
+        let index3 = properties.partition_point(|prop| prop.size() < 12);
+        let num2 = (index2..index3).len();
+        let num3 = (index3..index4).len();
+        let num_pairs = num1.min(num3);
+        for i in 0..num_pairs {
+            // Float3
+            let prop = properties[index3 + i];
+            let entry = PropertyLayoutEntry {
+                property: prop.clone(),
+                offset,
+            };
+            offset += 12;
+            layout.push(entry);
+
+            // Float
+            let prop = properties[i];
+            let entry = PropertyLayoutEntry {
+                property: prop.clone(),
+                offset,
+            };
+            offset += 4;
+            layout.push(entry);
+        }
+        let index1 = num_pairs;
+        let index3 = index3 + num_pairs;
+        let num1 = num1 - num_pairs;
+        let num3 = num3 - num_pairs;
+
+        // Enqueue paired { Float2 + Float2 }
+        for i in 0..(num2 / 2) {
+            for j in 0..2 {
+                let prop = properties[index2 + i * 2 + j];
+                let entry = PropertyLayoutEntry {
+                    property: prop.clone(),
+                    offset,
+                };
+                offset += 8;
+                layout.push(entry);
+            }
+        }
+        let index2 = index2 + (num2 / 2) * 2;
+        let num2 = num2 % 2;
+
+        // Enqueue { Float3, Float2 } or { Float2, Float1 }
+        if num3 > num1 {
+            // Float1 is done, some Float3 left, and at most one Float2
+            debug_assert_eq!(num1, 0);
+
+            // Try 3/3/2, fallback to 3/2
+            let num3head = if num2 > 0 {
+                debug_assert_eq!(num2, 1);
+                let num3head = num3.min(2);
+                for i in 0..num3head {
+                    let prop = properties[index3 + i];
+                    let entry = PropertyLayoutEntry {
+                        property: prop.clone(),
+                        offset,
+                    };
+                    offset += 12;
+                    layout.push(entry);
+                }
+                let prop = properties[index2];
+                let entry = PropertyLayoutEntry {
+                    property: prop.clone(),
+                    offset,
+                };
+                offset += 8;
+                layout.push(entry);
+                num3head
+            } else {
+                0
+            };
+
+            // End with remaining Float3
+            for i in num3head..num3 {
+                let prop = properties[index3 + i];
+                let entry = PropertyLayoutEntry {
+                    property: prop.clone(),
+                    offset,
+                };
+                offset += 12;
+                layout.push(entry);
+            }
+        } else {
+            // Float3 is done, some Float1 left, and at most one Float2
+            debug_assert_eq!(num3, 0);
+
+            // Emit the single Float2 now if any
+            if num2 > 0 {
+                debug_assert_eq!(num2, 1);
+                let prop = properties[index2];
+                let entry = PropertyLayoutEntry {
+                    property: prop.clone(),
+                    offset,
+                };
+                offset += 8;
+                layout.push(entry);
+            }
+
+            // End with remaining Float1
+            for i in 0..num1 {
+                let prop = properties[index1 + i];
+                let entry = PropertyLayoutEntry {
+                    property: prop.clone(),
+                    offset,
+                };
+                offset += 4;
+                layout.push(entry);
+            }
+        }
+
+        Self { layout }
+    }
+
+    /// Returns `true` if the layout contains no properties.
+    pub fn is_empty(&self) -> bool {
+        self.layout.is_empty()
+    }
+
+    /// Get the size of the layout in bytes.
+    pub fn size(&self) -> u32 {
+        if self.layout.is_empty() {
+            0
+        } else {
+            let last_entry = self.layout.last().unwrap();
+            last_entry.offset + last_entry.property.size() as u32
+        }
+    }
+
+    /// Get the alignment of the layout in bytes.
+    pub fn align(&self) -> usize {
+        if self.layout.is_empty() {
+            0
+        } else {
+            self.layout
+                .iter()
+                .map(|entry| entry.property.value_type().align())
+                .max()
+                .unwrap()
+        }
+    }
+
+    /// Minimum binding size in bytes.
+    ///
+    /// This corresponds to the stride of the properties struct in WGSL when
+    /// contained inside an array.
+    pub fn min_binding_size(&self) -> NonZeroU64 {
+        assert!(!self.layout.is_empty());
+        let size = self.size() as usize;
+        let align = self.align();
+        NonZeroU64::new(next_multiple_of(size, align) as u64).unwrap()
+    }
+
+    /// Generate the WGSL attribute code corresponding to the layout.
+    pub fn generate_code(&self) -> String {
+        //assert!(self.layout.is_sorted_by_key(|entry| entry.offset));
+        let content = self
+            .layout
+            .iter()
+            .map(|entry| {
+                format!(
+                    "    {}: {},",
+                    entry.property.name(),
+                    entry.property.value_type().to_wgsl_string()
+                )
+            })
+            .fold(String::new(), |mut a, b| {
+                a.reserve(b.len() + 1);
+                a.push_str(&b);
+                a.push('\n');
+                a
+            });
+        if content.is_empty() {
+            String::new()
+        } else {
+            format!("struct Properties {{\n{}\n}}\n", content)
+        }
+    }
+}
+
+impl Default for PropertyLayout {
+    fn default() -> Self {
+        PropertyLayout::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde() {
+        let p = Property::new("my_prop", Value::Float(3.0).into());
+        let s = ron::to_string(&p).unwrap();
+        println!("property: {:?}", s);
+        let p_serde: Property = ron::from_str(&s).unwrap();
+        assert_eq!(p_serde, p);
+
+        // let b: BoxedExpr = Box::new(p);
+        // let s = ron::to_string(&b).unwrap();
+        // println!("boxed property: {:?}", s);
+        // let b_serde: BoxedExpr = ron::from_str(&s).unwrap();
+        // assert!(!b_serde.is_const());
+    }
+}

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -39,6 +39,11 @@ impl Property {
         self.name.as_ref()
     }
 
+    /// The default value of the property.
+    pub fn default_value(&self) -> &Value {
+        &self.default_value
+    }
+
     /// The property type.
     pub fn value_type(&self) -> ValueType {
         self.default_value.value_type()
@@ -56,6 +61,15 @@ impl ToWgslString for Property {
     fn to_wgsl_string(&self) -> String {
         format!("properties.{}", self.name)
     }
+}
+
+/// Instance of a [`Property`] owned by a specific [`ParticleEffect`] component.
+#[derive(Debug, Clone, Reflect, FromReflect)]
+pub(crate) struct PropertyInstance {
+    /// The property definition, including its default value.
+    pub def: Property,
+    /// The current runtime value of the property.
+    pub value: Value,
 }
 
 #[derive(Clone)]
@@ -311,6 +325,20 @@ impl PropertyLayout {
         } else {
             format!("struct Properties {{\n{}\n}}\n", content)
         }
+    }
+
+    /// Get the offset for the property with the given name.
+    pub(crate) fn offset(&self, name: &str) -> Option<u32> {
+        self.layout
+            .iter()
+            .filter_map(|entry| {
+                if entry.property.name == name {
+                    Some(entry.offset)
+                } else {
+                    None
+                }
+            })
+            .next()
     }
 }
 

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -604,9 +604,11 @@ impl EffectCache {
 
 #[cfg(all(test, feature = "gpu_tests"))]
 mod gpu_tests {
+    use std::borrow::Cow;
+
     use bevy::asset::HandleId;
 
-    use crate::{test_utils::MockRenderer, Attribute};
+    use crate::{test_utils::MockRenderer, Attribute, ValueType};
 
     use super::*;
 
@@ -639,20 +641,18 @@ mod gpu_tests {
         assert!(slice2 > slice3);
     }
 
+    const F4A: &'static Attribute = &Attribute::new(Cow::Borrowed("F4A"), ValueType::Float4);
+    const F4B: &'static Attribute = &Attribute::new(Cow::Borrowed("F4B"), ValueType::Float4);
+    const F4C: &'static Attribute = &Attribute::new(Cow::Borrowed("F4C"), ValueType::Float4);
+    const F4D: &'static Attribute = &Attribute::new(Cow::Borrowed("F4D"), ValueType::Float4);
+
     #[test]
     fn slice_ref() {
-        let l16 = ParticleLayout::new().add(Attribute::HDR_COLOR).build();
+        let l16 = ParticleLayout::new().add(F4A).build();
         assert_eq!(16, l16.size());
-        let l32 = ParticleLayout::new()
-            .add(Attribute::HDR_COLOR)
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .build();
+        let l32 = ParticleLayout::new().add(F4A).add(F4B).build();
         assert_eq!(32, l32.size());
-        let l48 = ParticleLayout::new()
-            .add(Attribute::HDR_COLOR)
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .build();
+        let l48 = ParticleLayout::new().add(F4A).add(F4B).add(F4C).build();
         assert_eq!(48, l48.size());
         for (range, particle_layout, len, byte_size) in [
             (0..0, &l16, 0, 0),
@@ -676,10 +676,10 @@ mod gpu_tests {
         //let render_queue = renderer.queue();
 
         let l64 = ParticleLayout::new()
-            .add(Attribute::HDR_COLOR)
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
+            .add(F4A)
+            .add(F4B)
+            .add(F4C)
+            .add(F4D)
             .build();
         assert_eq!(64, l64.size());
 
@@ -749,10 +749,10 @@ mod gpu_tests {
         //let render_queue = renderer.queue();
 
         let l64 = ParticleLayout::new()
-            .add(Attribute::HDR_COLOR)
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
+            .add(F4A)
+            .add(F4B)
+            .add(F4C)
+            .add(F4D)
             .build();
         assert_eq!(64, l64.size());
 
@@ -817,10 +817,7 @@ mod gpu_tests {
         let render_device = renderer.device();
         let render_queue = renderer.queue();
 
-        let l32 = ParticleLayout::new()
-            .add(Attribute::HDR_COLOR)
-            .add(Attribute::HDR_COLOR) // FIXME - Should be forbidden, currently isn't yet...
-            .build();
+        let l32 = ParticleLayout::new().add(F4A).add(F4B).build();
         assert_eq!(32, l32.size());
 
         let mut effect_cache = EffectCache::new(render_device);

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -132,7 +132,10 @@ impl EffectBuffer {
             particle_layout,
             particle_layout.min_binding_size().get(),
         );
+
         let capacity = capacity.max(Self::MIN_CAPACITY);
+        debug_assert!(capacity > 0);
+
         let particle_capacity_bytes: BufferAddress =
             capacity as u64 * particle_layout.min_binding_size().get();
         let particle_buffer = render_device.create_buffer(&BufferDescriptor {

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -134,7 +134,10 @@ impl EffectBuffer {
         );
 
         let capacity = capacity.max(Self::MIN_CAPACITY);
-        debug_assert!(capacity > 0, "Attempted to create a zero-sized effect buffer.");
+        debug_assert!(
+            capacity > 0,
+            "Attempted to create a zero-sized effect buffer."
+        );
 
         let particle_capacity_bytes: BufferAddress =
             capacity as u64 * particle_layout.min_binding_size().get();

--- a/src/render/force_field_code.wgsl
+++ b/src/render/force_field_code.wgsl
@@ -17,7 +17,7 @@
             break;
         }
 
-        let particle_to_point_source = vPos - spawner.force_field[kk].position;
+        let particle_to_point_source = (*particle).position - spawner.force_field[kk].position;
         let distance = length(particle_to_point_source);
         let unit_p2p = normalize(particle_to_point_source) ;
 
@@ -62,22 +62,20 @@
     // conform to a sphere of radius min_radius/2 by projecting the velocity vector
     // onto a plane that is tangent to the sphere.
     let eps = vec3<f32>(0.000001);
-    let projected_on_sphere = vVel - proj(unit_p2p_conformed + eps, vVel + eps);
-    let conformed_field = 
-        (1.0 - not_conformed_to_sphere) * normalize(projected_on_sphere) * length(vVel);
+    let projected_on_sphere = (*particle).velocity - proj(unit_p2p_conformed + eps, (*particle).velocity + eps);
+    let conformed_field = (1.0 - not_conformed_to_sphere) * normalize(projected_on_sphere) * length((*particle).velocity);
 
     // Euler integration
-    vVel = (vVel + (spawner.accel  + ff_acceleration) * sim_params.dt) 
-        * not_conformed_to_sphere + conformed_field;
+    (*particle).velocity = ((*particle).velocity + (spawner.accel  + ff_acceleration) * sim_params.dt) * not_conformed_to_sphere + conformed_field;
 
-    // let temp_vPos = vPos;
-    vPos = (vPos + (vVel * sim_params.dt));
+    // let temp_vPos = (*particle).position;
+    (*particle).position = (*particle).position + (*particle).velocity * sim_params.dt;
     
     // project on the sphere if within conforming distance
-    let pos_to_source = conforming_source - vPos ;
+    let pos_to_source = conforming_source - (*particle).position;
     let difference = length(pos_to_source) - conforming_radius;
-    vPos = vPos  + difference * normalize(pos_to_source ) * (1.0 - not_conformed_to_sphere) ;
+    (*particle).position = (*particle).position  + difference * normalize(pos_to_source) * (1.0 - not_conformed_to_sphere);
 
     // // commented because of the potential bug where dt could be zero, although the simulation
     // // works anyways, needs investigation
-    // vVel = (vPos - temp_vPos) / sim_params.dt;
+    // (*particle).velocity = ((*particle).position - temp_vPos) / sim_params.dt;

--- a/src/render/force_field_code.wgsl
+++ b/src/render/force_field_code.wgsl
@@ -73,10 +73,10 @@
     // // let temp_vPos = (*particle).position;
     // (*particle).position = (*particle).position + (*particle).velocity * sim_params.dt;
     
-    // // project on the sphere if within conforming distance
-    // let pos_to_source = conforming_source - (*particle).position;
-    // let difference = length(pos_to_source) - conforming_radius;
-    // (*particle).position = (*particle).position  + difference * normalize(pos_to_source) * (1.0 - not_conformed_to_sphere);
+    // project on the sphere if within conforming distance
+    let pos_to_source = conforming_source - (*particle).position;
+    let difference = length(pos_to_source) - conforming_radius;
+    (*particle).position = (*particle).position  + difference * normalize(pos_to_source) * (1.0 - not_conformed_to_sphere);
 
     // // // commented because of the potential bug where dt could be zero, although the simulation
     // // // works anyways, needs investigation

--- a/src/render/force_field_code.wgsl
+++ b/src/render/force_field_code.wgsl
@@ -66,16 +66,18 @@
     let conformed_field = (1.0 - not_conformed_to_sphere) * normalize(projected_on_sphere) * length((*particle).velocity);
 
     // Euler integration
-    (*particle).velocity = ((*particle).velocity + (spawner.accel  + ff_acceleration) * sim_params.dt) * not_conformed_to_sphere + conformed_field;
+    //(*particle).velocity = ((*particle).velocity + (spawner.accel  + ff_acceleration) * sim_params.dt) * not_conformed_to_sphere + conformed_field;
+    (*particle).velocity += ff_acceleration * sim_params.dt;
+    (*particle).velocity = (*particle).velocity * not_conformed_to_sphere + conformed_field; // TODO: lerp()
 
-    // let temp_vPos = (*particle).position;
-    (*particle).position = (*particle).position + (*particle).velocity * sim_params.dt;
+    // // let temp_vPos = (*particle).position;
+    // (*particle).position = (*particle).position + (*particle).velocity * sim_params.dt;
     
-    // project on the sphere if within conforming distance
-    let pos_to_source = conforming_source - (*particle).position;
-    let difference = length(pos_to_source) - conforming_radius;
-    (*particle).position = (*particle).position  + difference * normalize(pos_to_source) * (1.0 - not_conformed_to_sphere);
+    // // project on the sphere if within conforming distance
+    // let pos_to_source = conforming_source - (*particle).position;
+    // let difference = length(pos_to_source) - conforming_radius;
+    // (*particle).position = (*particle).position  + difference * normalize(pos_to_source) * (1.0 - not_conformed_to_sphere);
 
-    // // commented because of the potential bug where dt could be zero, although the simulation
-    // // works anyways, needs investigation
-    // (*particle).velocity = ((*particle).position - temp_vPos) / sim_params.dt;
+    // // // commented because of the potential bug where dt could be zero, although the simulation
+    // // // works anyways, needs investigation
+    // // (*particle).velocity = ((*particle).position - temp_vPos) / sim_params.dt;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1961,7 +1961,8 @@ pub(crate) fn prepare_effects(
 
         // extract the force field and turn it into a struct that is compliant with
         // GPU use, namely GpuForceFieldSource
-        let mut extracted_force_field = [GpuForceFieldSource::default(); ForceFieldSource::MAX_SOURCES];
+        let mut extracted_force_field =
+            [GpuForceFieldSource::default(); ForceFieldSource::MAX_SOURCES];
         for (i, ff) in extracted_effect.force_field.iter().enumerate() {
             extracted_force_field[i] = (*ff).into();
         }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1850,7 +1850,7 @@ pub(crate) fn prepare_effects(
                 tr[11],
             ],
             force_field: extracted_force_field,
-            seed: random::<u32>(),
+            seed: random::<u32>(), // FIXME - Probably bad to re-seed each time there's a change
             effect_index,
         };
         trace!("spawner_params = {:?}", spawner_params);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1028,12 +1028,12 @@ pub(crate) struct ExtractedEffect {
     pub update_shader: Handle<Shader>,
     /// Render shader.
     pub render_shader: Handle<Shader>,
-    /// Update position code.
-    pub position_code: String,
     /// Update force field code.
     pub force_field_code: String,
+    /// Update position code.
+    pub init_code: String,
     /// Update lifetime code.
-    pub lifetime_code: String,
+    pub init_extra: String,
     /// For 2D rendering, the Z coordinate used as the sort key. Ignored for 3D
     /// rendering.
     pub z_sort_key_2d: FloatOrd,
@@ -1194,9 +1194,9 @@ pub(crate) fn extract_effects(
         let spawn_count = effect.spawn_count;
         let accel = effect.accel;
         let force_field = effect.force_field;
-        let position_code = effect.position_code.clone();
         let force_field_code = effect.force_field_code.clone();
-        let lifetime_code = effect.lifetime_code.clone();
+        let init_code = effect.init_code.clone();
+        let init_extra = effect.init_extra.clone();
 
         // Check if asset is available, otherwise silently ignore
         let Some(asset) = effects.get(&effect.handle) else {
@@ -1245,9 +1245,9 @@ pub(crate) fn extract_effects(
                 init_shader,
                 update_shader,
                 render_shader,
-                position_code,
                 force_field_code,
-                lifetime_code,
+                init_code,
+                init_extra,
                 z_sort_key_2d,
             },
         );
@@ -1566,12 +1566,12 @@ pub(crate) struct EffectBatch {
     update_shader: Handle<Shader>,
     /// Configured shader used for the particle rendering of this batch.
     render_shader: Handle<Shader>,
-    /// Update position code.
-    position_code: String,
     /// Update force field code.
     force_field_code: String,
+    /// Update position code.
+    init_code: String,
     /// Update lifetime code.
-    lifetime_code: String,
+    init_extra: String,
     /// Init compute pipeline specialized for this batch.
     init_pipeline_id: CachedComputePipelineId,
     /// Update compute pipeline specialized for this batch.
@@ -1669,9 +1669,9 @@ pub(crate) fn prepare_effects(
     let mut start = 0;
     let mut end = 0;
     let mut num_emitted = 0;
-    let mut position_code = String::default();
     let mut force_field_code = String::default();
-    let mut lifetime_code = String::default();
+    let mut init_code = String::default();
+    let mut init_extra = String::default();
     let mut init_pipeline_id = CachedComputePipelineId::INVALID;
     let mut update_pipeline_id = CachedComputePipelineId::INVALID;
     let mut z_sort_key_2d = FloatOrd(f32::NAN);
@@ -1745,9 +1745,9 @@ pub(crate) fn prepare_effects(
                         init_shader: init_shader.clone(),
                         update_shader: update_shader.clone(),
                         render_shader: render_shader.clone(),
-                        position_code: position_code.clone(),
                         force_field_code: force_field_code.clone(),
-                        lifetime_code: lifetime_code.clone(),
+                        init_code: init_code.clone(),
+                        init_extra: init_extra.clone(),
                         init_pipeline_id,
                         update_pipeline_id,
                         z_sort_key_2d,
@@ -1815,14 +1815,14 @@ pub(crate) fn prepare_effects(
 
         trace!("particle_layout = {:?}", slice.particle_layout);
 
-        position_code = extracted_effect.position_code.clone();
-        trace!("position_code = {}", position_code);
-
         force_field_code = extracted_effect.force_field_code.clone();
         trace!("force_field_code = {}", force_field_code);
 
-        lifetime_code = extracted_effect.lifetime_code.clone();
-        trace!("lifetime_code = {}", lifetime_code);
+        init_code = extracted_effect.init_code.clone();
+        trace!("init_code = {}", init_code);
+
+        init_extra = extracted_effect.init_extra.clone();
+        trace!("init_extra = {}", init_extra);
 
         trace!("z_sort_key_2d = {:?}", z_sort_key_2d);
 
@@ -1890,9 +1890,9 @@ pub(crate) fn prepare_effects(
                     init_shader: init_shader.clone(),
                     update_shader: update_shader.clone(),
                     render_shader: render_shader.clone(),
-                    position_code: position_code.clone(),
                     force_field_code: force_field_code.clone(),
-                    lifetime_code: lifetime_code.clone(),
+                    init_code: init_code.clone(),
+                    init_extra: init_extra.clone(),
                     init_pipeline_id,
                     update_pipeline_id,
                     z_sort_key_2d,
@@ -1933,9 +1933,9 @@ pub(crate) fn prepare_effects(
             init_shader,
             update_shader,
             render_shader,
-            position_code,
             force_field_code,
-            lifetime_code,
+            init_code,
+            init_extra,
             init_pipeline_id,
             update_pipeline_id,
             z_sort_key_2d,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2659,7 +2659,7 @@ impl Draw<Transparent2d> for DrawEffects {
             pass.set_bind_group(
                 1,
                 effect_bind_groups
-                    .particle_init(effect_batch.buffer_index)
+                    .particle_render(effect_batch.buffer_index)
                     .unwrap(),
                 &[dispatch_indirect_offset],
             );
@@ -2686,13 +2686,19 @@ impl Draw<Transparent2d> for DrawEffects {
             let vertex_count = effects_meta.vertices.len() as u32;
             let particle_count = effect_batch.slice.end - effect_batch.slice.start;
 
+            let render_indirect_buffer = effects_meta.render_dispatch_buffer.buffer().unwrap();
+
+            let render_indirect_offset =
+                effects_meta.gpu_render_indirect_aligned_size.unwrap().get() as u64
+                    * effect_batch.buffer_index as u64;
             trace!(
-                "Draw {} particles with {} vertices per particle for batch from buffer #{}.",
+                "Draw {} particles with {} vertices per particle for batch from buffer #{} (render_indirect_offset={}).",
                 particle_count,
                 vertex_count,
-                effect_batch.buffer_index
+                effect_batch.buffer_index,
+                render_indirect_offset
             );
-            pass.draw(0..vertex_count, 0..particle_count);
+            pass.draw_indirect(render_indirect_buffer, render_indirect_offset);
         }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1221,7 +1221,7 @@ pub(crate) fn extract_effects(
                         .render_layout
                         .particle_texture
                         .clone()
-                        .map_or(HandleId::default::<Image>(), |handle| handle.id()),
+                        .unwrap_or(HandleId::default::<Image>()),
                     init_shader,
                     update_shader,
                     render_shader,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1214,7 +1214,8 @@ pub(crate) fn extract_effects(
             .render_layout
             .particle_texture
             .clone()
-            .unwrap_or(HandleId::default::<Image>());
+            .unwrap_or(Handle::<Image>::default())
+            .id();
 
         trace!(
             "Extracted instance of effect '{}' on entity {:?}: image_handle_id={:?}",

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -171,20 +171,16 @@ struct GpuSpawnerParams {
     /// spawn time, if the effect simulated in world space, or to all
     /// simulated particles if the effect is simulated in local space.
     transform: [f32; 12],
-    /// Global acceleration applied to all particles each frame.
-    /// TODO - This is NOT a spawner/emitter thing, but is a per-effect one.
-    /// Rename GpuSpawnerParams?
-    accel: Vec3,
     /// Number of particles to spawn this frame.
     spawn: i32,
-    /// Force field components. One GpuForceFieldSource takes up 32 bytes.
-    force_field: [GpuForceFieldSource; ForceFieldSource::MAX_SOURCES],
     /// Spawn seed, for randomized modifiers.
     seed: u32,
     /// Current number of used particles.
     count: i32,
     /// Index of the effect into the indirect dispatch and render buffers.
     effect_index: u32,
+    /// Force field components. One GpuForceFieldSource takes up 32 bytes.
+    force_field: [GpuForceFieldSource; ForceFieldSource::MAX_SOURCES],
 }
 
 // FIXME - min_storage_buffer_offset_alignment
@@ -1853,8 +1849,7 @@ pub(crate) fn prepare_effects(
                 tr[0], tr[1], tr[2], tr[3], tr[4], tr[5], tr[6], tr[7], tr[8], tr[9], tr[10],
                 tr[11],
             ],
-            accel: Vec3::ZERO,                  // TODO -  extracted_effect.accel,
-            force_field: extracted_force_field, // extracted_effect.force_field,
+            force_field: extracted_force_field,
             seed: random::<u32>(),
             effect_index,
         };

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -324,10 +324,8 @@ pub(crate) struct ParticlesInitPipeline {
     /// Render device the pipeline is attached to.
     render_device: RenderDevice,
     sim_params_layout: BindGroupLayout,
-    //particles_buffer_layout: BindGroupLayout,
     spawner_buffer_layout: BindGroupLayout,
     render_indirect_layout: BindGroupLayout,
-    //pipeline_layout: PipelineLayout,
 }
 
 impl FromWorld for ParticlesInitPipeline {
@@ -360,34 +358,6 @@ impl FromWorld for ParticlesInitPipeline {
                 }],
                 label: Some("hanabi:bind_group_layout:update_sim_params"),
             });
-
-        // trace!("GpuParticle: min_size={}", GpuParticle::min_size());
-        // let particles_buffer_layout =
-        //     render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        //         entries: &[
-        //             BindGroupLayoutEntry {
-        //                 binding: 0,
-        //                 visibility: ShaderStages::COMPUTE,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: false },
-        //                     has_dynamic_offset: true,
-        //                     min_binding_size: Some(GpuParticle::min_size()),
-        //                 },
-        //                 count: None,
-        //             },
-        //             BindGroupLayoutEntry {
-        //                 binding: 1,
-        //                 visibility: ShaderStages::COMPUTE,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: false },
-        //                     has_dynamic_offset: true,
-        //                     min_binding_size: BufferSize::new(12),
-        //                 },
-        //                 count: None,
-        //             },
-        //         ],
-        //         label: Some("hanabi:buffer_layout:init_particles"),
-        //     });
 
         trace!(
             "GpuSpawnerParams: min_size={}",
@@ -427,25 +397,11 @@ impl FromWorld for ParticlesInitPipeline {
                 label: Some("hanabi:bind_group_layout:init_render_indirect"),
             });
 
-        // let pipeline_layout =
-        // render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
-        //     label: Some("hanabi:pipeline_layout:init"),
-        //     bind_group_layouts: &[
-        //         &sim_params_layout,
-        //         &particles_buffer_layout,
-        //         &spawner_buffer_layout,
-        //         &render_indirect_layout,
-        //     ],
-        //     push_constant_ranges: &[],
-        // });
-
         Self {
             render_device: render_device.clone(),
             sim_params_layout,
-            //particles_buffer_layout,
             spawner_buffer_layout,
             render_indirect_layout,
-            //pipeline_layout,
         }
     }
 }
@@ -513,10 +469,8 @@ impl SpecializedComputePipeline for ParticlesInitPipeline {
 pub(crate) struct ParticlesUpdatePipeline {
     render_device: RenderDevice,
     sim_params_layout: BindGroupLayout,
-    //particles_buffer_layout: BindGroupLayout,
     spawner_buffer_layout: BindGroupLayout,
     render_indirect_layout: BindGroupLayout,
-    //pipeline_layout: PipelineLayout,
 }
 
 impl FromWorld for ParticlesUpdatePipeline {
@@ -549,34 +503,6 @@ impl FromWorld for ParticlesUpdatePipeline {
                 }],
                 label: Some("hanabi:update_sim_params_layout"),
             });
-
-        // trace!("GpuParticle: min_size={}", GpuParticle::min_size());
-        // let particles_buffer_layout =
-        //     render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        //         entries: &[
-        //             BindGroupLayoutEntry {
-        //                 binding: 0,
-        //                 visibility: ShaderStages::COMPUTE,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: false },
-        //                     has_dynamic_offset: true,
-        //                     min_binding_size: Some(GpuParticle::min_size()),
-        //                 },
-        //                 count: None,
-        //             },
-        //             BindGroupLayoutEntry {
-        //                 binding: 1,
-        //                 visibility: ShaderStages::COMPUTE,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: false },
-        //                     has_dynamic_offset: true,
-        //                     min_binding_size: BufferSize::new(12),
-        //                 },
-        //                 count: None,
-        //             },
-        //         ],
-        //         label: Some("hanabi:update_particles_buffer_layout"),
-        //     });
 
         trace!(
             "GpuSpawnerParams: min_size={}",
@@ -616,25 +542,11 @@ impl FromWorld for ParticlesUpdatePipeline {
                 label: Some("hanabi:update_render_indirect_layout"),
             });
 
-        // let pipeline_layout =
-        // render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
-        //     label: Some("hanabi:update_pipeline_layout"),
-        //     bind_group_layouts: &[
-        //         &sim_params_layout,
-        //         &particles_buffer_layout,
-        //         &spawner_buffer_layout,
-        //         &render_indirect_layout,
-        //     ],
-        //     push_constant_ranges: &[],
-        // });
-
         Self {
             render_device: render_device.clone(),
             sim_params_layout,
-            //particles_buffer_layout,
             spawner_buffer_layout,
             render_indirect_layout,
-            //pipeline_layout,
         }
     }
 }
@@ -957,43 +869,6 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         } else {
             TextureFormat::bevy_default()
         };
-
-        // let particles_buffer_layout =
-        //     render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        //         entries: &[
-        //             BindGroupLayoutEntry {
-        //                 binding: 0,
-        //                 visibility: ShaderStages::VERTEX,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: true },
-        //                     has_dynamic_offset: false,
-        //                     min_binding_size: Some(GpuParticle::min_size()),
-        //                 },
-        //                 count: None,
-        //             },
-        //             BindGroupLayoutEntry {
-        //                 binding: 1,
-        //                 visibility: ShaderStages::VERTEX,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: true },
-        //                     has_dynamic_offset: false,
-        //                     min_binding_size:
-        // BufferSize::new(std::mem::size_of::<u32>() as u64),
-        // },                 count: None,
-        //             },
-        //             BindGroupLayoutEntry {
-        //                 binding: 2,
-        //                 visibility: ShaderStages::VERTEX,
-        //                 ty: BindingType::Buffer {
-        //                     ty: BufferBindingType::Storage { read_only: true },
-        //                     has_dynamic_offset: true,
-        //                     min_binding_size: Some(GpuDispatchIndirect::min_size()),
-        //                 },
-        //                 count: None,
-        //             },
-        //         ],
-        //         label: Some("hanabi:buffer_layout_render"),
-        //     });
 
         RenderPipelineDescriptor {
             vertex: VertexState {

--- a/src/render/shader_cache.rs
+++ b/src/render/shader_cache.rs
@@ -9,7 +9,8 @@ use bevy::{
 /// Cache of baked shaders variants.
 ///
 /// Baked shader variants are shaders where the placeholders `{{PLACEHOLDER}}`
-/// have been replaced by actual WGSL code, making them a valid shader.
+/// present in the WGSL template code have been replaced by actual WGSL code,
+/// making them a valid shader from the point of view of the Bevy renderer.
 ///
 /// Shaders present in the cache are allocated [`Shader`] resources. Note that a
 /// [`Shader`] resource _may_ further be preprocessed to replace `#define`

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -22,13 +22,11 @@ struct ForceFieldSource {
 
 struct Spawner {
     transform: mat3x4<f32>, // transposed (row-major)
-    accel: vec3<f32>,
     spawn: i32,
-    force_field: array<ForceFieldSource, 16>,
     seed: u32,
     count: atomic<i32>,
-    dead_count: atomic<i32>,
     effect_index: u32,
+    force_field: array<ForceFieldSource, 16>,
 };
 
 struct IndirectBuffer {

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -114,26 +114,11 @@ fn rand4(input: u32) -> vec4<f32> {
     return vec4<f32>(x, y, z, w);
 }
 
-struct PosVel {
-    position: vec3<f32>,
-    velocity: vec3<f32>,
-};
-
-fn init_pos_vel(index: u32, transform: mat4x4<f32>) -> PosVel {
-    var ret : PosVel;
-{{INIT_POS_VEL}}
-    return ret;
-}
-
-fn init_lifetime() -> f32 {
-    var ret : f32;
-{{INIT_LIFETIME}}
-    return ret;
-}
-
 fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {
     return dot(v, u) / dot(u,u) * u;
 }
+
+{{INIT_EXTRA}}
 
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
@@ -156,11 +141,14 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let dead_index = atomicSub(&render_indirect.dead_count, 1u) - 1u;
     let index = indirect_buffer.indices[3u * dead_index + 2u];
 
-    var particle = Particle();
-
     // Update PRNG seed
     seed = pcg_hash(index ^ spawner.seed);
 
+    // Initialize new particle
+    var particle = Particle();
+    {{INIT_CODE}}
+
+    // Global-space simulation
     let transform = transpose(
         mat4x4(
             spawner.transform[0],
@@ -169,14 +157,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
             vec4<f32>(0.0, 0.0, 0.0, 1.0)
         )
     );
-
-    // Initialize new particle
-    var posVel = init_pos_vel(index, transform);
-    particle.position = posVel.position;
-    particle.velocity = posVel.velocity;
-    particle.age = 0.0;
-    particle.lifetime = init_lifetime();
-    {{INIT_SIZE}}
+    particle.position += transform[3].xyz;
 
     // Count as alive
     atomicAdd(&render_indirect.alive_count, 1u);

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -156,10 +156,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let dead_index = atomicSub(&render_indirect.dead_count, 1u) - 1u;
     let index = indirect_buffer.indices[3u * dead_index + 2u];
 
-    var vPos : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
-    var vVel : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
-    var vAge : f32 = 0.0;
-    var vLifetime : f32 = 0.0;
+    var particle = Particle();
 
     // Update PRNG seed
     seed = pcg_hash(index ^ spawner.seed);
@@ -175,10 +172,11 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Initialize new particle
     var posVel = init_pos_vel(index, transform);
-    vPos = posVel.position;
-    vVel = posVel.velocity;
-    vAge = 0.0;
-    vLifetime = init_lifetime();
+    particle.position = posVel.position;
+    particle.velocity = posVel.velocity;
+    particle.age = 0.0;
+    particle.lifetime = init_lifetime();
+    {{INIT_SIZE}}
 
     // Count as alive
     atomicAdd(&render_indirect.alive_count, 1u);
@@ -191,8 +189,5 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     indirect_buffer.indices[3u * indirect_index + ping] = index;
 
     // Write back spawned particle
-    particle_buffer.particles[index].position = vPos;
-    particle_buffer.particles[index].velocity = vVel;
-    particle_buffer.particles[index].age = vAge;
-    particle_buffer.particles[index].lifetime = vLifetime;
+    particle_buffer.particles[index] = particle;
 }

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -1,8 +1,5 @@
 struct Particle {
-    pos: vec3<f32>,
-    age: f32,
-    vel: vec3<f32>,
-    lifetime: f32,
+{{ATTRIBUTES}}
 };
 
 struct ParticleBuffer {
@@ -118,8 +115,8 @@ fn rand4(input: u32) -> vec4<f32> {
 }
 
 struct PosVel {
-    pos: vec3<f32>,
-    vel: vec3<f32>,
+    position: vec3<f32>,
+    velocity: vec3<f32>,
 };
 
 fn init_pos_vel(index: u32, transform: mat4x4<f32>) -> PosVel {
@@ -178,8 +175,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Initialize new particle
     var posVel = init_pos_vel(index, transform);
-    vPos = posVel.pos;
-    vVel = posVel.vel;
+    vPos = posVel.position;
+    vVel = posVel.velocity;
     vAge = 0.0;
     vLifetime = init_lifetime();
 
@@ -194,8 +191,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     indirect_buffer.indices[3u * indirect_index + ping] = index;
 
     // Write back spawned particle
-    particle_buffer.particles[index].pos = vPos;
-    particle_buffer.particles[index].vel = vVel;
+    particle_buffer.particles[index].position = vPos;
+    particle_buffer.particles[index].velocity = vVel;
     particle_buffer.particles[index].age = vAge;
     particle_buffer.particles[index].lifetime = vLifetime;
 }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -11,10 +11,7 @@ struct View {
 };
 
 struct Particle {
-    pos: vec3<f32>,
-    age: f32,
-    vel: vec3<f32>,
-    lifetime: f32,
+{{ATTRIBUTES}}
 };
 
 struct ParticlesBuffer {

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -85,6 +85,7 @@ fn vertex(
 #endif
 
     var size = vec2<f32>(1.0, 1.0);
+    {{SIZE}}
 
 {{VERTEX_MODIFIERS}}
 

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -47,9 +47,12 @@ struct RenderIndirectBuffer {
     max_update: u32,
 };
 
+{{PROPERTIES}}
+
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
+{{PROPERTIES_BINDING}}
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as init
 @group(3) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
 
@@ -118,6 +121,8 @@ fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {
     return dot(v, u) / dot(u,u) * u;
 }
 
+{{UPDATE_EXTRA}}
+
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let thread_index = global_invocation_id.x;
@@ -157,11 +162,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         return;
     }
 
-    // Drag
-{{DRAG_CODE}}
-
-    // Force field
-{{FORCE_FIELD_CODE}}
+    {{UPDATE_CODE}}
 
     // Increment alive particle count and write indirection index for later rendering
     let indirect_index = atomicAdd(&render_indirect.instance_count, 1u);

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -155,7 +155,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         let dead_index = atomicAdd(&render_indirect.dead_count, 1u);
         indirect_buffer.indices[3u * dead_index + 2u] = index;
         // Also increment copy of dead count, which was updated in dispatch indirect
-        // pass just before, and need to remain right after this pass
+        // pass just before, and need to remain correct after this pass
         atomicAdd(&render_indirect.max_spawn, 1u);
         atomicSub(&render_indirect.alive_count, 1u);
         return;

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -22,12 +22,11 @@ struct ForceFieldSource {
 
 struct Spawner {
     transform: mat3x4<f32>, // transposed (row-major)
-    accel: vec3<f32>,
     spawn: atomic<i32>,
-    force_field: array<ForceFieldSource, 16>,
     seed: u32,
     count_unused: u32,
     effect_index: u32,
+    force_field: array<ForceFieldSource, 16>,
 };
 
 struct IndirectBuffer {

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -1,8 +1,5 @@
 struct Particle {
-    pos: vec3<f32>,
-    age: f32,
-    vel: vec3<f32>,
-    lifetime: f32,
+{{ATTRIBUTES}}
 };
 
 struct ParticleBuffer {
@@ -143,8 +140,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     let index = indirect_buffer.indices[3u * thread_index + pong];
 
-    var vPos : vec3<f32> = particle_buffer.particles[index].pos;
-    var vVel : vec3<f32> = particle_buffer.particles[index].vel;
+    var vPos : vec3<f32> = particle_buffer.particles[index].position;
+    var vVel : vec3<f32> = particle_buffer.particles[index].velocity;
     var vAge : f32 = particle_buffer.particles[index].age;
     var vLifetime : f32 = particle_buffer.particles[index].lifetime;
 
@@ -175,8 +172,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     indirect_buffer.indices[3u * indirect_index + ping] = index;
 
     // Write back particle itself
-    particle_buffer.particles[index].pos = vPos;
-    particle_buffer.particles[index].vel = vVel;
+    particle_buffer.particles[index].position = vPos;
+    particle_buffer.particles[index].velocity = vVel;
     particle_buffer.particles[index].age = vAge;
     particle_buffer.particles[index].lifetime = vLifetime;
 }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -25,6 +25,9 @@ pub(crate) fn new_rng() -> Pcg32 {
 pub struct Random(pub Pcg32);
 
 /// A constant or random value.
+///
+/// This enum represents a value which is either constant, or randomly sampled
+/// according to a given probability distribution.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Reflect, FromReflect)]
 pub enum Value<T: Copy + FromReflect> {
     /// Single constant value.
@@ -81,6 +84,15 @@ impl<T: Copy + FromReflect> From<T> for Value<T> {
 }
 
 /// Dimension-variable floating-point [`Value`].
+///
+/// This enum represents a floating-point [`Value`] whose dimension (number of
+/// components) is variable. This is mainly used where a modifier can work with
+/// multiple attribute variants like [`Attribute::SIZE`] and
+/// [`Attribute::SIZE2`] which conceptually both represent the particle size,
+/// but with different representations.
+///
+/// [`Attribute::SIZE`]: crate::Attribute::SIZE
+/// [`Attribute::SIZE2`]: crate::Attribute::SIZE2
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub enum DimValue {
     /// Scalar.

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,5 +1,6 @@
 use bevy::{
     ecs::system::Resource,
+    prelude::{Vec2, Vec3, Vec4},
     reflect::{FromReflect, Reflect},
 };
 use rand::{
@@ -8,6 +9,8 @@ use rand::{
 };
 use rand_pcg::Pcg32;
 use serde::{Deserialize, Serialize};
+
+use crate::ToWgslString;
 
 /// An RNG to be used in the CPU for the particle system engine
 pub(crate) fn new_rng() -> Pcg32 {
@@ -77,28 +80,79 @@ impl<T: Copy + FromReflect> From<T> for Value<T> {
     }
 }
 
+/// Dimension-variable floating-point [`Value`].
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+pub enum DimValue {
+    /// Scalar.
+    D1(Value<f32>),
+    /// 2D vector.
+    D2(Value<Vec2>),
+    /// 3D vector.
+    D3(Value<Vec3>),
+    /// 4D vector.
+    D4(Value<Vec4>),
+}
+
+impl Default for DimValue {
+    fn default() -> Self {
+        DimValue::D1(Value::<f32>::default())
+    }
+}
+
+impl From<Value<f32>> for DimValue {
+    fn from(value: Value<f32>) -> Self {
+        DimValue::D1(value)
+    }
+}
+
+impl From<Value<Vec2>> for DimValue {
+    fn from(value: Value<Vec2>) -> Self {
+        DimValue::D2(value)
+    }
+}
+
+impl From<Value<Vec3>> for DimValue {
+    fn from(value: Value<Vec3>) -> Self {
+        DimValue::D3(value)
+    }
+}
+
+impl From<Value<Vec4>> for DimValue {
+    fn from(value: Value<Vec4>) -> Self {
+        DimValue::D4(value)
+    }
+}
+
+impl ToWgslString for DimValue {
+    fn to_wgsl_string(&self) -> String {
+        match self {
+            DimValue::D1(s) => s.to_wgsl_string(),
+            DimValue::D2(v) => v.to_wgsl_string(),
+            DimValue::D3(v) => v.to_wgsl_string(),
+            DimValue::D4(v) => v.to_wgsl_string(),
+        }
+    }
+}
+
 /// Spawner defining how new particles are emitted.
 ///
 /// The spawner defines how new particles are emitted and when. Each time the
 /// spawner ticks, once per frame, it calculates a number of particles to emit
 /// for this tick. This spawn count is passed to the GPU for the init compute
 /// pass to actually allocate the new particles and initialize them.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Reflect, FromReflect)]
+#[derive(Debug, Copy, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct Spawner {
     /// Number of particles to spawn over [`spawn_time`].
     ///
     /// [`spawn_time`]: Spawner::spawn_time
-    #[reflect(ignore)] // TODO
     num_particles: Value<f32>,
 
     /// Time over which to spawn `num_particles`, in seconds
-    #[reflect(ignore)] // TODO
     spawn_time: Value<f32>,
 
     /// Time between bursts of the particle system, in seconds.
     /// If this is infinity, there's only one burst.
     /// If this is `spawn_time`, the system spawns a steady stream of particles.
-    #[reflect(ignore)] // TODO
     period: Value<f32>,
 
     /// Time since last spawn.

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -22,8 +22,8 @@ pub(crate) fn new_rng() -> Pcg32 {
 pub struct Random(pub Pcg32);
 
 /// A constant or random value.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum Value<T: Copy> {
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Reflect, FromReflect)]
+pub enum Value<T: Copy + FromReflect> {
     /// Single constant value.
     Single(T),
     /// Random value distributed uniformly between two inclusive bounds.
@@ -35,13 +35,13 @@ pub enum Value<T: Copy> {
     Uniform((T, T)),
 }
 
-impl<T: Copy + Default> Default for Value<T> {
+impl<T: Copy + FromReflect + Default> Default for Value<T> {
     fn default() -> Self {
         Self::Single(T::default())
     }
 }
 
-impl<T: Copy + SampleUniform> Value<T> {
+impl<T: Copy + FromReflect + SampleUniform> Value<T> {
     /// Sample the value.
     /// - For [`Value::Single`], always return the same single value.
     /// - For [`Value::Uniform`], use the given pseudo-random number generator
@@ -54,7 +54,7 @@ impl<T: Copy + SampleUniform> Value<T> {
     }
 }
 
-impl<T: Copy + PartialOrd> Value<T> {
+impl<T: Copy + FromReflect + PartialOrd> Value<T> {
     /// Returns the range of allowable values in the form `[minimum, maximum]`.
     /// For [`Value::Single`], both values are the same.
     pub fn range(&self) -> [T; 2] {
@@ -71,7 +71,7 @@ impl<T: Copy + PartialOrd> Value<T> {
     }
 }
 
-impl<T: Copy> From<T> for Value<T> {
+impl<T: Copy + FromReflect> From<T> for Value<T> {
     fn from(t: T) -> Self {
         Self::Single(t)
     }


### PR DESCRIPTION
This change introduces a new dynamic particle layout based on _attributes_. A
particle attribute is a single scalar or vector value describing one aspect of
the particle. The value is stored per particle, and the set of attributes for
all the particles of an effect is organized into a layout describing the offset
and alignment of each attribute into the particle buffer on the GPU.

This new design allows customizing the particle storage itself based on the
modifiers used for each effect, which enables both greater customizing and a
compact memory footprint, as particles only store the attributes needed by the
effect.

To enable even greater customization, _properties_ can be attached to effects.
A property is a dynamic quantity assignable at runtime, and uploaded to the GPU
each frame, allowing to control the quantity it's bound to. Properties can be
bound to values of modifiers, like the `AccelModifer` acceleration, to enable
users to vary that field at runtime without the need to recreate the effect.
Properties trade some performance for greater control and customizing. This
generalize an implicit concept previously only available for the acceleration
of `AccelModifier` and the force field sources, and now made available to any
property-enabled field of any modifier.

Fixes #109
