### PR TITLE
Fixed PositionCone3dModifier placing particles at twice the translation

### DIFF
--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -245,8 +245,7 @@ impl InitModifier for PositionCone3dModifier {
     let y = h;
     let z = r * sint;
     let p = vec3<f32>(x, y, z);
-    let p2 = transform * vec4<f32>(p, 1.0);
-    (*particle).{3} = p2.xyz;
+    (*particle).{3} = p.xyz;
     // Emit direction
     let rb2 = rb * alpha_r;
     let pb = vec3<f32>(rb2 * cost, h0, rb2 * sint);

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -245,7 +245,8 @@ impl InitModifier for PositionCone3dModifier {
     let y = h;
     let z = r * sint;
     let p = vec3<f32>(x, y, z);
-    (*particle).{3} = p.xyz;
+    let p2 = transform * vec4<f32>(p, 0.0);
+    (*particle).{3} = p2.xyz;
     // Emit direction
     let rb2 = rb * alpha_r;
     let pb = vec3<f32>(rb2 * cost, h0, rb2 * sint);


### PR DESCRIPTION
The position inside the cone was affected by the transform, but since the w component of the position was set to 1 the transform was affecting adding the translation. However this also gets done when it's rendered I believe, so the translation was added twice.

However I'm not sure why the position (and the speed in the next part) were affected by the transform at all. The code for InitPositionCircleModifier does not use transform, though the InitVelocityCircleModifier does, so maybe this change is the most correct? I can't seem to see any observable difference at all whether I keep it or remove it entirely, but maybe I'm missing something. Though I think maybe neither of them should be affected by the transform?
But maybe I'm missing something here.

Fixes #152