### PR TITLE
Enable simulation while hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Neither of those systems mutate the `ParticleEffect` component anymore (the change detection mechanism of Bevy components will not be triggered).
 
 - Added `ParticleEffect::with_properties()` to define a set of properties from an iterator. Note however that the `set_property()` method moved to the `CompiledParticleEffect`.
+- Added a `SimulationCondition` enum and an `EffectAsset::simulation_condition` field allowing to control whether the effect is simulated while hidden (`Visibility::Hidden`). (#166)
 
 ### Changed
 
@@ -54,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug on some GPUs (most notably, on macOS) where incorrect data padding was breaking simulation of all but the first effect. (#165)
 - Fixed calls to `ParticleEffect::set_property()` being ignored if made before the particle effect has been updated once, due to properties not being resolved into the `EffectAsset` until the effect is effectively compiled. The `set_property()` method has now moved to the new `CompiledParticleEffect`, so cannot by design be made anymore before the effect is first updated.
 - Fixed `ParticleEffect::set_property()` invalidating the shader cache of the particle effect and causing a full shader recompile, which was impacting performance and defeating the point of using properties in the first place. The method has been moved to `CompiledParticleEffect`. (#162)
+- Fixed a bug where hidden (`Visibility::Hidden`) but still active effects were simulated in the background despite the documentation stating they were not. The newly-added `SimulationCondition::Always` allows explicitly opting in to this behavior in case you were relying on it, but this fix otherwise prevent those effects from being simulated. This _possibly_ relates to #67.
 
 ## [0.6.1] 2023-03-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ name = "multicam"
 required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
+name = "visibility"
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+
+[[example]]
 name = "random"
 required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ cargo run --example circle --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d
 
 ![circle](https://raw.githubusercontent.com/djeedai/bevy_hanabi/ffbf91be7f0780f8830869d14a64a79ca79baebb/examples/circle.gif)
 
+### Visibility
+
+This example demonstrates the difference between the default `SimulationCondition::WhenVisible` which simulates an effect when it's visible only, and `SimulationCondition::Always` which always simulates an effect even if the entity is hidden.
+
+```shell
+cargo run --example visibility --features="bevy/bevy_winit bevy/bevy_pbr 3d"
+```
+
 ### Random
 
 This example spawns particles with randomized parameters.
@@ -277,6 +285,9 @@ The image on the left has the `BillboardModifier` enabled.
   - [x] Constant/random per-particle size
   - [x] Constant/random par-particle age and lifetime
 - Update
+  - [x] Simulation condition
+    - [x] Always, even when hidden
+    - [x] Only when visible
   - [x] Motion integration (Euler)
   - [x] Apply forces
     - [x] Constant (gravity)

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -1,0 +1,178 @@
+//! Example showing the effect of [`SimulationCondition`] to continue simulating
+//! or not when the entity is invisible.
+//!
+//! This example spawns two effects:
+//! - The top one is only simulated when visible
+//!   ([`SimulationCondition::WhenVisible`]; default behavior).
+//! - The bottom one is always simulated, even when invisible
+//!   ([`SimulationCondition::Always`]).
+//!
+//! A system updates the visibility of the effects, toggling it ON and OFF. We
+//! can observe that the top effect continue to be simulated while hidden.
+
+use std::time::Duration;
+
+use bevy::{
+    log::LogPlugin,
+    prelude::*,
+    render::{
+        mesh::shape::Cube, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
+    },
+};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+
+use bevy_hanabi::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
+        .features
+        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
+
+    App::default()
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,visibility=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings })
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "🎆 Hanabi — visibility".to_string(),
+                        ..default()
+                    }),
+                    ..default()
+                }),
+        )
+        .add_system(bevy::window::close_on_esc)
+        .add_plugin(HanabiPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
+        .add_startup_system(setup)
+        .add_system(update)
+        .run();
+
+    Ok(())
+}
+
+fn setup(
+    mut commands: Commands,
+    mut effects: ResMut<Assets<EffectAsset>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let mut camera = Camera3dBundle::default();
+    camera.transform.translation = Vec3::new(0.0, 0.0, 100.0);
+    commands.spawn(camera);
+
+    commands.spawn(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            color: Color::WHITE,
+            // Crank the illuminance way (too) high to make the reference cube clearly visible
+            illuminance: 100000.,
+            shadows_enabled: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let cube = meshes.add(Mesh::from(Cube { size: 1.0 }));
+    let mat = materials.add(Color::PURPLE.into());
+
+    let mut gradient = Gradient::new();
+    gradient.add_key(0.0, Vec4::new(1.0, 0.0, 0.0, 1.0));
+    gradient.add_key(0.25, Vec4::new(0.0, 1.0, 0.0, 1.0));
+    gradient.add_key(0.5, Vec4::new(0.0, 0.0, 1.0, 1.0));
+    gradient.add_key(0.75, Vec4::new(0.0, 1.0, 1.0, 1.0));
+    gradient.add_key(1.0, Vec4::new(1.0, 1.0, 1.0, 1.0));
+
+    let mut asset = EffectAsset {
+        capacity: 4096,
+        spawner: Spawner::burst(50.0.into(), 15.0.into()),
+        simulation_condition: SimulationCondition::WhenVisible,
+        ..Default::default()
+    }
+    .init(InitPositionSphereModifier {
+        center: Vec3::ZERO,
+        radius: 5.,
+        dimension: ShapeDimension::Volume,
+    })
+    .init(InitAttributeModifier {
+        attribute: Attribute::VELOCITY,
+        value: ValueOrProperty::Value((Vec3::X * 3.).into()),
+    })
+    .init(InitLifetimeModifier {
+        lifetime: 15_f32.into(),
+    })
+    //.update(AccelModifier::constant(Vec3::new(0., 2., 0.)))
+    .render(ColorOverLifetimeModifier { gradient });
+    let effect1 = effects.add(asset.clone());
+
+    // Reference cube to visualize the emit origin
+    commands
+        .spawn(PbrBundle {
+            mesh: cube.clone(),
+            material: mat.clone(),
+            transform: Transform::from_translation(Vec3::new(-30., -20., 0.)),
+            ..Default::default()
+        })
+        .with_children(|p| {
+            p.spawn((
+                Name::new("WhenVisible"),
+                ParticleEffectBundle {
+                    effect: ParticleEffect::new(effect1),
+                    ..Default::default()
+                },
+            ));
+        });
+
+    asset.simulation_condition = SimulationCondition::Always;
+    let effect2 = effects.add(asset);
+
+    // Reference cube to visualize the emit origin
+    commands
+        .spawn(PbrBundle {
+            mesh: cube.clone(),
+            material: mat.clone(),
+            transform: Transform::from_translation(Vec3::new(-30., 20., 0.)),
+            ..Default::default()
+        })
+        .with_children(|p| {
+            p.spawn((
+                Name::new("Always"),
+                ParticleEffectBundle {
+                    effect: ParticleEffect::new(effect2),
+                    ..Default::default()
+                },
+            ));
+        });
+}
+
+fn update(
+    time: Res<Time>,
+    mut last_time: Local<u64>,
+    mut query: Query<&mut Visibility, With<ParticleEffect>>,
+) {
+    // Every half second, toggle the visibility. For the left effect (WhenVisible)
+    // this will effectively halve the simulation time compared to the real
+    // wall-clock time. For the right effect (Always) nothing will change because it
+    // continues to simulate when hidden.
+    // warn!(
+    //     "t={} l={} d={}",
+    //     time.elapsed().as_millis(),
+    //     *last_time,
+    //     (time.elapsed() - Duration::from_millis(*last_time)).as_millis()
+    // );
+    if time.elapsed() - Duration::from_millis(*last_time) >= Duration::from_millis(1500) {
+        //warn!("TOGGLE: ");
+        *last_time = time.elapsed().as_millis() as u64;
+        for mut visibility in query.iter_mut() {
+            *visibility = if *visibility == Visibility::Visible {
+                Visibility::Hidden
+            } else {
+                Visibility::Visible
+            };
+        }
+    }
+}

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -5,6 +5,7 @@ cargo r --example firework --no-default-features --features="bevy/bevy_winit bev
 cargo r --example portal --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example spawn --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example multicam --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
+cargo r --example visibility --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example random --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example spawn_on_command --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example activate --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -4,6 +4,7 @@ cargo r --example firework --no-default-features --features="bevy/bevy_winit bev
 cargo r --example portal --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example spawn --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example multicam --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
+cargo r --example visibility --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example random --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example spawn_on_command --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"
 cargo r --example activate --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -38,6 +38,48 @@ pub enum MotionIntegration {
     PostUpdate,
 }
 
+/// Simulation condition for an effect.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, FromReflect, Serialize, Deserialize,
+)]
+pub enum SimulationCondition {
+    /// Simulate the effect only when visible.
+    ///
+    /// The visibility is determined by the [`Visibility`] and
+    /// [`ComputedVisibility`] components.
+    ///
+    /// This is the default for all assets, and is the most performant option,
+    /// allowing to have many effects in the scene without the need to simulate
+    /// all of them if they're not visible.
+    ///
+    /// Note: AABB culling is not currently available. Only boolean ON/OFF
+    /// visibility is used.
+    ///
+    /// [`Visibility`]: bevy::render::view::Visibility
+    /// [`ComputedVisibility`]: bevy::render::view::ComputedVisibility
+    #[default]
+    WhenVisible,
+
+    /// Always simulate the effect, whether visible or not.
+    ///
+    /// For performance reasons, it's recommended to only simulate visible
+    /// particle effects (that is, use [`SimulationCondition::WhenVisible`]).
+    /// However occasionally it may be needed to continue the simulation
+    /// when the effect is not visible, to ensure some temporal continuity when
+    /// the effect is made visible again. This is an uncommon case, and you
+    /// should be aware of the performance implications of using this
+    /// condition, and only use it when strictly necessary.
+    ///
+    /// Any [`Visibility`] or [`ComputedVisibility`] component is ignored. You
+    /// may want to spawn the particle effect components manually instead of
+    /// using the [`ParticleEffectBundle`] to avoid adding those components.
+    ///
+    /// [`Visibility`]: bevy::render::view::Visibility
+    /// [`ComputedVisibility`]: bevy::render::view::ComputedVisibility
+    /// [`ParticleEffectBundle`]: crate::ParticleEffectBundle
+    Always,
+}
+
 /// Asset describing a visual effect.
 ///
 /// The effect can be instanciated with a [`ParticleEffect`] component, or a
