### PR TITLE
Enchance `Gradient<T>` with more utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SimulationSpace::Local` to simulate particles in local effect space, before rendering them with the `GlobalTransform` of the effect's entity.
 - Add access to `ModifierContext` and `ParticleLayout` from the `EvalContext` when evaluating modifiers.
 - Added `SimulationSpace::eval()` to evaluate a context-specific expression allowing to transform the particles to the proper simulation space.
+- Added a few more functions to `Gradient<T>`: `is_empty(` and `len()` which do as implied, `from_keys()` which creates a new gradient from a key point iterator, and `with_key()` and `with_keys()` which append one or more keys to an existing gradient.
 
 ### Changed
 
 - `InitContext::new()` and `UpdateContext::new()` now take an additional reference to the `ParticleLayout` of the effect.
 - `RenderContext` now implements `EvalContext` like the init and update contexts, and like them reference the module, particle layout, and property layout of the effect.
+- `Gradient<T>::new()`, `Gradient<T>::constant()`, and `Gradient<T>::linear()` do not require the `T: Default` trait bound anymore. The bound had been added by mistake, and is not necessary.
+- `Gradient<T>::new()` is now a `const fn`.
+- `Gradient<T>::constant()` and `Gradient<T>::linear()` do not attempt to perform linear searches anymore; instead they directly create the `Gradient<T>` object from scratch. This should not have any real consequence in practice though.
 
 ### Removed
 


### PR DESCRIPTION
Add a few utility functions to make it easier to work with `Gradient<T>`, and in particular to build a new gradient:
- `from_keys()` extends the existing `constant()` and `linear()` to a collection of keys;
- `with_key()` and `with_keys()` append to an existing gradient object while consuming it;
- `is_empty()` and `len()` return the expected values for the underlying collection of key points.