### PR TITLE
Better document and test the properties module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a few more functions to `Gradient<T>`: `is_empty(` and `len()` which do as implied, `from_keys()` which creates a new gradient from a key point iterator, and `with_key()` and `with_keys()` which append one or more keys to an existing gradient.
 - Added `AlphaMode` and the ability to render particles with alpha masking instead of alpha blending. This is controlled by `EffectAsset::alpha_mode` and the new `EffectAsset::with_alpha_mode()` helper.
 - Added a new `BuiltInOperator::AlphaCutoff` value and associated expression, which represent the alpha cutoff threshold when rendering an effect with alpha masking. The `billboard` example has been updated to show how to use that value, and even dynamically change it with an expression.
+- Added `PropertyLayout::properties()` to iterate over the layout.
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Gradient<T>::constant()` and `Gradient<T>::linear()` do not attempt to perform linear searches anymore; instead they directly create the `Gradient<T>` object from scratch. This should not have any real consequence in practice though.
 - Changed `CompiledParticleEffect` to store a `LayoutFlags` instead of individual boolean values, for convenience and consistency with the internal representation.
 - Changed `RenderContext` to implement `EvalContext`. This allows render modifiers to use the expression API.
+- `PropertyLayout::generate_code()` has no more extra empty line at the end of the struct in the generated code.
 
 ### Removed
 


### PR DESCRIPTION
Add some extra documentation, examples, and more tests to the `properties` module.

Add a new `PropertyLayout::properties()` function to iterate over the properties of a layout and their offset.

Delete the extra blank line generated by `PropertyLayout::generate_code()` at the end of the generated layout.