### PR TITLE
Don't panic when effect asset marked as changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Render modifiers can now access simulation parameters (time, delta time) like in any other context.
+- Fixed a panic in Debug builds when a `ParticleEffect` was marked as changed (for example, via `Mut`) but the asset handle remained the same. (#228)
 
 ## [0.7.0] 2023-07-17
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -465,7 +465,7 @@ impl PropertyLayout {
     /// empty string if the layout is empty. The `Properties` struct contains
     /// the values of all the effect properties, as defined by this layout.
     pub fn generate_code(&self) -> String {
-        //debug_assert!(self.layout.is_sorted_by_key(|entry| entry.offset));
+        // debug_assert!(self.layout.is_sorted_by_key(|entry| entry.offset));
         let content = self
             .layout
             .iter()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3124,7 +3124,7 @@ mod tests {
         let device = renderer.device();
         let limits = GpuLimits::from_device(&device);
 
-        //assert!(limits.storage_buffer_align().get() >= 1);
+        // assert!(limits.storage_buffer_align().get() >= 1);
         assert!(limits.render_indirect_offset(256) >= 256 * GpuRenderIndirect::min_size().get());
         assert!(
             limits.dispatch_indirect_offset(256) as u64


### PR DESCRIPTION
Do not panic when the `ParticleEffect` is marked as changed, but the asset handle didn't actually change. Just do a full rebuild instead.

Bug: #228