### PR TITLE
Run CI on PR changed from Draft to Ready

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,23 @@
 name: CI
 
 on:
+  # Run on pull requests (PR)
   pull_request:
     types:
+    # New PR
     - opened
+    # Change pushed to source branch
     - synchronize
+    # PR reopened
     - reopened
+    # PR converted from Draft to Ready For Review
     - ready_for_review
+  # Run on any new change on the main branch (CI)
   push:
     branches:
       - main
+  # Enable manual trigger via GitHub UI
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
   push:
     branches:
       - main


### PR DESCRIPTION
Run CI workflow when a PR is converted from Draft status to Ready For Review. Somehow bizarrely this doesn't happen by default.

Also enable manually triggering CI, in case there's a GitHub bug.