### PR TITLE
Non-mandatory `AGE` and `LIFETIME` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `SetColorModifier` to set a per-particle color on spawning, which doesn't vary during the particle's lifetime.
+- `SetSizeModifier` to set a per-particle size on spawning, which doesn't vary during the particle's lifetime.
+
+### Changed
+
+- The `Attribute::AGE` and `Attribute::LIFETIME` are not mandatory anymore, and are now only added to the particle layout of an effect if a modifier requires them.
+  - Particles without an age are (obviously) not aged anymore.
+  - Particles without a lifetime are not reaped and therefore do not die from aging.
+
+  The documentation for all modifiers has been updated to state which attribute(s) they require, if any.
+
 ## [0.6.1] 2023-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -267,14 +267,13 @@ The image on the left has the `BillboardModifier` enabled.
     - [ ] plane
     - [ ] generic mesh / point cloud (?)
   - [ ] Random position offset
-  - [x] Velocity over shape
+  - [x] Velocity over shape (with random speed)
     - [x] circle
     - [x] sphere
     - [x] tangent
-  - [x] Random velocity (partial; linked to emitter type)
-  - [ ] Constant color
-  - [ ] Random color
-  - [x] Constant/random age and lifetime
+  - [x] Constant/random per-particle color
+  - [x] Constant/random per-particle size
+  - [x] Constant/random par-particle age and lifetime
 - Update
   - [x] Motion integration (Euler)
   - [x] Apply forces

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -44,11 +44,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn base_effect(
-    name: impl Into<String>,
-    color_mod: ColorOverLifetimeModifier,
-    size_mod: SizeOverLifetimeModifier,
-) -> EffectAsset {
+const COLOR: Vec4 = Vec4::new(0.7, 0.7, 1.0, 1.0);
+const SIZE: Vec2 = Vec2::splat(0.1);
+
+fn base_effect(name: impl Into<String>) -> EffectAsset {
     EffectAsset {
         name: name.into(),
         capacity: 32768,
@@ -59,8 +58,10 @@ fn base_effect(
         lifetime: 3600_f32.into(),
     })
     .render(BillboardModifier)
-    .render(color_mod)
-    .render(size_mod)
+    .render(SetColorModifier {
+        color: COLOR.into(),
+    })
+    .render(SetSizeModifier { size: SIZE.into() })
 }
 
 fn spawn_effect(
@@ -116,28 +117,12 @@ fn setup(
     let cube = meshes.add(Mesh::from(Cube { size: 0.1 }));
     let mat = materials.add(Color::PURPLE.into());
 
-    let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec4::new(0.7, 0.7, 1.0, 1.0));
-    gradient.add_key(1.0, Vec4::new(0.7, 0.7, 1.0, 1.0));
-    let color_mod = ColorOverLifetimeModifier { gradient };
-
-    const SIZE: f32 = 0.1;
-
-    let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec2::splat(SIZE));
-    let size_mod = SizeOverLifetimeModifier { gradient };
-
     spawn_effect(
         &mut commands,
         "InitPositionCircleModifier".to_string(),
         Transform::from_translation(Vec3::new(-20., 0., 0.)),
         effects.add(
-            base_effect(
-                "InitPositionCircleModifier",
-                color_mod.clone(),
-                size_mod.clone(),
-            )
-            .init(InitPositionCircleModifier {
+            base_effect("InitPositionCircleModifier").init(InitPositionCircleModifier {
                 center: Vec3::ZERO,
                 axis: Vec3::Z,
                 radius: 5.,
@@ -153,12 +138,7 @@ fn setup(
         "InitPositionSphereModifier".to_string(),
         Transform::from_translation(Vec3::new(0., 0., 0.)),
         effects.add(
-            base_effect(
-                "InitPositionSphereModifier",
-                color_mod.clone(),
-                size_mod.clone(),
-            )
-            .init(InitPositionSphereModifier {
+            base_effect("InitPositionSphereModifier").init(InitPositionSphereModifier {
                 center: Vec3::ZERO,
                 radius: 5.,
                 dimension: ShapeDimension::Volume,
@@ -174,12 +154,7 @@ fn setup(
         Transform::from_translation(Vec3::new(20., -5., 0.))
             .with_rotation(Quat::from_rotation_z(1.)),
         effects.add(
-            base_effect(
-                "InitPositionCone3dModifier",
-                color_mod.clone(),
-                size_mod.clone(),
-            )
-            .init(InitPositionCone3dModifier {
+            base_effect("InitPositionCone3dModifier").init(InitPositionCone3dModifier {
                 height: 10.,
                 base_radius: 1.,
                 top_radius: 4.,

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -160,9 +160,7 @@ impl EffectAsset {
         // For legacy compatibility reasons, and because both the motion integration and
         // the particle aging are currently mandatory, add some default attributes.
         set.insert(Attribute::POSITION);
-        set.insert(Attribute::AGE);
         set.insert(Attribute::VELOCITY);
-        set.insert(Attribute::LIFETIME);
 
         // Build the layout
         let mut layout = ParticleLayout::new();

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -115,10 +115,15 @@ impl Attribute {
 
     /// The age of the particle.
     ///
-    /// When the age of the particle exceeds its lifetime (either a per-effect
+    /// Each time the particle is updated, the current simualtion delta time is
+    /// added to the particle's age. The age can be used to animate some other
+    /// quantities; see the [`ColorOverLifetimeModifier`] for example.
+    ///
+    /// If the particle also has a lifetime (either a per-effect
     /// constant value, or a per-particle value stored in the
-    /// [`Attribute::LIFETIME`] attribute), the particle dies and is not
-    /// simulated nor rendered anymore.
+    /// [`Attribute::LIFETIME`] attribute), then when the age of the particle
+    /// exceeds its lifetime, the particle dies and is not simulated nor
+    /// rendered anymore.
     ///
     /// # Type
     ///

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -54,6 +54,11 @@ macro_rules! impl_mod_init {
 }
 
 /// An initialization modifier spawning particles on a circle/disc.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitPositionCircleModifier {
     /// The circle center, relative to the emitter position.
@@ -124,6 +129,11 @@ impl InitModifier for InitPositionCircleModifier {
 }
 
 /// An initialization modifier spawning particles on a sphere.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitPositionSphereModifier {
     /// The sphere center, relative to the emitter position.
@@ -192,6 +202,11 @@ impl InitModifier for InitPositionSphereModifier {
 /// Particles are spawned somewhere inside the volume or on the surface of a
 /// truncated 3D cone defined by its base radius, its top radius, and the height
 /// of the cone section.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitPositionCone3dModifier {
     /// The cone height along its axis, between the base and top radii.
@@ -252,6 +267,12 @@ impl InitModifier for InitPositionCone3dModifier {
 }
 
 /// A modifier to set the initial velocity of particles radially on a circle.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
+/// - [`Attribute::VELOCITY`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitVelocityCircleModifier {
     /// The circle center, relative to the emitter position.
@@ -292,6 +313,12 @@ impl InitModifier for InitVelocityCircleModifier {
 
 /// A modifier to set the initial velocity of particles to a spherical
 /// distribution.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
+/// - [`Attribute::VELOCITY`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitVelocitySphereModifier {
     /// Center of the sphere. The radial direction of the velocity is the
@@ -321,6 +348,12 @@ impl InitModifier for InitVelocitySphereModifier {
 
 /// A modifier to set the initial velocity of particles along the tangent to an
 /// axis.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
+/// - [`Attribute::VELOCITY`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitVelocityTangentModifier {
     /// Origin from which to derive the radial axis based on the particle
@@ -366,6 +399,11 @@ impl InitModifier for InitVelocityTangentModifier {
 /// delta time. Various other modifiers use that age to smoothly vary some
 /// quantities, like [`SizeOverLifetimeModifier`].
 ///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::AGE`]
+///
 /// [`SizeOverLifetimeModifier`]: crate::SizeOverLifetimeModifier
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitAgeModifier {
@@ -392,6 +430,11 @@ impl InitModifier for InitAgeModifier {
 /// equal to their lifetime.
 ///
 /// The default lifetime is 5 seconds.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::LIFETIME`]
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct InitLifetimeModifier {
     /// The lifetime of all particles when they spawn, in seconds.
@@ -424,6 +467,11 @@ impl InitModifier for InitLifetimeModifier {
 /// The particle is initialized with a fixed or randomly distributed size value,
 /// and will retain that size unless another modifier (like
 /// [`SizeOverLifetimeModifier`]) changes its size after spawning.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::SIZE`] or [`Attribute::SIZE2`]
 ///
 /// [`SizeOverLifetimeModifier`]: crate::SizeOverLifetimeModifier
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -98,6 +98,11 @@ impl ToWgslString for ValueOrProperty {
 /// ```txt
 /// particle.velocity += acceleration * simulation.delta_time;
 /// ```
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::VELOCITY`]
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct AccelModifier {
     /// The acceleration to apply to all particles in the effect each frame.
@@ -221,6 +226,12 @@ impl ForceFieldSource {
 /// field is made up of [`ForceFieldSource`]s.
 ///
 /// The maximum number of sources is [`ForceFieldSource::MAX_SOURCES`].
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
+/// - [`Attribute::VELOCITY`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ForceFieldModifier {
     /// Array of force field sources.
@@ -291,6 +302,11 @@ impl UpdateModifier for ForceFieldModifier {
 
 /// A modifier to apply a linear drag force to all particles each frame. The
 /// force slows down the particles without changing their direction.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::VELOCITY`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct LinearDragModifier {
     /// Drag coefficient. Higher values increase the drag force, and
@@ -321,6 +337,11 @@ impl UpdateModifier for LinearDragModifier {
 ///
 /// This enables confining particles to a region in space, or preventing
 /// particles to enter that region.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct AabbKillModifier {
     /// Min corner of the AABB.

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -146,16 +146,12 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     let particle: ptr<storage, Particle, read_write> = &particle_buffer.particles[index];
 
-    // Age the particle
-    (*particle).age = (*particle).age + sim_params.dt;
-    var is_alive = (*particle).age < (*particle).lifetime;
-
+    {{AGE_CODE}}
     {{UPDATE_CODE}}
+    {{REAP_CODE}}
 
     // Check if alive
-    if (!is_alive || ((*particle).age >= (*particle).lifetime)) {
-        // Write back constant "dead" age
-        (*particle).age = (*particle).lifetime + 1.0;
+    if (!is_alive) {
         // Save dead index
         let dead_index = atomicAdd(&render_indirect.dead_count, 1u);
         indirect_buffer.indices[3u * dead_index + 2u] = index;


### PR DESCRIPTION
Make particle aging and reaping conditional to the presence of the `Attribute::AGE` and `Attribute::LIFETIME`, which are themselves not mandatory anymore (not added by default) but instead depend on the modifier(s) added to the `EffectAsset`.

Add two new modifiers:
- `SetColorModifier` to set the per-particle rendering color on spawn, to a constant value that do not vary with the age/lifetime of the particle.
- `SetSizeModifier` to set the per-particle size on spawn, also not varying after spawning.

This change further improves support for #118.