### PR TITLE
Add `MotionIntegration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SetColorModifier` to set a per-particle color on spawning, which doesn't vary during the particle's lifetime.
 - `SetSizeModifier` to set a per-particle size on spawning, which doesn't vary during the particle's lifetime.
+- `EffectAsset::motion_integration` to configure the type of motion integration of the particles of a system. Using this field, the user can now completely disable motion integration, or perform it _before_ the modifiers are applied. The default behavior remains to perform the motion integration _after_ all modifiers have been applied (`MotionIntegration::PostUpdate`).
 
 ### Changed
 
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Particles without a lifetime are not reaped and therefore do not die from aging.
 
   The documentation for all modifiers has been updated to state which attribute(s) they require, if any.
+
+- The `Attribute::POSITION` and `Attribute::VELOCITY` are not mandatory anymore. They are required if `EffectAsset::motion_integration` is set to something other than `MotionIntegration::None`, but are not added automatically to all effect, and instead require a modifier to explicitly insert them into the particle layout. Effects with a non-`None` motion integration but missing either of those two attributes will emit a warning at runtime. Add a position or velocity initializing modifier to fix it.
 
 ## [0.6.1] 2023-03-13
 

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -132,7 +132,11 @@ impl RenderModifier for ParticleTextureModifier {
     }
 }
 
-/// A modifier to set each particle's rendering color.
+/// A modifier to set the rendering color of all particles.
+///
+/// This modifier assigns a _single_ color to all particles. That color can be
+/// determined by the user with [`Value::Single`], or left randomized with
+/// [`Value::Uniform`], but will be the same color for all particles.
 ///
 /// # Attributes
 ///
@@ -221,7 +225,11 @@ impl RenderModifier for ColorOverLifetimeModifier {
     }
 }
 
-/// A modifier to set each particle's size.
+/// A modifier to set the size of all particles.
+///
+/// This modifier assigns a _single_ size to all particles. That size can be
+/// determined by the user with [`Value::Single`], or left randomized with
+/// [`Value::Uniform`], but will be the same size for all particles.
 ///
 /// # Attributes
 ///


### PR DESCRIPTION
Add a new `MotionIntegration` setting to `EffectAsset` to configure when, if at all, the motion integration of particles occurs relative to the application of modifiers. During the update pass, the optional motion integration code will be injected before or after the code for all modifiers. The default value is `MotionIntegration::PostUpdate` corresponding to the previous behavior of integrating the motion after the modifiers were applied.