### PR TITLE
Emit alpha masked effects with proper drawfunc

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2033,6 +2033,8 @@ pub(crate) struct QueueEffectsReadOnlyParams<'w, 's> {
     draw_functions_2d: Res<'w, DrawFunctions<Transparent2d>>,
     #[cfg(feature = "3d")]
     draw_functions_3d: Res<'w, DrawFunctions<Transparent3d>>,
+    #[cfg(feature = "3d")]
+    draw_functions_alpha_mask: Res<'w, DrawFunctions<AlphaMask3d>>,
     dispatch_indirect_pipeline: Res<'w, DispatchIndirectPipeline>,
     init_pipeline: Res<'w, ParticlesInitPipeline>,
     update_pipeline: Res<'w, ParticlesUpdatePipeline>,
@@ -2521,15 +2523,16 @@ pub(crate) fn queue_effects(
     // Loop over all 3D cameras/views that need to render effects
     #[cfg(feature = "3d")]
     {
-        let draw_effects_function_3d = read_params
-            .draw_functions_3d
-            .read()
-            .get_id::<DrawEffects>()
-            .unwrap();
-
         // Effects with full alpha blending
         if !views_3d.is_empty() {
             trace!("Emit effect draw calls for alpha blended 3D views...");
+
+            let draw_effects_function_3d = read_params
+                .draw_functions_3d
+                .read()
+                .get_id::<DrawEffects>()
+                .unwrap();
+
             emit_draw(
                 &mut views_3d,
                 &effect_batches,
@@ -2555,6 +2558,13 @@ pub(crate) fn queue_effects(
         // Effects with alpha mask
         if !views_alpha_mask.is_empty() {
             trace!("Emit effect draw calls for alpha masked 3D views...");
+
+            let draw_effects_function_alpha_mask = read_params
+                .draw_functions_alpha_mask
+                .read()
+                .get_id::<DrawEffects>()
+                .unwrap();
+
             emit_draw(
                 &mut views_alpha_mask,
                 &effect_batches,
@@ -2566,7 +2576,7 @@ pub(crate) fn queue_effects(
                 &pipeline_cache,
                 msaa.samples(),
                 |id, entity, _batch| AlphaMask3d {
-                    draw_function: draw_effects_function_3d,
+                    draw_function: draw_effects_function_alpha_mask,
                     pipeline: id,
                     entity,
                     distance: 0.0, // TODO


### PR DESCRIPTION
Fix a bug where alpha masked effects are emitted with the wrong draw function, causing a panic at runtime.