### PR TITLE
Rename `spawn::Value` to `CpuValue` and fix `Hash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the property layout of the efect. The trait is implemented by `InitContext` and `UpdateContext`.
 - Added convenience method `PropertyLayout::contains()` to determine if a layout contains a property by name.
 - Added `SetSizeModifier::screen_space_size` and `SizeOverLifetimeModifier::screen_space_size` boolean fields which change the behavior of the particle size to be expressed in screen-space logical pixels, independently of the camera projection. This enables creating particle effect with constant pixel size. Set `screen_space_size = false` to get the previous behavior.
+- Added a new utility trait `FloatHash` to allow implementing `std::cmp::Eq` and `std::hash::Hash` on floating-point variants of `CpuValue` (ex-`spawn::Value`), making it possible to derive `std::hash::Hash` for any type using `CpuValue`.
+- `SetColorModifier` and `SetSizeModifier` now implement `std::cmp::Eq`, thanks to `CpuValue` itself implementing that trait for all floating point types (see `FloatHash`).
 
 ### Changed
 
+- Renamed `spawn::Value` to `spawn::CpuValue` to prevent confusion with `graph::Value`. The former is a legacy construct which should eventually be replaced by the latter (but cannot be yet).
 - `ValueType` is now one of `ScalarType` / `VectorType` / `MatrixType`, allowing to represent a wider range of types, including booleans and matrices.
 - `graph::Value` is now one of `ScalarValue` / `VectorValue` / `MatrixValue`, for consistency with `ValueType`.
 - `SimParams::dt` was renamed to `SimParams::delta_time` for readability. Inside shaders, `sim_params.dt` was also renamed to `sim_params.delta_time`.
@@ -49,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where a `ParticleEffect` spawned hidden (with `Visibility::Hidden`) would make Hanabi panic when made visible. Effects are now always compiled as soon as spawned. (#182)
+- Fixed the implementation of `std::hash::Hash` for `SetColorModifier` and `SetSizeModifier`, which were manually implemented and were not hashing the variant type of the value. This increased the risk of hash collision. The new implementation is derived thanks to `CpuValue` itself now implementing `std::hash::Hash`, and therefore likely hashes to a different value than in the previous release.
 
 ## [0.6.2] 2023-06-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ wgpu = "0.16"
 naga = "0.12"
 
 futures = "0.3"
-bevy-inspector-egui = "0.18"
+#bevy-inspector-egui = "0.18"
 
 [[example]]
 name = "firework"

--- a/docs/migration-v0.6-to-v0.7.md
+++ b/docs/migration-v0.6-to-v0.7.md
@@ -103,6 +103,10 @@ Note that previously a common pattern was to create modifiers inline while build
 
 ## Other migration items
 
+- Rename `spawn::Value` to `spawn::CpuValue`. This prevents confusion with `graph::Value` and allow importing both types at once.
+
+- The `std::hash::Hash` implementation for `SetColorModifier` and `SetSizeModifier` changed. If you previously stored some hash values, they likely will be different between v0.6 and v0.7. You can check the old manual implementation in v0.6 if you need to write some conversion code.
+
 - All typed values like `graph::Value::Float3` need to be replaced by their scalar/vector counterpart:
   - `graph::Value::Float(f)` becomes `graph::Value::Scalar(ScalarValue::Float(f)))`
   - `graph::Value::Float3(v)` becomes `graph::Value::Vector(VectorValue::new_vec3(v))`

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -82,7 +82,7 @@ fn setup(
             .init(InitVelocityCircleModifier {
                 center: Vec3::ZERO,
                 axis: Vec3::Y,
-                speed: Value::Uniform((0.7, 0.5)),
+                speed: CpuValue::Uniform((0.7, 0.5)),
             })
             .init(init_lifetime)
             .render(ParticleTextureModifier {

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -77,7 +77,7 @@ fn setup(
             .init(InitVelocityCircleModifier {
                 center: Vec3::ZERO,
                 axis: Vec3::Y,
-                speed: Value::Uniform((1.0, 1.5)),
+                speed: CpuValue::Uniform((1.0, 1.5)),
             })
             .init(init_lifetime)
             .render(ParticleTextureModifier {

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -103,7 +103,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
     .init(InitVelocitySphereModifier {
         center: Vec3::ZERO,
         // Give a bit of variation by randomizing the initial speed
-        speed: Value::Uniform((65., 75.)),
+        speed: CpuValue::Uniform((65., 75.)),
     })
     .init(init_age)
     .init(init_lifetime)

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -174,7 +174,7 @@ fn setup(
             })
             .init(InitVelocitySphereModifier {
                 center: Vec3::ZERO,
-                speed: Value::Uniform((0.1, 0.3)),
+                speed: CpuValue::Uniform((0.1, 0.3)),
             })
             .init(init_lifetime)
             .update(ForceFieldModifier::new(vec![

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     App::default()
         .add_plugins(DefaultPlugins.set(LogPlugin {
             level: bevy::log::Level::WARN,
-            filter: "bevy_hanabi=trace,portal=trace".to_string(),
+            filter: "bevy_hanabi=warn,portal=trace".to_string(),
         }))
         .add_systems(Update, bevy::window::close_on_esc)
         .add_plugins(HanabiPlugin)

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -81,7 +81,7 @@ fn setup(
     let effect = effects.add(
         EffectAsset::new(
             32768,
-            Spawner::burst(Value::Uniform((1., 100.)), Value::Uniform((1., 4.))),
+            Spawner::burst(CpuValue::Uniform((1., 100.)), CpuValue::Uniform((1., 4.))),
             writer.finish(),
         )
         .with_name("emit:burst")

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -233,7 +233,7 @@ fn setup(
         .init(init_lifetime3)
         .init(InitSizeModifier {
             // At spawn time, assign each particle a random size between 0.3 and 0.7
-            size: Value::<f32>::Uniform((0.3, 0.7)).into(),
+            size: CpuValue::<f32>::Uniform((0.3, 0.7)).into(),
         })
         .update(update_accel3)
         .render(ColorOverLifetimeModifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub use modifier::*;
 pub use plugin::HanabiPlugin;
 pub use properties::{Property, PropertyLayout};
 pub use render::{EffectSystems, ShaderCache};
-pub use spawn::{tick_spawners, DimValue, EffectSpawner, Random, Spawner, Value};
+pub use spawn::{tick_spawners, CpuValue, DimValue, EffectSpawner, Random, Spawner};
 
 #[allow(missing_docs)]
 pub mod prelude {
@@ -288,7 +288,7 @@ impl ToWgslString for u32 {
     }
 }
 
-impl ToWgslString for Value<f32> {
+impl ToWgslString for CpuValue<f32> {
     fn to_wgsl_string(&self) -> String {
         match self {
             Self::Single(x) => x.to_wgsl_string(),
@@ -301,7 +301,7 @@ impl ToWgslString for Value<f32> {
     }
 }
 
-impl ToWgslString for Value<Vec2> {
+impl ToWgslString for CpuValue<Vec2> {
     fn to_wgsl_string(&self) -> String {
         match self {
             Self::Single(v) => v.to_wgsl_string(),
@@ -314,7 +314,7 @@ impl ToWgslString for Value<Vec2> {
     }
 }
 
-impl ToWgslString for Value<Vec3> {
+impl ToWgslString for CpuValue<Vec3> {
     fn to_wgsl_string(&self) -> String {
         match self {
             Self::Single(v) => v.to_wgsl_string(),
@@ -327,7 +327,7 @@ impl ToWgslString for Value<Vec3> {
     }
 }
 
-impl ToWgslString for Value<Vec4> {
+impl ToWgslString for CpuValue<Vec4> {
     fn to_wgsl_string(&self) -> String {
         match self {
             Self::Single(v) => v.to_wgsl_string(),
@@ -367,7 +367,7 @@ pub struct PropertyValue {
 
     /// The property value to assign, instead of the default value of the
     /// property.
-    value: graph::Value,
+    value: Value,
 }
 
 impl From<PropertyInstance> for PropertyValue {
@@ -526,7 +526,7 @@ impl ParticleEffect {
     /// [`properties`]: crate::ParticleEffect::properties
     pub fn with_properties<P>(
         mut self,
-        properties: impl IntoIterator<Item = (String, graph::Value)>,
+        properties: impl IntoIterator<Item = (String, Value)>,
     ) -> Self {
         let iter = properties.into_iter();
         for (name, value) in iter {
@@ -964,7 +964,7 @@ impl CompiledParticleEffect {
     ///
     /// A property must exist which has been added to the source
     /// [`EffectAsset`].
-    pub fn set_property(&mut self, name: &str, value: graph::Value) {
+    pub fn set_property(&mut self, name: &str, value: Value) {
         if let Some(index) = self
             .properties
             .iter()
@@ -1262,17 +1262,17 @@ mod tests {
 
     #[test]
     fn to_wgsl_value_f32() {
-        let s = Value::Single(1.0_f32).to_wgsl_string();
+        let s = CpuValue::Single(1.0_f32).to_wgsl_string();
         assert_eq!(s, "1.");
-        let s = Value::Uniform((1.0_f32, 2.0_f32)).to_wgsl_string();
+        let s = CpuValue::Uniform((1.0_f32, 2.0_f32)).to_wgsl_string();
         assert_eq!(s, "(rand() * (2. - 1.) + 1.)");
     }
 
     #[test]
     fn to_wgsl_value_vec2() {
-        let s = Value::Single(Vec2::ONE).to_wgsl_string();
+        let s = CpuValue::Single(Vec2::ONE).to_wgsl_string();
         assert_eq!(s, "vec2<f32>(1.,1.)");
-        let s = Value::Uniform((Vec2::ZERO, Vec2::ONE)).to_wgsl_string();
+        let s = CpuValue::Uniform((Vec2::ZERO, Vec2::ONE)).to_wgsl_string();
         assert_eq!(
             s,
             "(rand2() * (vec2<f32>(1.,1.) - vec2<f32>(0.,0.)) + vec2<f32>(0.,0.))"
@@ -1281,9 +1281,9 @@ mod tests {
 
     #[test]
     fn to_wgsl_value_vec3() {
-        let s = Value::Single(Vec3::ONE).to_wgsl_string();
+        let s = CpuValue::Single(Vec3::ONE).to_wgsl_string();
         assert_eq!(s, "vec3<f32>(1.,1.,1.)");
-        let s = Value::Uniform((Vec3::ZERO, Vec3::ONE)).to_wgsl_string();
+        let s = CpuValue::Uniform((Vec3::ZERO, Vec3::ONE)).to_wgsl_string();
         assert_eq!(
             s,
             "(rand3() * (vec3<f32>(1.,1.,1.) - vec3<f32>(0.,0.,0.)) + vec3<f32>(0.,0.,0.))"
@@ -1292,9 +1292,9 @@ mod tests {
 
     #[test]
     fn to_wgsl_value_vec4() {
-        let s = Value::Single(Vec4::ONE).to_wgsl_string();
+        let s = CpuValue::Single(Vec4::ONE).to_wgsl_string();
         assert_eq!(s, "vec4<f32>(1.,1.,1.,1.)");
-        let s = Value::Uniform((Vec4::ZERO, Vec4::ONE)).to_wgsl_string();
+        let s = CpuValue::Uniform((Vec4::ZERO, Vec4::ONE)).to_wgsl_string();
         assert_eq!(s, "(rand4() * (vec4<f32>(1.,1.,1.,1.) - vec4<f32>(0.,0.,0.,0.)) + vec4<f32>(0.,0.,0.,0.))");
     }
 

--- a/src/modifier/init.rs
+++ b/src/modifier/init.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     graph::{EvalContext, ExprError},
     modifier::ShapeDimension,
-    Attribute, BoxedModifier, DimValue, Expr, ExprHandle, Modifier, ModifierContext, Module,
-    PropertyLayout, ToWgslString, Value,
+    Attribute, BoxedModifier, CpuValue, DimValue, Expr, ExprHandle, Modifier, ModifierContext,
+    Module, PropertyLayout, ToWgslString,
 };
 
 /// Particle initializing shader code generation context.
@@ -397,7 +397,7 @@ pub struct InitVelocityCircleModifier {
     /// Set this to `Vec3::Z` for a 2D game.
     pub axis: Vec3,
     /// The initial speed distribution of a particle when it spawns.
-    pub speed: Value<f32>,
+    pub speed: CpuValue<f32>,
 }
 
 impl_mod_init!(
@@ -443,7 +443,7 @@ pub struct InitVelocitySphereModifier {
     /// direction from the sphere center to the particle position.
     pub center: Vec3,
     /// The initial speed distribution of a particle when it spawns.
-    pub speed: Value<f32>,
+    pub speed: CpuValue<f32>,
 }
 
 impl_mod_init!(
@@ -482,7 +482,7 @@ pub struct InitVelocityTangentModifier {
     /// axes.
     pub axis: Vec3,
     /// The initial speed distribution of a particle when it spawns.
-    pub speed: Value<f32>,
+    pub speed: CpuValue<f32>,
 }
 
 impl_mod_init!(

--- a/src/modifier/render.rs
+++ b/src/modifier/render.rs
@@ -1,15 +1,12 @@
 //! Modifiers to influence the rendering of each particle.
 
-use bevy::{
-    prelude::*,
-    utils::{FloatOrd, HashMap},
-};
+use bevy::{prelude::*, utils::HashMap};
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 use crate::{
-    calc_func_id, Attribute, BoxedModifier, Gradient, Modifier, ModifierContext, ShaderCode,
-    ToWgslString, Value,
+    calc_func_id, Attribute, BoxedModifier, CpuValue, Gradient, Modifier, ModifierContext,
+    ShaderCode, ToWgslString,
 };
 
 /// Particle rendering shader code generation context.
@@ -129,43 +126,16 @@ impl RenderModifier for ParticleTextureModifier {
 /// A modifier to set the rendering color of all particles.
 ///
 /// This modifier assigns a _single_ color to all particles. That color can be
-/// determined by the user with [`Value::Single`], or left randomized with
-/// [`Value::Uniform`], but will be the same color for all particles.
+/// determined by the user with [`CpuValue::Single`], or left randomized with
+/// [`CpuValue::Uniform`], but will be the same color for all particles.
 ///
 /// # Attributes
 ///
 /// This modifier does not require any specific particle attribute.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 pub struct SetColorModifier {
     /// The particle color.
-    pub color: Value<Vec4>,
-}
-
-// TODO - impl Hash for Value<T>
-// SAFETY: This is consistent with the derive, but we can't derive due to
-// FloatOrd.
-#[allow(clippy::derived_hash_with_manual_eq)]
-impl Hash for SetColorModifier {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self.color {
-            Value::Single(v) => {
-                FloatOrd(v.x).hash(state);
-                FloatOrd(v.y).hash(state);
-                FloatOrd(v.z).hash(state);
-                FloatOrd(v.w).hash(state);
-            }
-            Value::Uniform((a, b)) => {
-                FloatOrd(a.x).hash(state);
-                FloatOrd(a.y).hash(state);
-                FloatOrd(a.z).hash(state);
-                FloatOrd(a.w).hash(state);
-                FloatOrd(b.x).hash(state);
-                FloatOrd(b.y).hash(state);
-                FloatOrd(b.z).hash(state);
-                FloatOrd(b.w).hash(state);
-            }
-        }
-    }
+    pub color: CpuValue<Vec4>,
 }
 
 impl_mod_render!(SetColorModifier, &[]);
@@ -222,42 +192,20 @@ impl RenderModifier for ColorOverLifetimeModifier {
 /// A modifier to set the size of all particles.
 ///
 /// This modifier assigns a _single_ size to all particles. That size can be
-/// determined by the user with [`Value::Single`], or left randomized with
-/// [`Value::Uniform`], but will be the same size for all particles.
+/// determined by the user with [`CpuValue::Single`], or left randomized with
+/// [`CpuValue::Uniform`], but will be the same size for all particles.
 ///
 /// # Attributes
 ///
 /// This modifier does not require any specific particle attribute.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 pub struct SetSizeModifier {
     /// The particle color.
-    pub size: Value<Vec2>,
+    pub size: CpuValue<Vec2>,
     /// Is the particle size in screen-space logical pixel? If `true`, the size
     /// is in screen-space logical pixels, and not affected by the camera
     /// projection. If `false`, the particle size is in world units.
     pub screen_space_size: bool,
-}
-
-// TODO - impl Hash for Value<T>
-// SAFETY: This is consistent with the derive, but we can't derive due to
-// FloatOrd.
-#[allow(clippy::derived_hash_with_manual_eq)]
-impl Hash for SetSizeModifier {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self.size {
-            Value::Single(v) => {
-                FloatOrd(v.x).hash(state);
-                FloatOrd(v.y).hash(state);
-            }
-            Value::Uniform((a, b)) => {
-                FloatOrd(a.x).hash(state);
-                FloatOrd(a.y).hash(state);
-                FloatOrd(b.x).hash(state);
-                FloatOrd(b.y).hash(state);
-            }
-        }
-        self.screen_space_size.hash(state);
-    }
 }
 
 impl_mod_render!(SetSizeModifier, &[]);


### PR DESCRIPTION
Rename the `spawn::Value` type to `CpuValue` to prevent confusion with the more recent `graph::Value`, which is destined to eventually replace it.

Add `impl Hash for CpuValue` for all floating-point types via a helper trait `FloatHash`. This enables deriving `Hash` for types using `CpuValue<T: FloatHash>`, which at the time of writing includes all uses.

Fix the `Hash` implementation of `SetColorModifier` and `SetSizeModifier`, which were ignoring the `CpuValue` enum variant.