### PR TITLE
Evaluate `SimulationSpace` in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new `OrientModifier` and its `OrientMode`, allowing various modes of particle orienting during the rendering phase.
 - Added `SimulationSpace::Local` to simulate particles in local effect space, before rendering them with the `GlobalTransform` of the effect's entity.
+- Add access to `ModifierContext` and `ParticleLayout` from the `EvalContext` when evaluating modifiers.
+- Added `SimulationSpace::eval()` to evaluate a context-specific expression allowing to transform the particles to the proper simulation space.
+
+### Changed
+
+- `InitContext::new()` and `UpdateContext::new()` now take an additional reference to the `ParticleLayout` of the effect.
+- `RenderContext` now implements `EvalContext` like the init and update contexts, and like them reference the module, particle layout, and property layout of the effect.
 
 ### Removed
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -496,7 +496,8 @@ mod tests {
         assert_eq!(effect.capacity, 4096);
 
         let property_layout = PropertyLayout::default();
-        let mut init_context = InitContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut init_context = InitContext::new(&mut module, &property_layout, &particle_layout);
         assert!(init_pos_sphere.apply_init(&mut init_context).is_ok());
         assert!(init_vel_sphere.apply_init(&mut init_context).is_ok());
         assert!(init_age.apply_init(&mut init_context).is_ok());
@@ -507,7 +508,9 @@ mod tests {
         let accel_mod = AccelModifier::constant(&mut module, Vec3::ONE);
         let drag_mod = LinearDragModifier::constant(&mut module, 3.5);
         let property_layout = PropertyLayout::default();
-        let mut update_context = UpdateContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut update_context =
+            UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(accel_mod.apply_update(&mut update_context).is_ok());
         assert!(drag_mod.apply_update(&mut update_context).is_ok());
         assert!(ForceFieldModifier::default()
@@ -515,7 +518,11 @@ mod tests {
             .is_ok());
         // assert_eq!(effect.update_layout, update_layout);
 
-        let mut render_context = RenderContext::default();
+        let mut module = Module::default();
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let mut render_context =
+            RenderContext::new(&mut module, &property_layout, &particle_layout);
         ParticleTextureModifier::default().apply_render(&mut render_context);
         ColorOverLifetimeModifier::default().apply_render(&mut render_context);
         SizeOverLifetimeModifier::default().apply_render(&mut render_context);

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1038,6 +1038,21 @@ impl From<&ParticleLayout> for ParticleLayoutBuilder {
 /// together in a single call, therefore it is recommended to minimize the
 /// layout variations across effects and attempt to reuse the same layout for
 /// multiple effects, which can be benefical for performance.
+///
+/// # Construction
+///
+/// To create a particle layout you can either:
+/// - Use [`ParticleLayout::default()`] to create the default layout, which
+///   contains some default attributes commonly used for effects
+///   ([`Attribute::POSITION`], [`Attribute::VELOCITY`], [`Attribute::AGE`],
+///   [`Attribute::LIFETIME`]).
+/// - Use [`ParticleLayout::empty()`] to create an empty layout without any
+///   attribute.
+/// - Use [`ParticleLayout::new()`] to create a [`ParticleLayoutBuilder`] and
+///   append the necessary attributes manually then call [`build()`] to complete
+///   the layout.
+///
+/// [`build()`]: crate::ParticleLayoutBuilder::build
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ParticleLayout {
     layout: Vec<AttributeLayout>,

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -106,7 +106,9 @@ use std::{cell::RefCell, num::NonZeroU32, rc::Rc};
 use bevy::{reflect::Reflect, utils::thiserror::Error};
 use serde::{Deserialize, Serialize};
 
-use crate::{Attribute, PropertyLayout, ScalarType, ToWgslString, ValueType};
+use crate::{
+    Attribute, ModifierContext, ParticleLayout, PropertyLayout, ScalarType, ToWgslString, ValueType,
+};
 
 use super::Value;
 
@@ -439,8 +441,14 @@ pub enum ExprError {
 /// most common example are [`PropertyExpr`] which are only valid if the
 /// property is actually defined in the evaluation context.
 pub trait EvalContext {
+    /// Get the modifier context of the evaluation.
+    fn modifier_context(&self) -> ModifierContext;
+
     /// Get the module the evaluation is taking place in.
     fn module(&self) -> &Module;
+
+    /// Get the particle layout of the effect.
+    fn particle_layout(&self) -> &ParticleLayout;
 
     /// Get the property layout of the effect.
     fn property_layout(&self) -> &PropertyLayout;
@@ -566,7 +574,8 @@ impl Expr {
     /// # use bevy_hanabi::*;
     /// # let mut module = Module::default();
     /// # let pl = PropertyLayout::empty();
-    /// # let context = InitContext::new(&mut module, &pl);
+    /// # let pal = ParticleLayout::default();
+    /// # let context = InitContext::new(&mut module, &pl, &pal);
     /// let expr = Expr::Literal(LiteralExpr::new(1.));
     /// assert_eq!(Ok("1.".to_string()), expr.eval(&context));
     /// ```
@@ -1905,8 +1914,9 @@ mod tests {
         // Create an evaluation context
         let property_layout =
             PropertyLayout::new(&[Property::new("my_prop", ScalarValue::Float(3.))]);
+        let particle_layout = ParticleLayout::default();
         let mut m = w.finish();
-        let context = InitContext::new(&mut m, &property_layout);
+        let context = InitContext::new(&mut m, &property_layout, &particle_layout);
 
         // Evaluate the expression
         let s = context.expr(x).unwrap().eval(&context).unwrap();
@@ -1941,13 +1951,9 @@ mod tests {
         let gt = m.gt(x, y);
         let ge = m.ge(x, y);
 
-        let pl = PropertyLayout::default();
-        let ctx = InitContext {
-            module: &mut m,
-            init_code: String::new(),
-            init_extra: String::new(),
-            property_layout: &pl,
-        };
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let ctx = InitContext::new(&mut m, &property_layout, &particle_layout);
 
         for (expr, op) in [
             (add, "+"),
@@ -1980,13 +1986,9 @@ mod tests {
         for op in [BuiltInOperator::Time, BuiltInOperator::DeltaTime] {
             let value = m.builtin(op);
 
-            let pl = PropertyLayout::default();
-            let ctx = InitContext {
-                module: &mut m,
-                init_code: String::new(),
-                init_extra: String::new(),
-                property_layout: &pl,
-            };
+            let property_layout = PropertyLayout::default();
+            let particle_layout = ParticleLayout::default();
+            let ctx = InitContext::new(&mut m, &property_layout, &particle_layout);
 
             let expr = ctx.eval(value);
             assert!(expr.is_ok());
@@ -2002,13 +2004,9 @@ mod tests {
         ] {
             let value = m.builtin(BuiltInOperator::Rand(scalar_type.into()));
 
-            let pl = PropertyLayout::default();
-            let ctx = InitContext {
-                module: &mut m,
-                init_code: String::new(),
-                init_extra: String::new(),
-                property_layout: &pl,
-            };
+            let property_layout = PropertyLayout::default();
+            let particle_layout = ParticleLayout::default();
+            let ctx = InitContext::new(&mut m, &property_layout, &particle_layout);
 
             let expr = ctx.eval(value);
             assert!(expr.is_ok());
@@ -2020,13 +2018,9 @@ mod tests {
                     VectorType::new(scalar_type, count).into(),
                 ));
 
-                let pl = PropertyLayout::default();
-                let ctx = InitContext {
-                    module: &mut m,
-                    init_code: String::new(),
-                    init_extra: String::new(),
-                    property_layout: &pl,
-                };
+                let property_layout = PropertyLayout::default();
+                let particle_layout = ParticleLayout::default();
+                let ctx = InitContext::new(&mut m, &property_layout, &particle_layout);
 
                 let expr = ctx.eval(vec);
                 assert!(expr.is_ok());
@@ -2049,13 +2043,9 @@ mod tests {
         let any = m.any(z);
         let all = m.all(z);
 
-        let pl = PropertyLayout::default();
-        let ctx = InitContext {
-            module: &mut m,
-            init_code: String::new(),
-            init_extra: String::new(),
-            property_layout: &pl,
-        };
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let ctx = InitContext::new(&mut m, &property_layout, &particle_layout);
 
         for (expr, op, inner) in [
             (
@@ -2084,13 +2074,9 @@ mod tests {
         let min = m.min(x, y);
         let max = m.max(x, y);
 
-        let pl = PropertyLayout::default();
-        let ctx = InitContext {
-            module: &mut m,
-            init_code: String::new(),
-            init_extra: String::new(),
-            property_layout: &pl,
-        };
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let ctx = InitContext::new(&mut m, &property_layout, &particle_layout);
 
         for (expr, op) in [(min, "min"), (max, "max")] {
             let expr = ctx.eval(expr);

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -773,7 +773,7 @@ equal to one."
 mod tests {
     use bevy::prelude::*;
 
-    use crate::{EvalContext, InitContext, PropertyLayout};
+    use crate::{EvalContext, InitContext, ParticleLayout, PropertyLayout};
 
     use super::*;
 
@@ -794,8 +794,9 @@ mod tests {
         assert_eq!(outputs.len(), 1);
         let out = outputs[0];
 
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str = context.eval(out).unwrap();
         assert_eq!(str, "(3.) + (2.)".to_string());
     }
@@ -816,8 +817,9 @@ mod tests {
         let outputs = node.eval(&mut module, vec![three, two]).unwrap();
         assert_eq!(outputs.len(), 1);
         let out = outputs[0];
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str = context.eval(out).unwrap();
         assert_eq!(str, "(3.) - (2.)".to_string());
     }
@@ -838,8 +840,9 @@ mod tests {
         let outputs = node.eval(&mut module, vec![three, two]).unwrap();
         assert_eq!(outputs.len(), 1);
         let out = outputs[0];
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str = context.eval(out).unwrap();
         assert_eq!(str, "(3.) * (2.)".to_string());
     }
@@ -860,8 +863,9 @@ mod tests {
         let outputs = node.eval(&mut module, vec![three, two]).unwrap();
         assert_eq!(outputs.len(), 1);
         let out = outputs[0];
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str = context.eval(out).unwrap();
         assert_eq!(str, "(3.) / (2.)".to_string());
     }
@@ -879,8 +883,9 @@ mod tests {
         let outputs = node.eval(&mut module, vec![]).unwrap();
         assert_eq!(outputs.len(), 1);
         let out = outputs[0];
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str = context.eval(out).unwrap();
         assert_eq!(str, format!("particle.{}", Attribute::POSITION.name()));
     }
@@ -897,8 +902,9 @@ mod tests {
 
         let outputs = node.eval(&mut module, vec![]).unwrap();
         assert_eq!(outputs.len(), 2);
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str0 = context.eval(outputs[0]).unwrap();
         let str1 = context.eval(outputs[1]).unwrap();
         assert_eq!(str0, format!("sim_params.{}", BuiltInOperator::Time.name()));
@@ -920,8 +926,9 @@ mod tests {
         let ones = module.lit(Vec3::ONE);
         let outputs = node.eval(&mut module, vec![ones]).unwrap();
         assert_eq!(outputs.len(), 1);
-        let pl = PropertyLayout::empty();
-        let context = InitContext::new(&mut module, &pl);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let context = InitContext::new(&mut module, &property_layout, &particle_layout);
         let str = context.eval(outputs[0]).unwrap();
         assert_eq!(str, "normalize(vec3<f32>(1.,1.,1.))".to_string());
     }

--- a/src/modifier/accel.rs
+++ b/src/modifier/accel.rs
@@ -296,7 +296,7 @@ impl UpdateModifier for TangentAccelModifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::{PropertyLayout, ToWgslString};
+    use crate::{ParticleLayout, PropertyLayout, ToWgslString};
 
     use super::*;
 
@@ -307,7 +307,8 @@ mod tests {
         let modifier = AccelModifier::constant(&mut module, accel);
 
         let property_layout = PropertyLayout::default();
-        let mut context = UpdateContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut context = UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(modifier.apply_update(&mut context).is_ok());
 
         assert!(context.update_code.contains(&accel.to_wgsl_string()));
@@ -321,7 +322,8 @@ mod tests {
         let modifier = RadialAccelModifier::constant(&mut module, origin, accel);
 
         let property_layout = PropertyLayout::default();
-        let mut context = UpdateContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut context = UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(modifier.apply_update(&mut context).is_ok());
 
         // TODO: less weak check...
@@ -337,7 +339,8 @@ mod tests {
         let modifier = TangentAccelModifier::constant(&mut module, origin, axis, accel);
 
         let property_layout = PropertyLayout::default();
-        let mut context = UpdateContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut context = UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(modifier.apply_update(&mut context).is_ok());
 
         // TODO: less weak check...

--- a/src/modifier/force.rs
+++ b/src/modifier/force.rs
@@ -160,7 +160,7 @@ impl UpdateModifier for LinearDragModifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::{PropertyLayout, UpdateContext};
+    use crate::{ParticleLayout, PropertyLayout, UpdateContext};
 
     use super::*;
 
@@ -173,8 +173,9 @@ mod tests {
         let modifier = ForceFieldModifier { sources };
 
         let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
         let mut module = Module::default();
-        let mut context = UpdateContext::new(&mut module, &property_layout);
+        let mut context = UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(modifier.apply_update(&mut context).is_ok());
 
         // force_field_code.wgsl is too big
@@ -195,7 +196,8 @@ mod tests {
         let modifier = LinearDragModifier::constant(&mut module, 3.5);
 
         let property_layout = PropertyLayout::default();
-        let mut context = UpdateContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut context = UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(modifier.apply_update(&mut context).is_ok());
 
         assert!(context.update_code.contains("3.5")); // TODO - less weak check

--- a/src/modifier/kill.rs
+++ b/src/modifier/kill.rs
@@ -165,7 +165,7 @@ impl UpdateModifier for KillAabbModifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Module, PropertyLayout};
+    use crate::{Module, ParticleLayout, PropertyLayout};
 
     use super::*;
 
@@ -177,7 +177,8 @@ mod tests {
         let modifier = KillAabbModifier::new(center, half_size);
 
         let property_layout = PropertyLayout::default();
-        let mut context = UpdateContext::new(&mut module, &property_layout);
+        let particle_layout = ParticleLayout::default();
+        let mut context = UpdateContext::new(&mut module, &property_layout, &particle_layout);
         assert!(modifier.apply_update(&mut context).is_ok());
 
         assert!(context.update_code.contains("is_alive = false")); // TODO - less weak check

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -303,6 +303,8 @@ axis_z = cross(axis_x, axis_y);
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
+
     use super::*;
 
     #[test]
@@ -312,7 +314,10 @@ mod tests {
             texture: texture.clone(),
         };
 
-        let mut context = RenderContext::default();
+        let mut module = Module::default();
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let mut context = RenderContext::new(&mut module, &property_layout, &particle_layout);
         modifier.apply_render(&mut context);
 
         assert!(context.particle_texture.is_some());
@@ -330,7 +335,10 @@ mod tests {
             gradient: gradient.clone(),
         };
 
-        let mut context = RenderContext::default();
+        let mut module = Module::default();
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let mut context = RenderContext::new(&mut module, &property_layout, &particle_layout);
         modifier.apply_render(&mut context);
 
         assert!(context
@@ -350,7 +358,10 @@ mod tests {
             screen_space_size: false,
         };
 
-        let mut context = RenderContext::default();
+        let mut module = Module::default();
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let mut context = RenderContext::new(&mut module, &property_layout, &particle_layout);
         modifier.apply_render(&mut context);
 
         assert!(context
@@ -361,7 +372,10 @@ mod tests {
     #[test]
     fn mod_billboard() {
         let modifier = OrientModifier::default();
-        let mut context = RenderContext::default();
+        let mut module = Module::default();
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let mut context = RenderContext::new(&mut module, &property_layout, &particle_layout);
         modifier.apply_render(&mut context);
         // TODO - less weak test...
         assert!(context


### PR DESCRIPTION
Make the `RenderContext` on par with the init and update ones, and evaluate the `SimulationSpace` based on the context, as an `eval()` function on the type itself instead of inline inside the shader compiling system. This makes the code more testable, and the compiling system more readable.