### PR TITLE
Update to bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,12 @@ wgpu = "0.15"
 naga = "0.11"
 
 futures = "0.3"
-bevy-inspector-egui = "0.17"
+bevy-inspector-egui = "0.18"
+
+# Enable default features for examples and tests
+[dev-dependencies.bevy]
+version = "0.10"
+default-features = true
 
 [[example]]
 name = "firework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ bitflags = "1.3"
 typetag = "0.2"
 
 [dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
-branch = "main"
+version = "0.10"
 default-features = false
 features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ bitflags = "1.3"
 typetag = "0.2"
 
 [dependencies.bevy]
-version = "0.9"
+git = "https://github.com/bevyengine/bevy"
+branch = "main"
 default-features = false
 features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset" ]
 
@@ -41,10 +42,10 @@ features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset" ]
 all-features = true
 
 [dev-dependencies]
-# Same version as Bevy 0.9 (bevy_render)
-wgpu = "0.14.0"
+# Same version as Bevy 0.10 (bevy_render)
+wgpu = "0.15"
 # For shader snippet validation
-naga = "0.10"
+naga = "0.11"
 
 futures = "0.3"
 bevy-inspector-egui = "0.17"

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update_plane)
         .run();

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -7,7 +7,9 @@
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{camera::ScalingMode, render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{
+        camera::ScalingMode, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
+    },
     sprite::{MaterialMesh2dBundle, Mesh2dHandle},
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -15,17 +17,21 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
+
     App::default()
         .insert_resource(ClearColor(Color::DARK_GRAY))
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -7,6 +7,7 @@ use bevy::{
         camera::{Projection, ScalingMode},
         render_resource::WgpuFeatures,
         settings::WgpuSettings,
+        RenderPlugin,
     },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -14,17 +15,21 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
+
     App::default()
         .insert_resource(ClearColor(Color::DARK_GRAY))
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -4,27 +4,30 @@
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{camera::Projection, render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{
+        camera::Projection, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
+    },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-    // options
-    //     .features
-    //     .set(WgpuFeatures::MAPPABLE_PRIMARY_BUFFERS, false);
-    // println!("wgpu options: {:?}", options.features);
+
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,circle=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)
@@ -95,7 +98,10 @@ fn setup(
     // The ground
     commands
         .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 4.0 })),
+            mesh: meshes.add(Mesh::from(shape::Plane {
+                size: 4.0,
+                ..default()
+            })),
             material: materials.add(Color::BLUE.into()),
             transform: Transform::from_xyz(0.0, -0.5, 0.0),
             ..Default::default()

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(rotate_camera)
         .run();

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .run();
 

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -4,27 +4,28 @@
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-    // options
-    //     .features
-    //     .set(WgpuFeatures::MAPPABLE_PRIMARY_BUFFERS, false);
-    // println!("wgpu options: {:?}", options.features);
+
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,circle=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)
@@ -87,7 +88,10 @@ fn setup(
     // The ground
     commands
         .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 4.0 })),
