### PR TITLE
Fix texture selection in effect batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where using `ParticleEffect::with_spawner()` would prevent properties from initializing correctly.
+- Fixed a bug where the effect texture of the previously batched effect was incorrectly selected instead of the texture of the current effect. (#167)
 
 ## [0.6.1] 2023-03-13
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1676,7 +1676,6 @@ pub(crate) fn prepare_effects(
         } else {
             LayoutFlags::NONE
         };
-        image_handle_id = extracted_effect.image_handle_id;
         trace!("Effect: buffer #{} | range {:?}", buffer_index, range);
 
         #[cfg(feature = "2d")]
@@ -1806,6 +1805,9 @@ pub(crate) fn prepare_effects(
 
         render_shader = extracted_effect.render_shader.clone();
         trace!("render_shader = {:?}", render_shader);
+
+        image_handle_id = extracted_effect.image_handle_id;
+        trace!("image_handle_id = {:?}", image_handle_id);
 
         trace!("particle_layout = {:?}", slice.particle_layout);
 
@@ -2398,6 +2400,12 @@ pub(crate) fn queue_effects(
                             trace!("GPU image not yet available; skipping batch for now.");
                             continue;
                         }
+                    } else {
+                        trace!(
+                            "Image {:?} already has bind group {:?}.",
+                            image_handle,
+                            effect_bind_groups.images.get(&image_handle).unwrap()
+                        );
                     }
                 }
 
@@ -2525,6 +2533,12 @@ pub(crate) fn queue_effects(
                             trace!("GPU image not yet available; skipping batch for now.");
                             continue;
                         }
+                    } else {
+                        trace!(
+                            "Image {:?} already has bind group {:?}.",
+                            image_handle,
+                            effect_bind_groups.images.get(&image_handle).unwrap()
+                        );
                     }
                 }
 


### PR DESCRIPTION
Ensure effect batching picks the correct texture for the current effect, not the previous one.

Fixes #167