### PR TITLE
Don't cache shader code unnecessarily

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,10 +374,6 @@ pub struct ParticleEffect {
     #[reflect(ignore)]
     force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
     spawn_count: u32,
-    init_code: String,
-    init_extra: String,
-    update_code: String,
-    update_extra: String,
 }
 
 impl ParticleEffect {
@@ -395,10 +391,6 @@ impl ParticleEffect {
             //
             force_field: [ForceFieldSource::default(); ForceFieldSource::MAX_SOURCES],
             spawn_count: 0,
-            init_code: String::default(),
-            init_extra: String::default(),
-            update_code: String::default(),
-            update_extra: String::default(),
         }
     }
 
@@ -742,6 +734,7 @@ fn tick_spawners(
                 .replace("{{INIT_CODE}}", &init_context.init_code)
                 .replace("{{INIT_EXTRA}}", &init_context.init_extra);
             let init_shader = shader_cache.get_or_insert(&init_shader_source, &mut shaders);
+            trace!("Configured init shader:\n{}", init_shader_source);
 
             // Configure the update shader template, and make sure a corresponding shader
             // asset exists
@@ -752,6 +745,7 @@ fn tick_spawners(
                 .replace("{{PROPERTIES}}", &properties_code)
                 .replace("{{PROPERTIES_BINDING}}", &properties_binding_code);
             let update_shader = shader_cache.get_or_insert(&update_shader_source, &mut shaders);
+            trace!("Configured update shader:\n{}", update_shader_source);
 
             // Configure the render shader template, and make sure a corresponding shader
             // asset exists
@@ -772,6 +766,7 @@ fn tick_spawners(
                 render_shader_source = render_shader_source.replace("{{SIZE}}", "");
             }
             let render_shader = shader_cache.get_or_insert(&render_shader_source, &mut shaders);
+            trace!("Configured render shader:\n{}", render_shader_source);
 
             trace!(
                 "tick_spawners: handle={:?} init_shader={:?} update_shader={:?} render_shader={:?} has_image={}",
@@ -798,10 +793,6 @@ fn tick_spawners(
             effect.configured_render_shader = Some(render_shader);
 
             // TEMP - Should disappear after fixing the above TODO.
-            effect.init_code = init_context.init_code;
-            effect.init_extra = init_context.init_extra;
-            effect.update_code = update_context.update_code;
-            effect.update_extra = update_context.update_extra;
             effect.force_field = update_context.force_field;
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -945,14 +945,6 @@ pub(crate) struct ExtractedEffect {
     pub update_shader: Handle<Shader>,
     /// Render shader.
     pub render_shader: Handle<Shader>,
-    /// Init code.
-    pub init_code: String,
-    /// Extra init code.
-    pub init_extra: String,
-    /// Update code.
-    pub update_code: String,
-    /// Extra update code.
-    pub update_extra: String,
     /// For 2D rendering, the Z coordinate used as the sort key. Ignored for 3D
     /// rendering.
     pub z_sort_key_2d: FloatOrd,
@@ -1124,10 +1116,6 @@ pub(crate) fn extract_effects(
         // TEMP - see tick_spawners()
         let spawn_count = effect.spawn_count;
         let force_field = effect.force_field; // TEMP
-        let init_code = effect.init_code.clone();
-        let init_extra = effect.init_extra.clone();
-        let update_code = effect.update_code.clone();
-        let update_extra = effect.update_extra.clone();
 
         // Check if asset is available, otherwise silently ignore
         let Some(asset) = effects.get(&effect.handle) else {
@@ -1181,10 +1169,6 @@ pub(crate) fn extract_effects(
                 init_shader,
                 update_shader,
                 render_shader,
-                init_code,
-                init_extra,
-                update_code,
-                update_extra,
                 z_sort_key_2d,
             },
         );
@@ -1530,14 +1514,6 @@ pub(crate) struct EffectBatch {
     update_shader: Handle<Shader>,
     /// Configured shader used for the particle rendering of this batch.
     render_shader: Handle<Shader>,
-    /// Init code.
-    init_code: String,
-    /// Extra init code.
-    init_extra: String,
-    /// Update code.
-    update_code: String,
-    /// Extra update code.
-    update_extra: String,
     /// Init compute pipeline specialized for this batch.
     init_pipeline_id: CachedComputePipelineId,
     /// Update compute pipeline specialized for this batch.
@@ -1655,10 +1631,6 @@ pub(crate) fn prepare_effects(
     let mut start = 0;
     let mut end = 0;
     let mut num_emitted = 0;
-    let mut init_code = String::default();
-    let mut init_extra = String::default();
-    let mut update_code = String::default();
-    let mut update_extra = String::default();
     let mut init_pipeline_id = CachedComputePipelineId::INVALID;
     let mut update_pipeline_id = CachedComputePipelineId::INVALID;
     let mut z_sort_key_2d = FloatOrd(f32::NAN);
@@ -1736,10 +1708,6 @@ pub(crate) fn prepare_effects(
                         init_shader: init_shader.clone(),
                         update_shader: update_shader.clone(),
                         render_shader: render_shader.clone(),
-                        init_code: init_code.clone(),
-                        init_extra: init_extra.clone(),
-                        update_code: update_code.clone(),
-                        update_extra: update_extra.clone(),
                         init_pipeline_id,
                         update_pipeline_id,
                         z_sort_key_2d,
@@ -1808,18 +1776,6 @@ pub(crate) fn prepare_effects(
         trace!("render_shader = {:?}", render_shader);
 
         trace!("particle_layout = {:?}", slice.particle_layout);
-
-        init_code = extracted_effect.init_code.clone();
-        //trace!("init_code = {}", init_code);
-
-        init_extra = extracted_effect.init_extra.clone();
-        //trace!("init_extra = {}", init_extra);
-
-        update_code = extracted_effect.update_code.clone();
-        //trace!("update_code = {}", update_code);
-
-        update_extra = extracted_effect.update_extra.clone();
-        //trace!("update_extra = {}", update_extra);
 
         trace!("z_sort_key_2d = {:?}", z_sort_key_2d);
 
@@ -1892,10 +1848,6 @@ pub(crate) fn prepare_effects(
                     init_shader: init_shader.clone(),
                     update_shader: update_shader.clone(),
                     render_shader: render_shader.clone(),
-                    init_code: init_code.clone(),
-                    init_extra: init_extra.clone(),
-                    update_code: update_code.clone(),
-                    update_extra: update_extra.clone(),
                     init_pipeline_id,
                     update_pipeline_id,
                     z_sort_key_2d,
@@ -1936,10 +1888,6 @@ pub(crate) fn prepare_effects(
             init_shader,
             update_shader,
             render_shader,
-            init_code,
-            init_extra,
-            update_code,
-            update_extra,
             init_pipeline_id,
             update_pipeline_id,
             z_sort_key_2d,


### PR DESCRIPTION
Delete fields storing the shader's WGSL code, which duplicates the batching key functionality of the `ShaderCache`. The configured shader handles saved in `ParticleEffect` and `ExtractedEffect` already guarantee the unicity of the effect batches.