+            mesh: meshes.add(Mesh::from(shape::Plane {
+                size: 4.0,
+                ..default()
+            })),
             material: materials.add(Color::BLUE.into()),
             ..Default::default()
         })

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .run();
 

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         //.add_plugin(LookTransformPlugin)
         //.add_plugin(OrbitCameraPlugin::default())
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
     render::{
         mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings,
-        view::RenderLayers,
+        view::RenderLayers, RenderPlugin,
     },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -12,20 +12,21 @@ use std::f32::consts::PI;
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-    // options
-    //     .features
-    //     .set(WgpuFeatures::MAPPABLE_PRIMARY_BUFFERS, false);
-    // println!("wgpu options: {:?}", options.features);
+
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -175,7 +175,7 @@ fn main() {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .insert_resource(InstanceManager::new(5, 4))
         .add_startup_system(setup)
         .add_system(keyboard_input_system)

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .run();
 

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -14,24 +14,30 @@
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{
+        mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
+    },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
 
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -8,7 +8,7 @@ use bevy::{
         mesh::shape::{Cube, Plane},
         view::RenderLayers,
     },
-    window::{WindowId, WindowResized},
+    window::WindowResized,
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
@@ -95,8 +95,8 @@ fn setup(
         commands.spawn((
             Camera3dBundle {
                 camera: Camera {
-                    // Have a different priority for each camera to ensure determinism
-                    priority: i as isize,
+                    // Have a different order for each camera to ensure determinism
+                    order: i as isize,
                     ..default()
                 },
                 camera_3d: Camera3d {
@@ -133,7 +133,10 @@ fn setup(
     });
 
     let cube = meshes.add(Mesh::from(Cube { size: 1.0 }));
-    let plane = meshes.add(Mesh::from(Plane { size: 200.0 }));
+    let plane = meshes.add(Mesh::from(Plane {
+        size: 200.0,
+        ..default()
+    }));
     let mat = materials.add(Color::PURPLE.into());
     let ground_mat = materials.add(Color::OLIVE.into());
 
@@ -227,7 +230,7 @@ fn setup(
 }
 
 fn update_camera_viewports(
-    windows: Res<Windows>,
+    window: Query<&Window, With<bevy::window::PrimaryWindow>>,
     mut resize_events: EventReader<WindowResized>,
     mut query: Query<(&mut Camera, &SplitCamera)>,
 ) {
@@ -236,22 +239,20 @@ fn update_camera_viewports(
     // A resize_event is sent when the window is first created, allowing us to reuse
     // this system for initial setup.
     for resize_event in resize_events.iter() {
-        if resize_event.id == WindowId::primary() {
-            let window = windows.primary();
-            let dw = window.physical_width() / 2;
-            let dh = window.physical_height() / 2;
-            let physical_size = UVec2::new(dw, dh);
+        let Ok(window) = window.get(resize_event.window) else {continue;};
+        let dw = window.physical_width() / 2;
+        let dh = window.physical_height() / 2;
+        let physical_size = UVec2::new(dw, dh);
 
-            for (mut camera, split_camera) in query.iter_mut() {
-                camera.viewport = Some(Viewport {
-                    physical_position: UVec2::new(
-                        dw * split_camera.pos.x,
-                        dh * (1 - split_camera.pos.y),
-                    ),
-                    physical_size,
-                    ..default()
-                });
-            }
+        for (mut camera, split_camera) in query.iter_mut() {
+            camera.viewport = Some(Viewport {
+                physical_position: UVec2::new(
+                    dw * split_camera.pos.x,
+                    dh * (1 - split_camera.pos.y),
+                ),
+                physical_size,
+                ..default()
+            });
         }
     }
 }

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -22,7 +22,7 @@ fn main() {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update_camera_viewports)
         .run();

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .run();
 

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .run();
 

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -4,27 +4,30 @@
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{
+        mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
+    },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-    // options
-    //     .features
-    //     .set(WgpuFeatures::MAPPABLE_PRIMARY_BUFFERS, false);
-    // println!("wgpu options: {:?}", options.features);
+
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -4,6 +4,7 @@ use bevy::{
     render::{
         mesh::shape::Cube,
         settings::{WgpuLimits, WgpuSettings},
+        RenderPlugin,
     },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -22,18 +23,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 256 bytes, whereas on Desktop GPUs it can be much smaller, like 16 bytes
     // only. Force the downlevel limits here, and as an example of how
     // to force a particular limit, and to show Hanabi works with those settings.
-    let mut options = WgpuSettings::default();
+    let mut wgpu_settings = WgpuSettings::default();
     if USE_LOW_LIMITS {
         let limits = WgpuLimits::downlevel_defaults();
-        options.constrained_limits = Some(limits);
+        wgpu_settings.constrained_limits = Some(limits);
     }
 
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update_accel)
         .run();

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .add_system(update)
         .run();

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -8,6 +8,7 @@ use bevy::{
         camera::{Projection, ScalingMode},
         render_resource::WgpuFeatures,
         settings::WgpuSettings,
+        RenderPlugin,
     },
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -15,16 +16,21 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_hanabi::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = WgpuSettings::default();
-    options
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
         .features
         .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
+
     App::default()
-        .insert_resource(options)
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=warn,spawn=trace".to_string(),
-        }))
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
         .add_system(bevy::window::close_on_esc)
         .add_plugin(HanabiPlugin)
         .add_plugin(WorldInspectorPlugin)

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -701,7 +701,7 @@ mod tests {
             assert_eq!(value.value_type(), *value_type);
 
             // Create a tiny WGSL snippet with the Value(Type) and parse it
-            let src = format!("let x = {};", value.to_wgsl_string());
+            let src = format!("const x = {};", value.to_wgsl_string());
             let res = parser.parse(&src);
             if let Err(err) = &res {
                 println!("Error: {:?}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,7 +865,7 @@ struct RemovedEffectsEvent {
 }
 
 fn gather_removed_effects(
-    removed_effects: RemovedComponents<ParticleEffect>,
+    mut removed_effects: RemovedComponents<ParticleEffect>,
     mut removed_effects_event_writer: EventWriter<RemovedEffectsEvent>,
 ) {
     let entities: Vec<Entity> = removed_effects.iter().collect();

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -293,8 +293,8 @@ impl InitModifier for InitVelocityCircleModifier {
             r##"fn init_velocity_circle(transform: mat4x4<f32>, particle: ptr<function, Particle>) {{
     let delta = (*particle).{0} - {1};
     let radial = normalize(delta - dot(delta, {2}) * {2});
-    let radial = transform * vec4<f32>(radial.xyz, 0.0);
-    (*particle).{3} = radial.xyz * {4};
+    let radial_vec4 = transform * vec4<f32>(radial.xyz, 0.0);
+    (*particle).{3} = radial_vec4.xyz * {4};
 }}
 "##,
             Attribute::POSITION.name(),
@@ -363,8 +363,8 @@ impl InitModifier for InitVelocityTangentModifier {
             r##"fn init_velocity_tangent(transform: mat4x4<f32>, particle: ptr<function, Particle>) {{
     let radial = (*particle).{0} - {1};
     let tangent = normalize(cross({2}, radial));
-    let tangent = transform * vec4<f32>(tangent.xyz, 0.0);
-    (*particle).{3} = tangent.xyz * {4};
+    let tangent_vec4 = transform * vec4<f32>(tangent.xyz, 0.0);
+    (*particle).{3} = tangent_vec4.xyz * {4};
 }}
 "##,
             Attribute::POSITION.name(),
@@ -530,7 +530,7 @@ mod tests {
     return 0.0;
 }}
 
-let tau: f32 = 6.283185307179586476925286766559;
+const tau: f32 = 6.283185307179586476925286766559;
 
 struct Particle {{
     {attributes_code}
@@ -550,6 +550,7 @@ fn main() {{
             let mut parser = Parser::new();
             let res = parser.parse(&code);
             if let Err(err) = &res {
+                println!("Modifier: {:?}", modifier.type_name());
                 println!("Code: {:?}", code);
                 println!("Err: {:?}", err);
             }

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -335,7 +335,7 @@ fn rand() -> f32 {{
     return 0.0;
 }}
 
-let tau: f32 = 6.283185307179586476925286766559;
+const tau: f32 = 6.283185307179586476925286766559;
 
 struct Particle {{
     {attributes_code}
@@ -374,7 +374,7 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {{
             let mut parser = Parser::new();
             let res = parser.parse(&code);
             if let Err(err) = &res {
-                println!("Modifier: {:?}", modifier.get_type_info().type_name());
+                println!("Modifier: {:?}", modifier.type_name());
                 println!("Code: {:?}", code);
                 println!("Err: {:?}", err);
             }

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -432,7 +432,7 @@ mod tests {
     return 0.0;
 }}
 
-let tau: f32 = 6.283185307179586476925286766559;
+const tau: f32 = 6.283185307179586476925286766559;
 
 struct Particle {{
     {attributes_code}
@@ -487,6 +487,7 @@ fn main() {{
             let mut parser = Parser::new();
             let res = parser.parse(&code);
             if let Err(err) = &res {
+                println!("Modifier: {:?}", modifier.type_name());
                 println!("Code: {:?}", code);
                 println!("Err: {:?}", err);
             }

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -53,7 +53,7 @@ struct RenderIndirectBuffer {
 
 var<private> seed : u32 = 0u;
 
-let tau: f32 = 6.283185307179586476925286766559;
+const tau: f32 = 6.283185307179586476925286766559;
 
 // Rand: PCG
 // https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/
@@ -120,7 +120,7 @@ fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {
 
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let index = global_invocation_id.x;
+    var index = global_invocation_id.x;
 
     // Cap to max number of dead particles, copied from dead_count at the end of the
     // previous iteration, and constant during this pass (unlike dead_count).
@@ -137,7 +137,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Recycle a dead particle
     let dead_index = atomicSub(&render_indirect.dead_count, 1u) - 1u;
-    let index = indirect_buffer.indices[3u * dead_index + 2u];
+    index = indirect_buffer.indices[3u * dead_index + 2u];
 
     // Update PRNG seed
     seed = pcg_hash(index ^ spawner.seed);

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -57,7 +57,7 @@ struct RenderIndirectBuffer {
 
 var<private> seed : u32 = 0u;
 
-let tau: f32 = 6.283185307179586476925286766559;
+const tau: f32 = 6.283185307179586476925286766559;
 
 // Rand: PCG
 // https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -150,7 +150,10 @@ impl MockRenderer {
         // Create the WGPU adapter. Use PRIMARY backends (Vulkan, Metal, DX12,
         // Browser+WebGPU) to ensure we get a backend that supports compute and other
         // modern features we might need.
-        let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+        });
         let adapter =
             futures::executor::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::default(),
@@ -175,7 +178,7 @@ impl MockRenderer {
         .expect("Failed to create device");
 
         // Turn into Bevy objects
-        let device = RenderDevice::from(std::sync::Arc::new(device));
+        let device = RenderDevice::from(device);
         let queue = RenderQueue(std::sync::Arc::new(queue));
 
         Self {


### PR DESCRIPTION
**The update is blocked by bevy-inspector-egui, but not really since it only affects examples and can easily be disabled**

To run examples: Disable inspector in the Cargo toml and the example code

I only ran examples and tests, they all seemed to work fine, but I'm not sure if any features have been missed in these. I did have some weird errors when closing windows, and some of the tests seemed to eat a lot of GPU resources, but I'm not sure if this is new behavior.

Some things to note:

- Shaders now need to specify global variables with `const` instead of `let`.
- You can no longer redefine a variable name with `let`.
- The set EffectSystems::ExtractEffects is unused, and only lives in the ExtractSchedule, so it can probably be removed
- There is a new field on `RenderPipelineDescriptor` called `push_constant_ranges`, I left it empty but there might be a better value.