### PR TITLE
Add screen-space size to render modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new `EvalContext` trait representing the evaluation context of an expression, and giving access to the underlying expression `Module`
   and the property layout of the efect. The trait is implemented by `InitContext` and `UpdateContext`.
 - Added convenience method `PropertyLayout::contains()` to determine if a layout contains a property by name.
+- Added `SetSizeModifier::screen_space_size` and `SizeOverLifetimeModifier::screen_space_size` boolean fields which change the behavior of the particle size to be expressed in screen-space logical pixels, independently of the camera projection. This enables creating particle effect with constant pixel size. Set `screen_space_size = false` to get the previous behavior.
 
 ### Changed
 

--- a/docs/migration-v0.6-to-v0.7.md
+++ b/docs/migration-v0.6-to-v0.7.md
@@ -130,3 +130,5 @@ Note that previously a common pattern was to create modifiers inline while build
 - Same kind of conversions for `graph::ValueType`.
 
 - Rename `SimParams::dt` into `SimParams::delta_time`, and any shader use of `dt` into `delta_time`.
+
+- Add an extra `screen_space_size = false` field to the `SetSizeModifier` and `SizeOverLifetimeModifier`.

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -102,6 +102,7 @@ fn setup(
             .init(init_lifetime)
             .render(SizeOverLifetimeModifier {
                 gradient: Gradient::constant(Vec2::splat(0.02)),
+                screen_space_size: false,
             })
             .render(ColorOverLifetimeModifier { gradient }),
     );

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -117,6 +117,7 @@ fn setup(
             .init(init_lifetime)
             .render(SizeOverLifetimeModifier {
                 gradient: Gradient::constant(Vec2::splat(0.02)),
+                screen_space_size: false,
             })
             .render(ColorOverLifetimeModifier { gradient }),
     );

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -90,6 +90,7 @@ fn setup(
             .render(ColorOverLifetimeModifier { gradient })
             .render(SizeOverLifetimeModifier {
                 gradient: Gradient::constant([0.2; 2].into()),
+                screen_space_size: false,
             }),
     );
 

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -81,6 +81,7 @@ fn setup(
             .render(ColorOverLifetimeModifier { gradient })
             .render(SizeOverLifetimeModifier {
                 gradient: Gradient::constant([0.2; 2].into()),
+                screen_space_size: false,
             }),
     );
 

--- a/examples/expr.rs
+++ b/examples/expr.rs
@@ -96,6 +96,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
             })
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient,
+                screen_space_size: false,
             })
             .render(OrientAlongVelocityModifier),
     );

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -110,6 +110,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
     })
     .render(SizeOverLifetimeModifier {
         gradient: size_gradient1,
+        screen_space_size: false,
     });
 
     let effect1 = effects.add(effect);

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -198,6 +198,7 @@ fn setup(
             .update(deny_zone)
             .render(SizeOverLifetimeModifier {
                 gradient: Gradient::constant(Vec2::splat(0.05)),
+                screen_space_size: false,
             })
             .render(ColorOverLifetimeModifier { gradient }),
     );

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -60,7 +60,10 @@ fn base_effect(name: impl Into<String>) -> EffectAsset {
         .render(SetColorModifier {
             color: COLOR.into(),
         })
-        .render(SetSizeModifier { size: SIZE.into() })
+        .render(SetSizeModifier {
+            size: SIZE.into(),
+            screen_space_size: false,
+        })
 }
 
 fn spawn_effect(

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -72,6 +72,7 @@ fn make_effect(color: Color) -> EffectAsset {
         })
         .render(SizeOverLifetimeModifier {
             gradient: size_gradient.clone(),
+            screen_space_size: false,
         })
         .render(BillboardModifier)
 }

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -88,6 +88,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
             })
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient1,
+                screen_space_size: false,
             })
             .render(OrientAlongVelocityModifier),
     );

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -122,6 +122,7 @@ fn setup(
             })
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient1,
+                screen_space_size: false,
             }),
     );
 

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -123,8 +123,11 @@ fn setup(
             })
             .init(init_lifetime)
             .init(init_color)
