### PR TITLE
Add `InitAttributeModifier`

### DIFF
--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -97,10 +97,6 @@ fn setup(
         })
         .insert(Name::new("ball"));
 
-    let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec4::new(0.0, 1.0, 1.0, 1.0));
-    gradient.add_key(1.0, Vec4::new(0.0, 1.0, 1.0, 0.0));
-
     let spawner = Spawner::once(30.0.into(), false);
     let effect = effects.add(
         EffectAsset {
@@ -109,6 +105,7 @@ fn setup(
             spawner,
             ..Default::default()
         }
+        .with_property("my_color", graph::Value::Uint(0xFFFFFFFF))
         .init(InitPositionSphereModifier {
             center: Vec3::ZERO,
             radius: BALL_RADIUS,
@@ -121,10 +118,13 @@ fn setup(
         .init(InitLifetimeModifier {
             lifetime: 5_f32.into(),
         })
+        .init(InitAttributeModifier {
+            attribute: Attribute::COLOR,
+            value: "my_color".into(),
+        })
         .render(SizeOverLifetimeModifier {
             gradient: Gradient::constant(Vec2::splat(0.05)),
-        })
-        .render(ColorOverLifetimeModifier { gradient }),
+        }),
     );
 
     commands
@@ -163,6 +163,14 @@ fn update(
             // This isn't the most accurate place to spawn the particle effect,
             // but this is just for demonstration, so whatever.
             effect_transform.translation = transform.translation;
+
+            // Pick a random particle color
+            let r = rand::random::<u8>();
+            let g = rand::random::<u8>();
+            let b = rand::random::<u8>();
+            let color = 0xFF000000u32 | (b as u32) << 16 | (g as u32) << 8 | (r as u32);
+            effect.set_property("my_color", color.into());
+
             // Spawn the particles
             effect.maybe_spawner().unwrap().reset();
         }

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -98,7 +98,7 @@ pub trait Modifier: Reflect + Send + Sync + 'static {
 
     /// Get the list of dependent attributes required for this modifier to be
     /// used.
-    fn attributes(&self) -> &[&'static Attribute];
+    fn attributes(&self) -> &[Attribute];
 
     /// Attempt to resolve any property reference to the actual property in the
     /// effect.

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -97,7 +97,7 @@ macro_rules! impl_mod_render {
                 Some(self)
             }
 
-            fn attributes(&self) -> &[&'static Attribute] {
+            fn attributes(&self) -> &[Attribute] {
                 $attrs
             }
 

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -49,7 +49,7 @@ macro_rules! impl_mod_update {
                 Some(self)
             }
 
-            fn attributes(&self) -> &[&'static Attribute] {
+            fn attributes(&self) -> &[Attribute] {
                 $attrs
             }
 
@@ -76,6 +76,12 @@ pub enum ValueOrProperty {
     ///
     /// [`EffectAsset`]: crate::EffectAsset
     ResolvedProperty((usize, String)),
+}
+
+impl From<&str> for ValueOrProperty {
+    fn from(value: &str) -> Self {
+        Self::Property(value.to_string())
+    }
 }
 
 impl ToWgslString for ValueOrProperty {
@@ -139,7 +145,7 @@ impl Modifier for AccelModifier {
         Some(self)
     }
 
-    fn attributes(&self) -> &[&'static Attribute] {
+    fn attributes(&self) -> &[Attribute] {
         &[Attribute::VELOCITY]
     }
 

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -45,9 +45,12 @@ struct RenderIndirectBuffer {
     ping: u32,
 };
 
+{{PROPERTIES}}
+
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
+{{PROPERTIES_BINDING}}
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as update
 @group(3) @binding(0) var<storage, read_write> render_indirect : RenderIndirectBuffer;
 


### PR DESCRIPTION
Add a new `InitAttributeModifier` to initialize any attribute to a value or property.

Change `Attribute` to be a handle-style wrapper around `&'static AttributeInner`, and enable reflection and serialization. Serialization is performed as the unique attribute name, without the default value.

Add access to properties from init modifiers.

Fix a bug where using `ParticleEffect::with_spawner()` would prevent properties from initializing correctly.