### PR TITLE
Fix attribute name for InitSizeModifier w/ D2

### DIFF
--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -573,7 +573,7 @@ impl InitModifier for InitSizeModifier {
     fn apply(&self, context: &mut InitContext) {
         context.init_code += &format!(
             "particle.{} = {};\n",
-            Attribute::SIZE.name(),
+            self.attributes()[0].name(),
             self.size.to_wgsl_string(),
         );
     }


### PR DESCRIPTION
It should be "size2" for D2?