### PR TITLE
Pad the WGSL `Spawner` struct to align elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where using `ParticleEffect::with_spawner()` would prevent properties from initializing correctly.
 - Fixed a bug where the effect texture of the previously batched effect was incorrectly selected instead of the texture of the current effect. (#167)
+- Fixed a bug on some GPUs (most notably, on macOS) where incorrect data padding was breaking simulation of all but the first effect. (#165)
 
 ## [0.6.1] 2023-03-13
 

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -129,6 +129,8 @@ impl<T: Pod + ShaderType + ShaderSize> AlignedBufferVec<T> {
         self.values.len()
     }
 
+    /// Size in bytes of a single item in the buffer, aligned to the item
+    /// alignment.
     #[inline]
     pub fn aligned_size(&self) -> usize {
         self.aligned_size

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -43,6 +43,7 @@ struct Spawner {
     count: atomic<i32>,
     effect_index: u32,
     force_field: array<ForceFieldSource, 16>,
+    {{SPAWNER_PADDING}}
 };
 
 struct SpawnerBuffer {


### PR DESCRIPTION
Manually pad the WGSL `Spawner` struct in the `vfx_indirect.wgsl` compute shader, to ensure that when the struct is accessed as an element of the array in that shader and when that same struct is bound later as an individual item aligned to the storage buffer alignment of the device the two are at the same offset.

Fixes #165