+            // Set a size of 3->10 (logical) pixels, constant in screen space, independent of
+            // projection, but varying over the lifetime of the particle.
             .render(SizeOverLifetimeModifier {
-                gradient: Gradient::linear(Vec2::splat(0.02), Vec2::splat(0.04)),
+                gradient: Gradient::linear(Vec2::splat(3.), Vec2::splat(10.)),
+                screen_space_size: true,
             }),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,8 @@ pub struct CompiledParticleEffect {
     /// 2D layer for the effect instance.
     #[cfg(feature = "2d")]
     z_layer_2d: FloatOrd,
+    /// Is the particle size in screen-space logical pixels?
+    screen_space_size: bool,
 }
 
 impl Default for CompiledParticleEffect {
@@ -603,6 +605,7 @@ impl Default for CompiledParticleEffect {
             particle_texture: None,
             #[cfg(feature = "2d")]
             z_layer_2d: FloatOrd(0.0),
+            screen_space_size: false,
         }
     }
 }
@@ -839,6 +842,8 @@ impl CompiledParticleEffect {
             m.apply(&mut render_context);
         }
 
+        self.screen_space_size = render_context.screen_space_size;
+
         // Configure aging code
         let has_age = present_attributes.contains(&Attribute::AGE);
         let has_lifetime = present_attributes.contains(&Attribute::LIFETIME);
@@ -911,15 +916,12 @@ impl CompiledParticleEffect {
         trace!("Configured render shader:\n{}", render_shader_source);
 
         trace!(
-            "tick_spawners: init_shader={:?} update_shader={:?} render_shader={:?} has_image={}",
+            "tick_spawners: init_shader={:?} update_shader={:?} render_shader={:?} has_image={} screen_space_size={}",
             init_shader,
             update_shader,
             render_shader,
-            if render_context.particle_texture.is_some() {
-                "Y"
-            } else {
-                "N"
-            },
+            render_context.particle_texture.is_some(),
+            self.screen_space_size
         );
 
         // TODO - Replace with Option<ConfiguredShader { handle: Handle<Shader>, hash:

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -1,3 +1,11 @@
+
+struct ColorGrading {
+    exposure: f32,
+    gamma: f32,
+    pre_saturation: f32,
+    post_saturation: f32,
+}
+
 struct View {
     view_proj: mat4x4<f32>,
     inverse_view_proj: mat4x4<f32>,
@@ -6,9 +14,10 @@ struct View {
     projection: mat4x4<f32>,
     inverse_projection: mat4x4<f32>,
     world_position: vec3<f32>,
-    width: f32,
-    height: f32,
-};
+    // viewport(x_origin, y_origin, width, height)
+    viewport: vec4<f32>,
+    color_grading: ColorGrading,
+}
 
 struct Particle {
 {{ATTRIBUTES}}
@@ -137,11 +146,18 @@ fn vertex(
 
 {{VERTEX_MODIFIERS}}
 
+#ifdef PARTICLE_SCREEN_SPACE_SIZE
+    let half_screen = view.viewport.zw / 2.;
+    let vpos = vertex_position * vec3<f32>(size.x / half_screen.x, size.y / half_screen.y, 1.0);
+    out.position = view.view_proj * vec4<f32>(particle.position, 1.0) + vec4<f32>(vpos, 0.0);
+#else
     let vpos = vertex_position * vec3<f32>(size.x, size.y, 1.0);
     let world_position = particle.position
         + axis_x * vpos.x
         + axis_y * vpos.y;
     out.position = view.view_proj * vec4<f32>(world_position, 1.0);
+#endif
+
     out.color = color;
 
     return out;


### PR DESCRIPTION
Add the ability to define the particle size in screen-space logical pixels, instead of world units.

Fix batching of textured and non-textured effects mixed in the same scene.

Bug: #161, #181