### PR TITLE
ParticleTextureModifier serialization

### DIFF
--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -86,7 +86,7 @@ fn setup(
             lifetime: 5_f32.into(),
         })
         .render(ParticleTextureModifier {
-            texture: texture_handle,
+            texture: texture_handle.into(),
         })
         .render(BillboardModifier {})
         .render(ColorOverLifetimeModifier { gradient })

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -77,7 +77,7 @@ fn setup(
             lifetime: 5_f32.into(),
         })
         .render(ParticleTextureModifier {
-            texture: texture_handle.clone(),
+            texture: texture_handle.clone().into(),
         })
         .render(ColorOverLifetimeModifier { gradient })
         .render(SizeOverLifetimeModifier {

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -87,7 +87,7 @@ fn setup(
             lifetime: 5_f32.into(),
         })
         .render(ParticleTextureModifier {
-            texture: texture_handle.clone(),
+            texture: texture_handle.clone().into(),
         })
         .render(ColorOverLifetimeModifier { gradient }),
     );

--- a/examples/serde_asset.rs
+++ b/examples/serde_asset.rs
@@ -1,0 +1,168 @@
+//! This example demonstrates saving and loading an EffectAsset.
+
+use bevy::{
+    log::LogPlugin,
+    prelude::*,
+    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
+};
+use bevy_inspector_egui::{bevy_egui, egui, quick::WorldInspectorPlugin};
+
+use bevy_hanabi::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut wgpu_settings = WgpuSettings::default();
+    wgpu_settings
+        .features
+        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
+
+    App::default()
+        .insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    level: bevy::log::Level::WARN,
+                    filter: "bevy_hanabi=warn,spawn=trace".to_string(),
+                })
+                .set(RenderPlugin { wgpu_settings }),
+        )
+        .add_system(bevy::window::close_on_esc)
+        .add_plugin(HanabiPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
+        .add_startup_system(setup)
+        .add_system(respawn)
+        .add_system(load_save_ui)
+        .run();
+
+    Ok(())
+}
+
+const COLOR: Vec4 = Vec4::new(0.7, 0.7, 1.0, 1.0);
+const PATH: &str = "disk.effect";
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut effects: ResMut<Assets<EffectAsset>>,
+) {
+    // Spawn camera.
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+
+    // Try to load the asset first. If it doesn't exist yet, create it.
+    let effect = match asset_server
+        .asset_io()
+        .get_metadata(std::path::Path::new(PATH))
+    {
+        Ok(metadata) => {
+            assert!(metadata.is_file());
+            asset_server.load(PATH)
+        }
+        Err(_) => effects.add(
+            EffectAsset {
+                name: "💾".to_owned(),
+                capacity: 32768,
+                spawner: Spawner::rate(48.0.into()),
+                ..Default::default()
+            }
+            .init(InitPositionSphereModifier {
+                center: Vec3::ZERO,
+                radius: 1.,
+                dimension: ShapeDimension::Volume,
+            })
+            .init(InitAttributeModifier {
+                attribute: Attribute::VELOCITY,
+                value: ValueOrProperty::Value((Vec3::Y * 2.).into()),
+            })
+            .init(InitLifetimeModifier {
+                lifetime: 0.9.into(),
+            })
+            .render(ParticleTextureModifier {
+                // Need to supply a handle and a path in order to save it later.
+                texture: AssetHandle::new(asset_server.load("cloud.png"), "cloud.png"),
+            })
+            .render(SetColorModifier {
+                color: COLOR.into(),
+            })
+            .render(SizeOverLifetimeModifier {
+                gradient: {
+                    let mut gradient = Gradient::new();
+                    gradient.add_key(0.0, Vec2::splat(0.1));
+                    gradient.add_key(0.1, Vec2::splat(1.0));
+                    gradient.add_key(1.0, Vec2::splat(0.01));
+                    gradient
+                },
+            }),
+        ),
+    };
+
+    spawn_effect(&mut commands, effect);
+}
+
+fn spawn_effect(commands: &mut Commands, effect: Handle<EffectAsset>) -> Entity {
+    commands
+        .spawn((
+            Name::new("💾"),
+            ParticleEffectBundle {
+                effect: ParticleEffect::new(effect),
+                ..Default::default()
+            },
+        ))
+        .id()
+}
+
+// Respawn effects when the asset changes.
+fn respawn(
+    mut commands: Commands,
+    mut effect_events: EventReader<AssetEvent<EffectAsset>>,
+    effects: Res<Assets<EffectAsset>>,
+    query: Query<Entity, With<ParticleEffect>>,
+) {
+    for event in effect_events.iter() {
+        match event {
+            AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
+                for entity in query.iter() {
+                    commands.entity(entity).despawn();
+                    let mut handle = handle.clone();
+                    handle.make_strong(&effects);
+                    spawn_effect(&mut commands, handle);
+                }
+                return;
+            }
+            _ => (),
+        }
+    }
+}
+
+fn load_save_ui(
+    asset_server: Res<AssetServer>,
+    mut contexts: bevy_egui::EguiContexts,
+    effects: ResMut<Assets<EffectAsset>>,
+) {
+    use std::io::Write;
+
+    egui::Window::new("💾").show(contexts.ctx_mut(), |ui| {
+        // You can edit the asset on disk and click load to see changes.
+        let load = ui.button("Load");
+        if load.clicked() {
+            // Reload the asset.
+            asset_server.reload_asset(PATH);
+        }
+
+        // Save effect to PATH.
+        let save = ui.button("Save");
+        if save.clicked() {
+            let (_handle, effect) = effects.iter().next().unwrap();
+            let ron = ron::ser::to_string_pretty(&effect, Default::default()).unwrap();
+            let mut file = std::fs::File::create(format!(
+                "{}/{}/{}",
+                std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned()),
+                "assets",
+                PATH
+            ))
+            .unwrap();
+            file.write(ron.as_bytes()).unwrap();
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ mod test_utils;
 
 use properties::{Property, PropertyInstance};
 
-pub use asset::{EffectAsset, MotionIntegration, SimulationCondition};
+pub use asset::{AssetHandle, EffectAsset, MotionIntegration, SimulationCondition};
 pub use attributes::*;
 pub use bundle::ParticleEffectBundle;
 pub use gradient::{Gradient, GradientKey};

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
 use crate::{
-    calc_func_id, Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, ShaderCode,
-    ToWgslString, Value,
+    calc_func_id, AssetHandle, Attribute, BoxedModifier, Gradient, Modifier, ModifierContext,
+    ShaderCode, ToWgslString, Value,
 };
 
 /// Particle rendering shader code generation context.
@@ -106,11 +106,8 @@ macro_rules! impl_mod_render {
 #[derive(Default, Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize)]
 pub struct ParticleTextureModifier {
     /// The texture image to modulate the particle color with.
-    #[serde(skip)]
-    // TODO - Clarify if Modifier needs to be serializable, or we need another on-disk
-    // representation... NOTE - Need to keep a strong handle here, nothing else will keep that
-    // texture loaded currently.
-    pub texture: Handle<Image>,
+    // NOTE - Need to keep a strong handle here, nothing else will keep that texture loaded currently.
+    pub texture: AssetHandle<Image>,
 }
 
 impl_mod_render!(ParticleTextureModifier, &[]); // TODO - should require some UV maybe?
@@ -118,7 +115,7 @@ impl_mod_render!(ParticleTextureModifier, &[]); // TODO - should require some UV
 #[typetag::serde]
 impl RenderModifier for ParticleTextureModifier {
     fn apply(&self, context: &mut RenderContext) {
-        context.set_particle_texture(self.texture.clone());
+        context.set_particle_texture(self.texture.handle.clone());
     }
 }
 
@@ -361,7 +358,7 @@ mod tests {
     fn mod_particle_texture() {
         let texture = Handle::<Image>::default();
         let modifier = ParticleTextureModifier {
-            texture: texture.clone(),
+            texture: texture.clone().into(),
         };
 
         let mut context = RenderContext::default();


### PR DESCRIPTION
This is a way to handle serialization of particle textures within `EffectAsset` by way of:

- Storing the texture asset path with the handle in an `AssetHandle`, which derefs to `Handle` and de/serializes as an `AssetPath`.
- Loading particle textures in the `EffectAssetLoader` as dependent assets to the effect.

I included a new example in which you can save the current effect to the assets directory, edit the file, and click "load" to respawn the effect with the new asset.

I found the idea [here](https://github.com/bevyengine/bevy/issues/6275). I believe `AssetHandle` becomes unnecessary with the new asset rework (https://github.com/bevyengine/bevy/pull/8624) in Bevy 0.12.