### PR TITLE
Delete `DimValue` and `InitSizeModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - The `InitAgeModifier` and `InitLifetimeModifier` were deleted. They're replaced with the more generic `InitAttributeModifier` which can initialize any attribute of the particle.
+- Deleted `InitSizeModifier`; it can be replaced with the more generic `InitAttributeModifier`.
+- Deleted `DimValue` which was only used by `InitSizeModifier`, and is more generally covered by the Expression API.
 
 ### Fixed
 

--- a/docs/migration-v0.6-to-v0.7.md
+++ b/docs/migration-v0.6-to-v0.7.md
@@ -136,3 +136,7 @@ Note that previously a common pattern was to create modifiers inline while build
 - Rename `SimParams::dt` into `SimParams::delta_time`, and any shader use of `dt` into `delta_time`.
 
 - Add an extra `screen_space_size = false` field to the `SetSizeModifier` and `SizeOverLifetimeModifier`.
+
+- Replace the removed `InitSizeModifier` with the more generic `InitAttributeModifier`.
+
+- `DimValue` was deleted. It was only used in the now deleted `InitSizeModifier`. There's no direct equivalent if you were using this in your code.

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -209,6 +209,11 @@ fn setup(
     let lifetime3 = writer3.lit(5.).expr();
     let init_lifetime3 = InitAttributeModifier::new(Attribute::LIFETIME, lifetime3);
 
+    // Initialize size with a random value between 0.3 and 0.7: size = frand() * 0.4
+    // + 0.3
+    let size3 = (writer3.rand(ScalarType::Float) * writer3.lit(0.4) + writer3.lit(0.3)).expr();
+    let init_size3 = InitAttributeModifier::new(Attribute::SIZE, size3);
+
     // Add property-driven acceleration
     let accel3 = writer3.prop("my_accel").expr();
     let update_accel3 = AccelModifier::new(accel3);
@@ -231,10 +236,7 @@ fn setup(
             speed: 2.0.into(),
         })
         .init(init_lifetime3)
-        .init(InitSizeModifier {
-            // At spawn time, assign each particle a random size between 0.3 and 0.7
-            size: CpuValue::<f32>::Uniform((0.3, 0.7)).into(),
-        })
+        .init(init_size3)
         .update(update_accel3)
         .render(ColorOverLifetimeModifier {
             gradient: gradient3,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub use modifier::*;
 pub use plugin::HanabiPlugin;
 pub use properties::{Property, PropertyLayout};
 pub use render::{EffectSystems, ShaderCache};
-pub use spawn::{tick_spawners, CpuValue, DimValue, EffectSpawner, Random, Spawner};
+pub use spawn::{tick_spawners, CpuValue, EffectSpawner, Random, Spawner};
 
 #[allow(missing_docs)]
 pub mod prelude {

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -8,7 +8,7 @@ use rand::{
 use rand_pcg::Pcg32;
 use serde::{Deserialize, Serialize};
 
-use crate::{EffectAsset, ParticleEffect, SimulationCondition, ToWgslString};
+use crate::{EffectAsset, ParticleEffect, SimulationCondition};
 
 /// An RNG to be used in the CPU for the particle system engine
 pub(crate) fn new_rng() -> Pcg32 {
@@ -139,69 +139,6 @@ impl<T: Copy + FromReflect + FloatHash> Hash for CpuValue<T> {
                 a.hash_f32(state);
                 b.hash_f32(state);
             }
-        }
-    }
-}
-
-/// Dimension-variable floating-point [`CpuValue`].
-///
-/// This enum represents a floating-point [`CpuValue`] whose dimension (number
-/// of components) is variable. This is mainly used where a modifier can work
-/// with multiple attribute variants like [`Attribute::SIZE`] and
-/// [`Attribute::SIZE2`] which conceptually both represent the particle size,
-/// but with different representations.
-///
-/// [`Attribute::SIZE`]: crate::Attribute::SIZE
-/// [`Attribute::SIZE2`]: crate::Attribute::SIZE2
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, Hash, Serialize, Deserialize)]
-pub enum DimValue {
-    /// Scalar.
-    D1(CpuValue<f32>),
-    /// 2D vector.
-    D2(CpuValue<Vec2>),
-    /// 3D vector.
-    D3(CpuValue<Vec3>),
-    /// 4D vector.
-    D4(CpuValue<Vec4>),
-}
-
-impl Default for DimValue {
-    fn default() -> Self {
-        DimValue::D1(CpuValue::<f32>::default())
-    }
-}
-
-impl From<CpuValue<f32>> for DimValue {
-    fn from(value: CpuValue<f32>) -> Self {
-        DimValue::D1(value)
-    }
-}
-
-impl From<CpuValue<Vec2>> for DimValue {
-    fn from(value: CpuValue<Vec2>) -> Self {
-        DimValue::D2(value)
-    }
-}
-
-impl From<CpuValue<Vec3>> for DimValue {
-    fn from(value: CpuValue<Vec3>) -> Self {
-        DimValue::D3(value)
-    }
-}
-
-impl From<CpuValue<Vec4>> for DimValue {
-    fn from(value: CpuValue<Vec4>) -> Self {
-        DimValue::D4(value)
-    }
-}
-
-impl ToWgslString for DimValue {
-    fn to_wgsl_string(&self) -> String {
-        match self {
-            DimValue::D1(s) => s.to_wgsl_string(),
-            DimValue::D2(v) => v.to_wgsl_string(),
-            DimValue::D3(v) => v.to_wgsl_string(),
-            DimValue::D4(v) => v.to_wgsl_string(),
         }
     }
 }


### PR DESCRIPTION
Delete the `InitSizeModifier`, which is redundant with the more powerful `InitAttributeModifier` and the use of expressions.

Delete `DimValue`, which was only used by that modifier.