@@ -74,6 +116,8 @@ pub struct EffectAsset {
     pub z_layer_2d: f32,
     /// Particle simulation space.
     pub simulation_space: SimulationSpace,
+    /// Condition under which the effect is simulated.
+    pub simulation_condition: SimulationCondition,
     /// Modifiers defining the effect.
     #[reflect(ignore)]
     // TODO - Can't manage to implement FromReflect for BoxedModifier in a nice way yet

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -29,14 +29,30 @@ pub struct ParticleEffectBundle {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible.
     ///
-    /// Invisible entities do not process any particles, making it efficient to
-    /// temporarily disable an effect instance.
+    /// Invisible entities do not process any particles if their
+    /// [`EffectAsset::simulation_condition`] is set to
+    /// [`SimulationCondition::WhenVisible`], which is the default. This makes
+    /// it efficient to temporarily disable an effect instance.
+    ///
+    /// If your effect uses [`SimulationCondition::Always`] then this component
+    /// is not necessary and you can remove it (spawn components manually
+    /// instead of using this bundle).
+    ///
+    /// [`EffectAsset::simulation_condition`]: crate::EffectAsset::simulation_condition
+    /// [`SimulationCondition::WhenVisible`]: crate::SimulationCondition::WhenVisible
+    /// [`SimulationCondition::Always`]: crate::SimulationCondition::Always
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and
     /// should be extracted for rendering.
     ///
+    /// If your effect uses [`SimulationCondition::Always`] then this component
+    /// is not necessary and you can remove it (spawn components manually
+    /// instead of using this bundle).
+    ///
     /// Users should not interact with this component manually, but it is
     /// required by Bevy's built-in visibility system.
+    ///
+    /// [`SimulationCondition::Always`]: crate::SimulationCondition::Always
     pub computed_visibility: ComputedVisibility,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1370,11 +1370,12 @@ else { return c1; }
             // Tick once
             app.update();
 
+            let world = &mut app.world;
+
             // Check the state of the components after `tick_spawners()` ran
             if let Some(test_visibility) = test_case.visibility {
                 // Simulated-when-visible effect (SimulationCondition::WhenVisible)
 
-                let world = &mut app.world;
                 let (
                     entity,
                     visibility,
@@ -1417,7 +1418,6 @@ else { return c1; }
             } else {
                 // Always-simulated effect (SimulationCondition::Always)
 
-                let world = &mut app.world;
                 let (entity, particle_effect, compiled_particle_effect) = world
                     .query::<(Entity, &ParticleEffect, &CompiledParticleEffect)>()
                     .iter(world)

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -894,11 +894,12 @@ mod test {
             };
             app.update();
 
+            let world = &mut app.world;
+
             // Check the state of the components after `tick_spawners()` ran
             if let Some(test_visibility) = test_case.visibility {
                 // Simulated-when-visible effect (SimulationCondition::WhenVisible)
 
-                let world = &mut app.world;
                 let (entity, visibility, computed_visibility, particle_effect, effect_spawner) =
                     world
                         .query::<(
@@ -947,7 +948,6 @@ mod test {
             } else {
                 // Always-simulated effect (SimulationCondition::Always)
 
-                let world = &mut app.world;
                 let (entity, particle_effect, effect_spawner) = world
                     .query::<(Entity, &ParticleEffect, Option<&EffectSpawner>)>()
                     .iter(world)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,9 +1,15 @@
 #![cfg(test)]
 
-use bevy::prelude::{Quat, Vec2, Vec3, Vec4};
 #[cfg(feature = "gpu_tests")]
 use bevy::render::renderer::{RenderDevice, RenderQueue};
-use std::ops::Sub;
+use bevy::{
+    asset::{AssetIo, AssetIoError, Metadata},
+    prelude::{Quat, Vec2, Vec3, Vec4},
+};
+use std::{
+    ops::Sub,
+    path::{Path, PathBuf},
+};
 
 /// Utility trait to compare floating-point values with a tolerance.
 pub(crate) trait AbsDiffEq {
@@ -197,5 +203,44 @@ impl MockRenderer {
     /// Get the Bevy render queue of the mock renderer.
     pub fn queue(&self) -> RenderQueue {
         self.queue.clone()
+    }
+}
+
+/// A dummy asset IO, just to satisfy the `AssetServer` requirements.
+/// This implementation does nothing.
+pub(crate) struct DummyAssetIo {}
+
+impl AssetIo for DummyAssetIo {
+    fn load_path<'a>(
+        &'a self,
+        _path: &'a Path,
+    ) -> bevy::utils::BoxedFuture<'a, anyhow::Result<Vec<u8>, AssetIoError>> {
+        Box::pin(async move {
+            let bytes = Vec::new();
+            Ok(bytes)
+        })
+    }
+
+    fn read_directory(
+        &self,
+        _path: &Path,
+    ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
+        Ok(Box::new(Vec::<PathBuf>::new().into_iter()))
+    }
+
+    fn watch_path_for_changes(
+        &self,
+        _to_watch: &Path,
+        _to_reload: Option<PathBuf>,
+    ) -> Result<(), AssetIoError> {
+        Ok(())
+    }
+
+    fn watch_for_changes(&self) -> Result<(), AssetIoError> {
+        Ok(())
+    }
+
+    fn get_metadata(&self, _path: &Path) -> Result<Metadata, AssetIoError> {
+        Ok(Metadata::new(bevy::asset::FileType::File))
     }
 }


### PR DESCRIPTION
Allow the effects to be simulated while hidden with the new `SimulationCondition::Always`, which can be assigned to the `EffectAsset::simulation_condition` field. The default value `SimulationCondition::WhenVisible` retain the documented behavior of not simulating any hidden effect (those with a `Visibility::Hidden` or inheriting their parent state).

Added a new `visibility.rs` example showing the behavior of `SimulationCondition::WhenVisible` and `SimulationCondition::Always`.

Fixed a bug where, despite the documentation stating that hidden effects were not simulated, they were nonetheless updated in the background. This possibly could have led to poor performance if many such effects were hidden, which therefore would possibly relate to #67.

Fixes #166