### PR TITLE
Switch render shader to `RenderContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added properties, named quantities associated with an `EffectAsset` and modifiable at runtime at assignable to values of modifiers. This enables dynamically modifying at runtime any property-based modifier value. Other non-property-based values are assumed to be constant, and are optimized by hard-coding them into the various shaders. Use `EffectAsset::with_property()` and `EffectAsset::add_property()` to define a new property before binding it to a modifier's value. The `spawn.rs` example demonstrates this with the acceleration of the `AccelModifier`.
 - Added particle `Attribute`s, individual items holding a single per-particle scalar or vector value. Composed together, the attributes form the particle layout, which defines at runtime the set of per-particle values used in the simulation. This change marks a transition from the previous design where the particle attributes were hard-coded to be the position, velocity, age, and lifetime of the particle. With this change, a collection of various attributes is available for modifiers to manipulate. This ensures flexibility in customizing while retaining a minimal per-particle memory footprint for a given effect. Note that [`Attribute`]s are all built-in; a custom [`Attribute`] cannot be used.
 - Added a new `AabbKillModifier` which kills all particles entering or exiting an AABB.
+- Added a new `OrientAlongVelocityModifier` which orients the local X axis of particles alongside their velocity, and builds a local Z axis perpendicular to the camera view's plane. The local Y axis is derived to form an orthonormal frame.
 
 ### Changed
 
@@ -31,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Deleted `InitLayout` and `UpdateLayout`. Init and update modifiers are now directly applying themselves to the `InitContext` and `UpdateContext`, respectively. The `RenderLayout` is retained, as render modifiers are not yet transitioned to the new attribute-based API.
+- Deleted `InitLayout`, `UpdateLayout`, and `RenderLayout`. Init, update, and render modifiers are now directly applying themselves to the `InitContext`, `UpdateContext`, and `RenderContext`, respectively.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = ["examples/*.gif", "examples/*.png", ".github", "release.md", "run_examples.bat"]
 
 [features]
-default = [ "2d", "3d", "gpu_tests" ]
+default = ["2d", "3d", "gpu_tests"]
 2d = []
 3d = []
 

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -7,6 +7,8 @@
 //! Use the SPACE key to add more effect instances, or the DELETE key to remove
 //! an existing instance.
 
+#![allow(dead_code)]
+
 use bevy::{log::LogPlugin, prelude::*, render::mesh::shape::Cube};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use rand::Rng;

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -2,15 +2,12 @@
 //!
 //! An example demonstrating the use of the `InitVelocityTangentModifier` to
 //! create a kind of portal effect where particles turn around a circle and
-//! appear to be ejected from it.
+//! appear to be ejected from it. The `OrientAlongVelocityModifier` paired with
+//! an elongated particle size gives the appearance of sparks.
 //!
 //! The addition of some gravity and drag, combined with a careful choice of
 //! lifetime, give a subtle effect of particles appearing to fall down right
 //! before they disappear, like sparkles fading away.
-//!
-//! Note: there's currently no way to orient the particles along their velocity
-//! to create streaks.
-//! This is logged as https://github.com/djeedai/bevy_hanabi/issues/133.
 
 use bevy::{
     core_pipeline::{bloom::BloomSettings, clear_color::ClearColorConfig},
@@ -60,7 +57,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
     color_gradient1.add_key(1.0, Vec4::new(4.0, 0.0, 0.0, 0.0));
 
     let mut size_gradient1 = Gradient::new();
-    size_gradient1.add_key(0.3, Vec2::splat(0.07));
+    size_gradient1.add_key(0.3, Vec2::new(0.2, 0.02));
     size_gradient1.add_key(1.0, Vec2::splat(0.0));
 
     let effect1 = effects.add(
@@ -92,7 +89,8 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         })
         .render(SizeOverLifetimeModifier {
             gradient: size_gradient1,
-        }),
+        })
+        .render(OrientAlongVelocityModifier),
     );
 
     commands.spawn((

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,8 +1,6 @@
 use bevy::{
-    asset::{AssetLoader, Handle, LoadContext, LoadedAsset},
-    math::{Vec2, Vec4},
+    asset::{AssetLoader, LoadContext, LoadedAsset},
     reflect::{FromReflect, Reflect, TypeUuid},
-    render::texture::Image,
     utils::{BoxedFuture, HashSet},
 };
 use serde::{Deserialize, Serialize};
@@ -10,27 +8,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     graph::Value,
     modifier::{init::InitModifier, render::RenderModifier, update::UpdateModifier},
-    Attribute, BoxedModifier, Gradient, ParticleLayout, Property, PropertyLayout, SimulationSpace,
-    Spawner,
+    Attribute, BoxedModifier, ParticleLayout, Property, PropertyLayout, SimulationSpace, Spawner,
 };
-
-/// Struct containing data and snippets of WSGL code that can be used
-/// to render the particles every frame on the GPU.
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct RenderLayout {
-    /// If set, defines the PARTICLE_TEXTURE shader key and extend the vertex
-    /// format to contain UV coordinates. Also make available the image as a
-    /// 2D texture and sampler in the render shaders.
-    pub particle_texture: Option<Handle<Image>>,
-    /// Optional color gradient used to vary the particle color over its
-    /// lifetime.
-    pub lifetime_color_gradient: Option<Gradient<Vec4>>,
-    /// Optional size gradient used to vary the particle size over its lifetime.
-    pub lifetime_size_gradient: Option<Gradient<Vec2>>,
-    /// If true, renders sprites as "billboards", that is, they will always face
-    /// the camera when rendered.
-    pub billboard: bool,
-}
 
 /// Asset describing a visual effect.
 ///
@@ -57,13 +36,6 @@ pub struct EffectAsset {
     pub capacity: u32,
     /// Spawner.
     pub spawner: Spawner,
-    /// Layout describing the particle rendering code.
-    ///
-    /// The render layout determines how alive particles are rendered.
-    /// Compatible layouts increase the chance of batching together effects.
-    #[serde(skip)] // TODO
-    #[reflect(ignore)] // TODO?
-    pub render_layout: RenderLayout,
     /// For 2D rendering, the Z coordinate used as the sort key.
     ///
     /// This value is passed to the render pipeline and used when sorting
@@ -171,7 +143,6 @@ impl EffectAsset {
         M: RenderModifier + Send + Sync + 'static,
     {
         modifier.resolve_properties(&self.properties);
-        modifier.apply(&mut self.render_layout);
         self.modifiers.push(Box::new(modifier));
         self
     }
@@ -310,12 +281,12 @@ mod tests {
         ForceFieldModifier::default().apply(&mut update_context);
         //assert_eq!(effect.update_layout, update_layout);
 
-        let mut render_layout = RenderLayout::default();
-        ParticleTextureModifier::default().apply(&mut render_layout);
-        ColorOverLifetimeModifier::default().apply(&mut render_layout);
-        SizeOverLifetimeModifier::default().apply(&mut render_layout);
-        BillboardModifier::default().apply(&mut render_layout);
-        assert_eq!(effect.render_layout, render_layout);
+        let mut render_context = RenderContext::default();
+        ParticleTextureModifier::default().apply(&mut render_context);
+        ColorOverLifetimeModifier::default().apply(&mut render_context);
+        SizeOverLifetimeModifier::default().apply(&mut render_context);
+        BillboardModifier::default().apply(&mut render_context);
+        //assert_eq!(effect.render_layout, render_layout);
     }
 
     #[test]

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -1,15 +1,78 @@
 //! Modifiers to influence the rendering of each particle.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashMap};
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
 
-use crate::{Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, RenderLayout};
+use crate::{Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, ShaderCode};
+
+/// Calculate a function ID by hashing the given value representative of the
+/// function.
+fn calc_func_id<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Particle rendering shader code generation context.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct RenderContext {
+    /// Main particle rendering code for the vertex shader.
+    pub vertex_code: String,
+    /// Main particle rendering code for the fragment shader.
+    pub fragment_code: String,
+    /// Extra functions emitted at top level, which `vertex_code` and
+    /// `fragment_code` can call.
+    pub render_extra: String,
+    /// Texture modulating the particle color.
+    pub particle_texture: Option<Handle<Image>>,
+    /// Color gradients.
+    pub gradients: HashMap<u64, Gradient<Vec4>>,
+    /// Size gradients.
+    pub size_gradients: HashMap<u64, Gradient<Vec2>>,
+}
+
+impl RenderContext {
+    /// Set the main texture used to color particles.
+    fn set_particle_texture(&mut self, handle: Handle<Image>) {
+        self.particle_texture = Some(handle);
+    }
+
+    /// Add a color gradient.
+    ///
+    /// # Returns
+    ///
+    /// Returns the unique name of the gradient, to be used as function name in
+    /// the shader code.
+    fn add_color_gradient(&mut self, gradient: Gradient<Vec4>) -> String {
+        let func_id = calc_func_id(&gradient);
+        self.gradients.insert(func_id, gradient);
+        let func_name = format!("color_gradient_{0:016X}", func_id);
+        func_name
+    }
+
+    /// Add a size gradient.
+    ///
+    /// # Returns
+    ///
+    /// Returns the unique name of the gradient, to be used as function name in
+    /// the shader code.
+    fn add_size_gradient(&mut self, gradient: Gradient<Vec2>) -> String {
+        let func_id = calc_func_id(&gradient);
+        self.size_gradients.insert(func_id, gradient);
+        let func_name = format!("size_gradient_{0:016X}", func_id);
+        func_name
+    }
+}
 
 /// Trait to customize the rendering of alive particles each frame.
 #[typetag::serde]
 pub trait RenderModifier: Modifier {
-    /// Apply the modifier to the render layout of the effect instance.
-    fn apply(&self, render_layout: &mut RenderLayout);
+    /// Apply the rendering code.
+    fn apply(&self, context: &mut RenderContext);
 }
 
 /// Macro to implement the [`Modifier`] trait for a render modifier.
@@ -55,14 +118,14 @@ impl_mod_render!(ParticleTextureModifier, &[]); // TODO - should require some UV
 
 #[typetag::serde]
 impl RenderModifier for ParticleTextureModifier {
-    fn apply(&self, render_layout: &mut RenderLayout) {
-        render_layout.particle_texture = Some(self.texture.clone());
+    fn apply(&self, context: &mut RenderContext) {
+        context.set_particle_texture(self.texture.clone());
     }
 }
 
 /// A modifier modulating each particle's color over its lifetime with a
 /// gradient curve.
-#[derive(Debug, Default, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Hash, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ColorOverLifetimeModifier {
     /// The color gradient defining the particle color based on its lifetime.
     pub gradient: Gradient<Vec4>,
@@ -72,14 +135,28 @@ impl_mod_render!(ColorOverLifetimeModifier, &[]);
 
 #[typetag::serde]
 impl RenderModifier for ColorOverLifetimeModifier {
-    fn apply(&self, render_layout: &mut RenderLayout) {
-        render_layout.lifetime_color_gradient = Some(self.gradient.clone());
+    fn apply(&self, context: &mut RenderContext) {
+        let func_name = context.add_color_gradient(self.gradient.clone());
+        context.render_extra += &format!(
+            r#"fn {0}(key: f32) -> vec4<f32> {{
+    {1}
+}}
+
+"#,
+            func_name,
+            self.gradient.to_shader_code("key")
+        );
+
+        context.vertex_code += &format!(
+            "color = {0}(particle.age / particle.lifetime);\n",
+            func_name
+        );
     }
 }
 
 /// A modifier modulating each particle's size over its lifetime with a gradient
 /// curve.
-#[derive(Debug, Default, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Hash, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct SizeOverLifetimeModifier {
     /// The size gradient defining the particle size based on its lifetime.
     pub gradient: Gradient<Vec2>,
@@ -89,21 +166,57 @@ impl_mod_render!(SizeOverLifetimeModifier, &[]);
 
 #[typetag::serde]
 impl RenderModifier for SizeOverLifetimeModifier {
-    fn apply(&self, render_layout: &mut RenderLayout) {
-        render_layout.lifetime_size_gradient = Some(self.gradient.clone());
+    fn apply(&self, context: &mut RenderContext) {
+        let func_name = context.add_size_gradient(self.gradient.clone());
+        context.render_extra += &format!(
+            r#"fn {0}(key: f32) -> vec2<f32> {{
+    {1}
+}}
+
+"#,
+            func_name,
+            self.gradient.to_shader_code("key")
+        );
+
+        context.vertex_code +=
+            &format!("size = {0}(particle.age / particle.lifetime);\n", func_name);
     }
 }
 
 /// Reorients the vertices to always face the camera when rendering.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Hash, Reflect, FromReflect, Serialize, Deserialize,
+)]
 pub struct BillboardModifier;
 
-impl_mod_render!(BillboardModifier, &[Attribute::POSITION]);
+impl_mod_render!(BillboardModifier, &[]);
 
 #[typetag::serde]
 impl RenderModifier for BillboardModifier {
-    fn apply(&self, render_layout: &mut RenderLayout) {
-        render_layout.billboard = true;
+    fn apply(&self, context: &mut RenderContext) {
+        context.vertex_code += "axis_x = view.view[0].xyz;\naxis_y = view.view[1].xyz;\n";
+    }
+}
+
+/// A modifier orienting each particle alongside its velocity.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Hash, Reflect, FromReflect, Serialize, Deserialize,
+)]
+pub struct OrientAlongVelocityModifier;
+
+impl_mod_render!(
+    OrientAlongVelocityModifier,
+    &[Attribute::POSITION, Attribute::VELOCITY]
+);
+
+#[typetag::serde]
+impl RenderModifier for OrientAlongVelocityModifier {
+    fn apply(&self, context: &mut RenderContext) {
+        context.vertex_code += r#"let dir = normalize(particle.position - view.view[3].xyz);
+    axis_x = normalize(particle.velocity);
+    axis_y = cross(dir, axis_x);
+    axis_z = cross(axis_x, axis_y);
+"#;
     }
 }
 
@@ -118,11 +231,11 @@ mod tests {
             texture: texture.clone(),
         };
 
-        let mut layout = RenderLayout::default();
-        modifier.apply(&mut layout);
+        let mut context = RenderContext::default();
+        modifier.apply(&mut context);
 
-        assert!(layout.particle_texture.is_some());
-        assert_eq!(layout.particle_texture.unwrap(), texture);
+        assert!(context.particle_texture.is_some());
+        assert_eq!(context.particle_texture.unwrap(), texture);
     }
 
     #[test]
@@ -136,11 +249,12 @@ mod tests {
             gradient: gradient.clone(),
         };
 
-        let mut layout = RenderLayout::default();
-        modifier.apply(&mut layout);
+        let mut context = RenderContext::default();
+        modifier.apply(&mut context);
 
-        assert!(layout.lifetime_color_gradient.is_some());
-        assert_eq!(layout.lifetime_color_gradient.unwrap(), gradient);
+        assert!(context
+            .render_extra
+            .contains(&gradient.to_shader_code("key")));
     }
 
     #[test]
@@ -154,18 +268,19 @@ mod tests {
             gradient: gradient.clone(),
         };
 
-        let mut layout = RenderLayout::default();
-        modifier.apply(&mut layout);
+        let mut context = RenderContext::default();
+        modifier.apply(&mut context);
 
-        assert!(layout.lifetime_size_gradient.is_some());
-        assert_eq!(layout.lifetime_size_gradient.unwrap(), gradient);
+        assert!(context
+            .render_extra
+            .contains(&gradient.to_shader_code("key")));
     }
 
     #[test]
     fn mod_billboard() {
         let modifier = BillboardModifier;
-        let mut layout = RenderLayout::default();
-        modifier.apply(&mut layout);
-        assert!(layout.billboard);
+        let mut context = RenderContext::default();
+        modifier.apply(&mut context);
+        assert!(context.vertex_code.contains("view.view"));
     }
 }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -50,21 +50,7 @@ struct VertexOutput {
 // @group(3) @binding(1) var gradient_sampler: sampler;
 // #endif
 
-// fn color_over_lifetime(life: f32) -> vec4<f32> {
-//     let c0 = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-//     let t1 = 0.1;
-//     let c1 = vec4<f32>(1.0, 1.0, 0.0, 1.0);
-//     let t2 = 0.4;
-//     let c2 = vec4<f32>(1.0, 0.0, 0.0, 1.0);
-//     let c3 = vec4<f32>(0.0, 0.0, 0.0, 0.0);
-//     if (life <= t1) {
-//         return mix(c0, c1, life / t1);
-//     } else if (life <= t2) {
-//         return mix(c1, c2, (life - t1) / (t2 - t1));
-//     } else {
-//         return mix(c2, c3, (life - t2) / (1.0 - t2));
-//     }
-// }
+{{RENDER_EXTRA}}
 
 @vertex
 fn vertex(
@@ -85,23 +71,28 @@ fn vertex(
 #endif
 
     var size = vec2<f32>(1.0, 1.0);
-    {{SIZE}}
+    var axis_x = vec3<f32>(1.0, 0.0, 0.0);
+    var axis_y = vec3<f32>(0.0, 1.0, 0.0);
+    var axis_z = vec3<f32>(0.0, 0.0, 1.0);
+    var color = vec4<f32>(1.0, 1.0, 1.0, 1.0); 
 
 {{VERTEX_MODIFIERS}}
 
-    out.position = view.view_proj * world_position;
+    let vpos = vertex_position * vec3<f32>(size.x, size.y, 1.0);
+    let world_position = particle.position
+        + axis_x * vpos.x
+        + axis_y * vpos.y;
+    out.position = view.view_proj * vec4<f32>(world_position, 1.0);
+    out.color = color;
 
-    //out.color = vec4<f32>((vec4<u32>(vertex_color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
-    //out.color = color_over_lifetime(particle.age / particle.lifetime);
-    // out.color[3] = 1.0;
-    // if (particle.age < 0.0) {
-    //     out.color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
-    // }
     return out;
 }
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+
+{{FRAGMENT_MODIFIERS}}
+
 #ifdef PARTICLE_TEXTURE
     var color = textureSample(particle_texture, particle_sampler, in.uv);
     color = vec4<f32>(1.0, 1.0, 1.0, color.r); // FIXME - grayscale modulate


### PR DESCRIPTION
Transition the render shader too to the `RenderContext` architecture with render modifiers directly writing shader code to a template, like for the init and udpate contexts. This unlocks more complex render modifiers like orienting particles alongside their velocity.

Add a new `OrientAlongVelocityModifier` to orient particles along their velocity to allow creating streaks / sparkles.

Fixes #133