### PR TITLE
Add local space simulation and `OrientModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a new `OrientModifier` and its `OrientMode`, allowing various modes of particle orienting during the rendering phase.
+- Added `SimulationSpace::Local` to simulate particles in local effect space, before rendering them with the `GlobalTransform` of the effect's entity.
+
+### Removed
+
+- Removed the `BillboardModifier`; this is superseded by the `OrientModifier { mode: OrientMode::ParallelCameraDepthPlane }`.
+- Removed the `OrientAlongVelocityModifier`; this is superseded by the `OrientModifier { mode: OrientMode::AlongVelocity }`.
+
 ## [0.7.0] 2023-07-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.7.0"
+version = "0.8.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Hanabi GPU particle system for the Bevy game engine"

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -1,4 +1,4 @@
-//! An example using the [`BillboardModifier`] to force
+//! An example using the [`OrientModifier`] to force
 //! particles to always render facing the camera.
 
 use bevy::{
@@ -102,7 +102,9 @@ fn setup(
             .render(ParticleTextureModifier {
                 texture: texture_handle,
             })
-            .render(BillboardModifier {})
+            .render(OrientModifier {
+                mode: OrientMode::ParallelCameraDepthPlane,
+            })
             .render(ColorOverLifetimeModifier { gradient })
             .render(SizeOverLifetimeModifier {
                 gradient: Gradient::constant([0.2; 2].into()),

--- a/examples/expr.rs
+++ b/examples/expr.rs
@@ -119,7 +119,9 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
                 gradient: size_gradient,
                 screen_space_size: false,
             })
-            .render(OrientAlongVelocityModifier),
+            .render(OrientModifier {
+                mode: OrientMode::AlongVelocity,
+            }),
     );
 
     commands.spawn((

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -94,7 +94,9 @@ fn make_effect(color: Color) -> EffectAsset {
             gradient: size_gradient.clone(),
             screen_space_size: false,
         })
-        .render(BillboardModifier)
+        .render(OrientModifier {
+            mode: OrientMode::FaceCameraPosition,
+        })
 }
 
 fn setup(

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -4,8 +4,8 @@
 //! kind of portal effect where particles turn around a circle and appear to be
 //! ejected from it.
 //!
-//! The `OrientAlongVelocityModifier` paired with an elongated particle size
-//! gives the appearance of sparks.
+//! The `OrientMode::AlongVelocity` of the `OrientModifier` paired with an
+//! elongated particle size gives the appearance of sparks.
 //!
 //! The addition of some gravity and drag, combined with a careful choice of
 //! lifetime, give a subtle effect of particles appearing to fall down right
@@ -114,7 +114,9 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
                 gradient: size_gradient1,
                 screen_space_size: false,
             })
-            .render(OrientAlongVelocityModifier),
+            .render(OrientModifier {
+                mode: OrientMode::AlongVelocity,
+            }),
     );
 
     commands.spawn((

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -483,7 +483,15 @@ mod tests {
         .render(ParticleTextureModifier::default())
         .render(ColorOverLifetimeModifier::default())
         .render(SizeOverLifetimeModifier::default())
-        .render(BillboardModifier);
+        .render(OrientModifier {
+            mode: OrientMode::ParallelCameraDepthPlane,
+        })
+        .render(OrientModifier {
+            mode: OrientMode::FaceCameraPosition,
+        })
+        .render(OrientModifier {
+            mode: OrientMode::AlongVelocity,
+        });
 
         assert_eq!(effect.capacity, 4096);
 
@@ -511,7 +519,18 @@ mod tests {
         ParticleTextureModifier::default().apply_render(&mut render_context);
         ColorOverLifetimeModifier::default().apply_render(&mut render_context);
         SizeOverLifetimeModifier::default().apply_render(&mut render_context);
-        BillboardModifier.apply_render(&mut render_context);
+        OrientModifier {
+            mode: OrientMode::ParallelCameraDepthPlane,
+        }
+        .apply_render(&mut render_context);
+        OrientModifier {
+            mode: OrientMode::FaceCameraPosition,
+        }
+        .apply_render(&mut render_context);
+        OrientModifier {
+            mode: OrientMode::AlongVelocity,
+        }
+        .apply_render(&mut render_context);
         // assert_eq!(effect.render_layout, render_layout);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,7 +919,7 @@ impl CompiledParticleEffect {
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
             .replace(
                 "{{SIMULATION_SPACE_TRANSFORM_PARTICLE}}",
-                &sim_space_transform_code,
+                sim_space_transform_code,
             );
         let init_shader = shader_cache.get_or_insert(&asset.name, &init_shader_source, shaders);
         trace!("Configured init shader:\n{}", init_shader_source);
@@ -953,7 +953,7 @@ impl CompiledParticleEffect {
             .replace("{{RENDER_EXTRA}}", &render_context.render_extra)
             .replace(
                 "{{SIMULATION_SPACE_TRANSFORM_PARTICLE}}",
-                &sim_space_transform_code,
+                sim_space_transform_code,
             );
         let render_shader = shader_cache.get_or_insert(&asset.name, &render_shader_source, shaders);
         trace!("Configured render shader:\n{}", render_shader_source);

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -818,8 +818,15 @@ fn main() {{
             &ParticleTextureModifier::default(),
             &ColorOverLifetimeModifier::default(),
             &SizeOverLifetimeModifier::default(),
-            &BillboardModifier,
-            &OrientAlongVelocityModifier,
+            &OrientModifier {
+                mode: OrientMode::ParallelCameraDepthPlane,
+            },
+            &OrientModifier {
+                mode: OrientMode::FaceCameraPosition,
+            },
+            &OrientModifier {
+                mode: OrientMode::AlongVelocity,
+            },
         ];
         for &modifier in modifiers.iter() {
             let mut context = RenderContext::default();
@@ -849,9 +856,9 @@ struct View {{
     height: f32,
 }};
 
-fn frand() -> f32 {{
-    return 0.0;
-}}
+fn frand() -> f32 {{ return 0.0; }}
+fn get_camera_position_effect_space() -> vec3<f32> {{ return vec3<f32>(); }}
+fn get_camera_rotation_effect_space() -> mat3x3<f32> {{ return mat3x3<f32>(); }}
 
 const tau: f32 = 6.283185307179586476925286766559;
 
@@ -871,6 +878,8 @@ struct VertexOutput {{
 @compute @workgroup_size(64)
 fn main() {{
     var particle = Particle();
+    var position = vec3<f32>(0.0, 0.0, 0.0);
+    var velocity = vec3<f32>(0.0, 0.0, 0.0);
     var size = vec2<f32>(1.0, 1.0);
     var axis_x = vec3<f32>(1.0, 0.0, 0.0);
     var axis_y = vec3<f32>(0.0, 1.0, 0.0);

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -269,7 +269,7 @@ impl Modifier for OrientModifier {
     }
 
     fn boxed_clone(&self) -> BoxedModifier {
-        Box::new(self.clone())
+        Box::new(*self)
     }
 }
 

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
 use crate::{
-    impl_mod_render, Attribute, CpuValue, Gradient, RenderContext, RenderModifier, ShaderCode,
-    ToWgslString,
+    impl_mod_render, Attribute, BoxedModifier, CpuValue, Gradient, Modifier, ModifierContext,
+    RenderContext, RenderModifier, ShaderCode, ToWgslString,
 };
 
 /// A modifier modulating each particle's color by sampling a texture.
@@ -176,46 +176,128 @@ impl RenderModifier for SizeOverLifetimeModifier {
     }
 }
 
-/// Reorients the vertices to always face the camera when rendering.
+/// Mode of orientation of a particle's local frame.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+pub enum OrientMode {
+    /// Orient a particle such that its local XY plane is parallel to the
+    /// camera's near and far planes (depth planes).
+    ///
+    /// The local X axis is (1,0,0) in camera space, and the local Y axis is
+    /// (0,1,0). The local Z axis is (0,0,1), perpendicular to the camera depth
+    /// planes, pointing toward the camera.
+    ///
+    /// This mode is a bit cheaper to calculate than [`FaceCameraPosition`], and
+    /// should be preferred to it unless the particle absolutely needs to have
+    /// its Z axis pointing to the camera position.
+    ///
+    /// This is the default variant.
+    ///
+    /// [`FaceCameraPosition`]: crate::modifier::output::OrientMode::FaceCameraPosition
+    #[default]
+    ParallelCameraDepthPlane,
+
+    /// Orient a particle to face the camera's position.
+    ///
+    /// The local Z axis of the particle points directly at the camera position.
+    /// The X and Y axes form an orthonormal frame with it, where Y is roughly
+    /// upward.
+    ///
+    /// This mode is a bit more costly to calculate than
+    /// [`ParallelCameraDepthPlane`], and should be used only when the
+    /// particle absolutely needs to have its Z axis pointing to the camera
+    /// position.
+    ///
+    /// [`ParallelCameraDepthPlane`]: crate::modifier::output::OrientMode::ParallelCameraDepthPlane
+    FaceCameraPosition,
+
+    /// Orient a particle alongside its velocity.
+    ///
+    /// The local X axis points alongside the velocity. The local Y axis is
+    /// derived as the cross product of the camera direction with that local X
+    /// axis. The Z axis completes the orthonormal basis. This allows flat
+    /// particles (quads) to roughly face the camera position (as long as
+    /// velocity is not perpendicular to the camera depth plane), while having
+    /// their X axis always pointing alongside the velocity.
+    AlongVelocity,
+}
+
+/// Orients the particle's local frame.
+///
+/// The orientation is calculated during the rendering of each particle.
 ///
 /// # Attributes
 ///
-/// This modifier does not require any specific particle attribute.
+/// The required attribute(s) depend on the orientation [`mode`]:
+/// - [`OrientMode::ParallelCameraDepthPlane`]: This modifier does not require
+///   any specific particle attribute.
+/// - [`OrientMode::FaceCameraPosition`]: This modifier requires the
+///   [`Attribute::POSITION`] attribute.
+/// - [`OrientMode::AlongVelocity`]: This modifier requires the
+///   [`Attribute::POSITION`] and [`Attribute::VELOCITY`] attributes.
+///
+/// [`mode`]: crate::modifier::output::OrientModifier::mode
+/// [`Attribute::POSITION`]: crate::attributes::Attribute::POSITION
 #[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Reflect, Serialize, Deserialize)]
-pub struct BillboardModifier;
-
-impl_mod_render!(BillboardModifier, &[]);
+pub struct OrientModifier {
+    /// Orientation mode for the particles.
+    pub mode: OrientMode,
+}
 
 #[typetag::serde]
-impl RenderModifier for BillboardModifier {
-    fn apply_render(&self, context: &mut RenderContext) {
-        context.vertex_code += "axis_x = view.view[0].xyz;\naxis_y = view.view[1].xyz;\n";
+impl Modifier for OrientModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Render
+    }
+
+    fn as_render(&self) -> Option<&dyn RenderModifier> {
+        Some(self)
+    }
+
+    fn as_render_mut(&mut self) -> Option<&mut dyn RenderModifier> {
+        Some(self)
+    }
+
+    fn attributes(&self) -> &[Attribute] {
+        // Note: don't required AXIS_X/Y/Z, they're written at the last minute in the
+        // render shader alone, so don't need to be stored as part of the particle's
+        // layout for simulation.
+        match self.mode {
+            OrientMode::ParallelCameraDepthPlane => &[],
+            OrientMode::FaceCameraPosition => &[Attribute::POSITION],
+            OrientMode::AlongVelocity => &[Attribute::POSITION, Attribute::VELOCITY],
+        }
+    }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(self.clone())
     }
 }
 
-/// A modifier orienting each particle alongside its velocity.
-///
-/// # Attributes
-///
-/// This modifier requires the following particle attributes:
-/// - [`Attribute::POSITION`]
-/// - [`Attribute::VELOCITY`]
-#[derive(Debug, Default, Clone, Copy, PartialEq, Hash, Reflect, Serialize, Deserialize)]
-pub struct OrientAlongVelocityModifier;
-
-impl_mod_render!(
-    OrientAlongVelocityModifier,
-    &[Attribute::POSITION, Attribute::VELOCITY]
-);
-
 #[typetag::serde]
-impl RenderModifier for OrientAlongVelocityModifier {
+impl RenderModifier for OrientModifier {
     fn apply_render(&self, context: &mut RenderContext) {
-        context.vertex_code += r#"let dir = normalize(particle.position - view.view[3].xyz);
-    axis_x = normalize(particle.velocity);
-    axis_y = cross(dir, axis_x);
-    axis_z = cross(axis_x, axis_y);
+        match self.mode {
+            OrientMode::ParallelCameraDepthPlane => {
+                context.vertex_code += r#"let cam_rot = get_camera_rotation_effect_space();
+axis_x = cam_rot[0].xyz;
+axis_y = cam_rot[1].xyz;
+axis_z = cam_rot[2].xyz;
 "#;
+            }
+            OrientMode::FaceCameraPosition => {
+                context.vertex_code += r#"axis_z = normalize(get_camera_position_effect_space() - position);
+axis_x = normalize(cross(view.view[1].xyz, axis_z));
+axis_y = cross(axis_z, axis_x);
+"#;
+            }
+            OrientMode::AlongVelocity => {
+                context.vertex_code += r#"let dir = normalize(position - get_camera_position_effect_space());
+axis_x = normalize(particle.velocity);
+axis_y = cross(dir, axis_x);
+axis_z = cross(axis_x, axis_y);
+"#;
+            }
+        }
     }
 }
 
@@ -278,9 +360,12 @@ mod tests {
 
     #[test]
     fn mod_billboard() {
-        let modifier = BillboardModifier;
+        let modifier = OrientModifier::default();
         let mut context = RenderContext::default();
         modifier.apply_render(&mut context);
-        assert!(context.vertex_code.contains("view.view"));
+        // TODO - less weak test...
+        assert!(context
+            .vertex_code
+            .contains("get_camera_rotation_effect_space"));
     }
 }

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -107,6 +107,8 @@ pub(crate) struct BatchInput {
     pub spawn_count: u32,
     /// Emitter transform.
     pub transform: [f32; 12],
+    /// Emitter inverse transform.
+    pub inverse_transform: [f32; 12],
     /// GPU buffer where properties for this batch need to be written.
     pub property_buffer: Option<Buffer>,
     /// Serialized property data.
@@ -546,6 +548,7 @@ mod tests {
             force_field: [ForceFieldSource::default(); ForceFieldSource::MAX_SOURCES],
             spawn_count: 32,
             transform: [0.; 12],
+            inverse_transform: [0.; 12],
             property_buffer: None,
             property_data: vec![],
             #[cfg(feature = "2d")]

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -38,6 +38,7 @@ struct ForceFieldSource {
 
 struct Spawner {
     transform: mat3x4<f32>, // transposed (row-major)
+    inverse_transform: mat3x4<f32>, // transposed (row-major)
     spawn: i32,
     seed: u32,
     count: atomic<i32>,

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -1,15 +1,15 @@
 struct Particle {
 {{ATTRIBUTES}}
-};
+}
 
 struct ParticleBuffer {
     particles: array<Particle>,
-};
+}
 
 struct SimParams {
     delta_time: f32,
     time: f32,
-};
+}
 
 struct ForceFieldSource {
     position: vec3<f32>,
@@ -22,16 +22,17 @@ struct ForceFieldSource {
 
 struct Spawner {
     transform: mat3x4<f32>, // transposed (row-major)
+    inverse_transform: mat3x4<f32>, // transposed (row-major)
     spawn: i32,
     seed: u32,
     count: atomic<i32>,
     effect_index: u32,
     force_field: array<ForceFieldSource, 16>,
-};
+}
 
 struct IndirectBuffer {
     indices: array<u32>,
-};
+}
 
 struct RenderIndirectBuffer {
     vertex_count: u32,
@@ -43,7 +44,7 @@ struct RenderIndirectBuffer {
     dead_count: atomic<u32>,
     max_spawn: u32,
     ping: u32,
-};
+}
 
 {{PROPERTIES}}
 
@@ -163,8 +164,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     var particle = Particle();
     {{INIT_CODE}}
 
-    // Global-space simulation
-    particle.position += transform[3].xyz;
+    {{SIMULATION_SPACE_TRANSFORM_PARTICLE}}
 
     // Count as alive
     atomicAdd(&render_indirect.alive_count, 1u);

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -22,6 +22,7 @@ struct ForceFieldSource {
 
 struct Spawner {
     transform: mat3x4<f32>, // transposed (row-major)
+    inverse_transform: mat3x4<f32>, // transposed (row-major)
     spawn: atomic<i32>,
     seed: u32,
     count_unused: u32,


### PR DESCRIPTION
Add a new alternative `SimulationSpace::Local` for simulating particles in the space defined by the `GlobalTransform` attached to the entity of their `ParticleEffect`. This allows applying the effect's transform to all particles after they are simulated. This is opposed to the default global-space simulation offered by `SimulationSpace::Global` where particles are "detached" from the effect when they spawn, and are simulated in the global world space.

Add a new `OrientModifier` and its associated `OrientMode` enum, allowing to orient the particles to face the camera and/or their velocity, both when simulated in local and global space. This unified modifier replaces both the `BillboardModifier` and the `OrientAlongVelocityModifier`.

Bug: #180