### PR TITLE
Improve a few examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Value<T>` now requires `T: FromReflect`, and itself derives both `Reflect` and `FromReflect`.
 - Consequence of `Value<T>` being fully reflected, several fields on `Spawner` are now fully reflected too and not ignored anymore.
 - The conforming to sphere feature of `ForceFieldModifier` is now applied before the Euler integration updating the particle position. This may result is tiny deviations from the previous behavior, as the particle position will not strictly conform to the sphere at the end of the step. However the delta should be very small, and no visible difference is expected in practice.
+- Changed the `instancing` example to allow removing particles with the BACKSPACE key in addition of the DELETE one, mainly for useability on macOS.
+- Changed the `lifetime` example to render particles with a colored gradient, to make the lifetime effect more clear.
 
 ### Removed
 
 - Deleted `InitLayout` and `UpdateLayout`. Init and update modifiers are now directly applying themselves to the `InitContext` and `UpdateContext`, respectively. The `RenderLayout` is retained, as render modifiers are not yet transitioned to the new attribute-based API.
+
+### Fixed
+
+- Fixed the `spawn` example failing to start on several devices due to the monitor resolution being larger than the maximum resolution imposed by the downlevel settings of WGPU. The downlevel settings are now disabled by default, and can be manually re-added for testing.
 
 ## [0.5.3] 2023-02-07
 

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -1,4 +1,11 @@
-#![allow(dead_code)]
+//! Instancing
+//!
+//! An example to demonstrate instancing a single effect asset multiple times.
+//! The example defines a single [`EffectAsset`] then creates many
+//! [`ParticleEffect`]s from that same asset, disposed in a grid pattern.
+//!
+//! Use the SPACE key to add more effect instances, or the DELETE key to remove
+//! an existing instance.
 
 use bevy::{log::LogPlugin, prelude::*, render::mesh::shape::Cube};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -221,7 +228,9 @@ fn keyboard_input_system(
 
     if keyboard_input.just_pressed(KeyCode::Space) {
         my_effect.spawn_random(&mut commands);
-    } else if keyboard_input.just_pressed(KeyCode::Delete) {
+    } else if keyboard_input.just_pressed(KeyCode::Delete)
+        || keyboard_input.just_pressed(KeyCode::Back)
+    {
         my_effect.despawn_random(&mut commands);
     }
 

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -1,3 +1,16 @@
+//! Lifetime
+//!
+//! An example demonstrating the effect of the particle's lifetime. The example
+//! spawns 3 effect instances, which emit a burst of particles every 3 seconds.
+//! Each effect has a different particle lifetime:
+//! - The left effect has a lifetime of 12 seconds, much longer than the spawn
+//!   rate. Multiple bursts of particles are alive at the same time.
+//! - The center effect has a lifetime of 3 seconds, exactly the spawn rate. As
+//!   soon as particles die, a new burst spawns some more.
+//! - The right effect has a lifetime of 0.75 seconds. Particle die very
+//!   quickly, and during 2.25 seconds there's no particle, until the next burst
+//!   spawns some more.
+
 use bevy::{
     log::LogPlugin,
     prelude::*,
@@ -52,15 +65,23 @@ fn setup(
     let cube = meshes.add(Mesh::from(Cube { size: 1.0 }));
     let mat = materials.add(Color::PURPLE.into());
 
-    let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec4::new(0.0, 0.0, 1.0, 1.0));
-    gradient.add_key(1.0, Vec4::splat(0.0));
+    let lifetime1 = 12.;
+    let lifetime2 = 3.;
+    let lifetime3 = 0.75;
+    let period = 3.;
+
+    let mut gradient1 = Gradient::new();
+    gradient1.add_key(0.0, Vec4::new(1.0, 0.0, 0.0, 1.0));
+    gradient1.add_key(0.25, Vec4::new(1.0, 1.0, 0.0, 1.0));
+    gradient1.add_key(0.5, Vec4::new(0.0, 1.0, 0.0, 1.0));
+    gradient1.add_key(0.75, Vec4::new(0.0, 1.0, 1.0, 1.0));
+    gradient1.add_key(1.0, Vec4::ONE);
 
     let effect1 = effects.add(
         EffectAsset {
             name: "emit:burst".to_string(),
             capacity: 512,
-            spawner: Spawner::burst(50.0.into(), 3.0.into()),
+            spawner: Spawner::burst(50.0.into(), period.into()),
             ..Default::default()
         }
         .init(InitPositionSphereModifier {
@@ -73,10 +94,10 @@ fn setup(
             speed: 2.0.into(),
         })
         .init(InitLifetimeModifier {
-            lifetime: 12_f32.into(),
+            lifetime: lifetime1.into(),
         })
         .render(ColorOverLifetimeModifier {
-            gradient: gradient.clone(),
+            gradient: gradient1,
         }),
     );
 
@@ -101,11 +122,15 @@ fn setup(
             ));
         });
 
+    let mut gradient2 = Gradient::new();
+    gradient2.add_key(0.0, Vec4::new(1.0, 0.0, 0.0, 1.0));
+    gradient2.add_key(1.0, Vec4::new(1.0, 1.0, 0.0, 1.0));
+
     let effect2 = effects.add(
         EffectAsset {
             name: "emit:burst".to_string(),
             capacity: 512,
-            spawner: Spawner::burst(50.0.into(), 3.0.into()),
+            spawner: Spawner::burst(50.0.into(), period.into()),
             ..Default::default()
         }
         .init(InitPositionSphereModifier {
@@ -118,10 +143,10 @@ fn setup(
             speed: 2.0.into(),
         })
         .init(InitLifetimeModifier {
-            lifetime: 3_f32.into(),
+            lifetime: lifetime2.into(),
         })
         .render(ColorOverLifetimeModifier {
-            gradient: gradient.clone(),
+            gradient: gradient2,
         }),
     );
 
@@ -146,11 +171,15 @@ fn setup(
             ));
         });
 
+    let mut gradient3 = Gradient::new();
+    gradient3.add_key(0.0, Vec4::new(1.0, 0.0, 0.0, 1.0));
+    gradient3.add_key(1.0, Vec4::new(0.75, 0.25, 0.0, 1.0));
+
     let effect3 = effects.add(
         EffectAsset {
             name: "emit:burst".to_string(),
             capacity: 512,
-            spawner: Spawner::burst(50.0.into(), 3.0.into()),
+            spawner: Spawner::burst(50.0.into(), period.into()),
             ..Default::default()
         }
         .init(InitPositionSphereModifier {
@@ -163,10 +192,10 @@ fn setup(
             speed: 2.0.into(),
         })
         .init(InitLifetimeModifier {
-            lifetime: 0.75_f32.into(),
+            lifetime: lifetime3.into(),
         })
         .render(ColorOverLifetimeModifier {
-            gradient: gradient.clone(),
+            gradient: gradient3,
         }),
     );
 

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -10,6 +10,12 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
+/// Set this to `true` to enable WGPU downlevel constraints. This is disabled by
+/// default to prevent the example from failing to start on devices with a
+/// monitor resolution larger than the maximum resolution imposed by the
+/// downlevel settings of WGPU.
+const USE_LOW_LIMITS: bool = false;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Optional; test that a stronger constraint is handled correctly.
     // For example, on macOS the alignment for storage buffer offsets is commonly
@@ -17,8 +23,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // only. Force the downlevel limits here, and as an example of how
     // to force a particular limit, and to show Hanabi works with those settings.
     let mut options = WgpuSettings::default();
-    let limits = WgpuLimits::downlevel_defaults();
-    options.constrained_limits = Some(limits);
+    if USE_LOW_LIMITS {
+        let limits = WgpuLimits::downlevel_defaults();
+        options.constrained_limits = Some(limits);
+    }
 
     App::default()
         .insert_resource(options)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,7 +905,10 @@ mod tests {
         let s = Value::Single(Vec2::ONE).to_wgsl_string();
         assert_eq!(s, "vec2<f32>(1., 1.)");
         let s = Value::Uniform((Vec2::ZERO, Vec2::ONE)).to_wgsl_string();
-        assert_eq!(s, "(rand2() * (vec2<f32>(1., 1.) - vec2<f32>(0., 0.)) + vec2<f32>(0., 0.))");
+        assert_eq!(
+            s,
+            "(rand2() * (vec2<f32>(1., 1.) - vec2<f32>(0., 0.)) + vec2<f32>(0., 0.))"
+        );
     }
 
     #[test]
@@ -913,7 +916,10 @@ mod tests {
         let s = Value::Single(Vec3::ONE).to_wgsl_string();
         assert_eq!(s, "vec3<f32>(1., 1., 1.)");
         let s = Value::Uniform((Vec3::ZERO, Vec3::ONE)).to_wgsl_string();
-        assert_eq!(s, "(rand3() * (vec3<f32>(1., 1., 1.) - vec3<f32>(0., 0., 0.)) + vec3<f32>(0., 0., 0.))");
+        assert_eq!(
+            s,
+            "(rand3() * (vec3<f32>(1., 1., 1.) - vec3<f32>(0., 0., 0.)) + vec3<f32>(0., 0., 0.))"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Fix the `spawn` example on larger resolutions. (#110)
- Change the color gradient of the `lifetime` example for clarity.
- Allow the BACKSPACE key in addition of the DELETE key in the `instancing` example, for useability on macOS.

Fixes #110