### PR TITLE
Add radial and tangent acceleration modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed the unused `EffectMaterial`, `EffectMaterialPlugin`, and `GpuEffectMaterial`.
-
-### Removed
-
 - Deleted the following unused types: `EffectMaterial`, `EffectMaterialUniformData`, `EffectMaterialPlugin`, `GpuEffectMaterial`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `ParticleEffect::with_properties()` to define a set of properties from an iterator. Note however that the `set_property()` method moved to the `CompiledParticleEffect`.
 - Added a `SimulationCondition` enum and an `EffectAsset::simulation_condition` field allowing to control whether the effect is simulated while hidden (`Visibility::Hidden`). (#166)
+- Added a new `RadialAccelModifier` update modifier applying a per-particle acceleration in the radial direction defined as the direction from the modifier's specified origin to the particle current position.
+- Added a new `TangentAccelModifier` update modifier applying a per-particle acceleration in the tangent direction defined as the cross product of the the modifier's specified rotation plane axis with the radial direction of the particle (calculated like `RadialAccelModifier`).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -289,8 +289,10 @@ The image on the left has the `BillboardModifier` enabled.
     - [x] Always, even when hidden
     - [x] Only when visible
   - [x] Motion integration (Euler)
-  - [x] Apply forces
-    - [x] Constant (gravity)
+  - [x] Apply forces and accelerations
+    - [x] Constant acceleration (gravity)
+    - [x] Radial acceleration
+    - [x] Tangent acceleration
     - [x] Force field
     - [x] Linear drag
   - [ ] Collision

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -73,17 +73,13 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
             radius: 4.,
             dimension: ShapeDimension::Surface,
         })
-        .init(InitVelocityTangentModifier {
-            origin: Vec3::ZERO,
-            axis: Vec3::Z,
-            speed: Value::Uniform((30., 50.)),
-        })
         .init(InitLifetimeModifier {
             // Give a bit of variation by randomizing the lifetime per particle
-            lifetime: Value::Uniform((0.6, 1.0)),
+            lifetime: Value::Uniform((0.6, 1.3)),
         })
-        .update(LinearDragModifier { drag: 6. })
-        .update(AccelModifier::constant(Vec3::new(0., -12., 0.)))
+        .update(LinearDragModifier { drag: 2. })
+        .update(RadialAccelModifier::constant(Vec3::ZERO, -6.0))
+        .update(TangentAccelModifier::constant(Vec3::ZERO, Vec3::Z, 30.))
         .render(ColorOverLifetimeModifier {
             gradient: color_gradient1,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,7 +746,7 @@ impl CompiledParticleEffect {
             if has_position && has_velocity {
                 // Note the prepended "\n" to prevent appending to a comment line.
                 let code = format!(
-                    "\n(*particle).{0} += (*particle).{1} * sim_params.dt;\n",
+                    "\nparticle.{0} += particle.{1} * sim_params.dt;\n",
                     Attribute::POSITION.name(),
                     Attribute::VELOCITY.name()
                 );
@@ -779,7 +779,7 @@ impl CompiledParticleEffect {
         let has_lifetime = present_attributes.contains(&Attribute::LIFETIME);
         let alive_init_code = if has_age && has_lifetime {
             format!(
-                "var is_alive = (*particle).{0} < (*particle).{1};",
+                "var is_alive = particle.{0} < particle.{1};",
                 Attribute::AGE.name(),
                 Attribute::LIFETIME.name()
             )
@@ -791,7 +791,7 @@ impl CompiledParticleEffect {
         };
         let age_code = if has_age {
             format!(
-                "(*particle).{0} = (*particle).{0} + sim_params.dt;",
+                "particle.{0} = particle.{0} + sim_params.dt;",
                 Attribute::AGE.name()
             )
         } else {
@@ -802,7 +802,7 @@ impl CompiledParticleEffect {
         // Configure reaping code
         let reap_code = if has_age && has_lifetime {
             format!(
-                "is_alive = is_alive && ((*particle).{0} < (*particle).{1});",
+                "is_alive = is_alive && (particle.{0} < particle.{1});",
                 Attribute::AGE.name(),
                 Attribute::LIFETIME.name()
             )

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -24,6 +24,10 @@
 
 use bevy::reflect::{FromReflect, Reflect};
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
 
 pub mod init;
 pub mod render;
@@ -47,6 +51,14 @@ pub enum ShapeDimension {
     Surface,
     /// Consider the entire shape volume.
     Volume,
+}
+
+/// Calculate a function ID by hashing the given value representative of the
+/// function.
+pub(crate) fn calc_func_id<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Context a modifier applies to.

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -5,22 +5,12 @@ use bevy::{
     utils::{FloatOrd, HashMap},
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
 use crate::{
-    Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, ShaderCode, ToWgslString, Value,
+    calc_func_id, Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, ShaderCode,
+    ToWgslString, Value,
 };
-
-/// Calculate a function ID by hashing the given value representative of the
-/// function.
-fn calc_func_id<T: Hash>(value: &T) -> u64 {
-    let mut hasher = DefaultHasher::default();
-    value.hash(&mut hasher);
-    hasher.finish()
-}
 
 /// Particle rendering shader code generation context.
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/src/modifier/update.rs
+++ b/src/modifier/update.rs
@@ -803,7 +803,7 @@ fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {{
 
 @compute @workgroup_size(64)
 fn main() {{
-    let particle: ptr<storage, Particle, read_write> = &particle_buffer.particles[0];
+    var particle: Particle = particle_buffer.particles[0];
     var transform: mat4x4<f32> = mat4x4<f32>();
     var is_alive = true;
 {update_code}

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -144,11 +144,13 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     let index = indirect_buffer.indices[3u * thread_index + pong];
 
-    let particle: ptr<storage, Particle, read_write> = &particle_buffer.particles[index];
+    var particle: Particle = particle_buffer.particles[index];
 
     {{AGE_CODE}}
     {{UPDATE_CODE}}
     {{REAP_CODE}}
+
+    particle_buffer.particles[index] = particle;
 
     // Check if alive
     if (!is_alive) {


### PR DESCRIPTION
Add two new update modifiers applying a per-particle acceleration dependent on the particle's position:
- `RadialAccelModifier` applies a radial acceleration in the direction going from the modifier's specified `origin` to the particle current position.
- `TangentAccelModifier` applies an acceleration in the tangent direction obtained as the cross product of the modifier's specified `axis` direction defining the rotation plane normal and the radial direction defined by the particle position (same calculation as `RadialAccelModifier`).

Fixes #97