### PR TITLE
Fix matrix to wgsl string conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `AlphaMode` and the ability to render particles with alpha masking instead of alpha blending. This is controlled by `EffectAsset::alpha_mode` and the new `EffectAsset::with_alpha_mode()` helper.
 - Added a new `BuiltInOperator::AlphaCutoff` value and associated expression, which represent the alpha cutoff threshold when rendering an effect with alpha masking. The `billboard` example has been updated to show how to use that value, and even dynamically change it with an expression.
 - Added `PropertyLayout::properties()` to iterate over the layout.
+- Added `From` implementations for the most common matrix types
 
 ### Changed
 
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Render modifiers can now access simulation parameters (time, delta time) like in any other context.
 - Fixed a panic in Debug builds when a `ParticleEffect` was marked as changed (for example, via `Mut`) but the asset handle remained the same. (#228)
+- Fixed a bug in the `to_wgsl_string` impl of `MatrixType` that caused the first element to be added twice
 
 ## [0.7.0] 2023-07-17
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -48,6 +48,11 @@ use bevy::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::{MatrixType, ScalarType, ToWgslString, ValueType, VectorType};
+
+pub mod expr;
+pub mod node;
+
 pub use expr::{
     AttributeExpr, BinaryOperator, BuiltInExpr, BuiltInOperator, EvalContext, Expr, ExprError,
     ExprHandle, ExprWriter, LiteralExpr, Module, PropertyExpr, UnaryOperator, WriterExpr,
@@ -56,11 +61,6 @@ pub use node::{
     AddNode, AttributeNode, DivNode, Graph, MulNode, Node, NormalizeNode, Slot, SlotDir, SlotId,
     SubNode, TimeNode,
 };
-
-use crate::{MatrixType, ScalarType, ToWgslString, ValueType, VectorType};
-
-pub mod expr;
-pub mod node;
 
 /// Variant storage for a scalar value.
 #[derive(Debug)]
@@ -350,8 +350,8 @@ pub trait ElemType {
     ///
     /// This is only valid for numeric types, and will panic for a boolean type.
     fn get_all(storage: &[u32; 4], count: usize) -> &[Self]
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 
     /// Get a mutable reference to the given component of the vector from within
     /// its raw storage.
@@ -1604,8 +1604,6 @@ mod tests {
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
     };
-    use bevy::math::Mat3;
-
     use super::*;
 
     #[test]
@@ -1974,7 +1972,7 @@ mod tests {
         );
         assert_eq!(
             calc_hash(&Into::<VectorValue>::into(Vec4::new(
-                3.5, -42., 999.99, -0.01
+                3.5, -42., 999.99, -0.01,
             ))),
             calc_f32_vector_hash(VectorType::VEC4F, &[3.5, -42., 999.99, -0.01])
         );

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -350,8 +350,8 @@ pub trait ElemType {
     ///
     /// This is only valid for numeric types, and will panic for a boolean type.
     fn get_all(storage: &[u32; 4], count: usize) -> &[Self]
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 
     /// Get a mutable reference to the given component of the vector from within
     /// its raw storage.
@@ -1604,6 +1604,7 @@ mod tests {
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
     };
+    use bevy::math::Mat3;
 
     use super::*;
 
@@ -1690,8 +1691,16 @@ mod tests {
             ValueType::Vector(VectorType::VEC4B)
         );
         assert_eq!(
+            Value::Matrix(Mat2::IDENTITY.into()).value_type(),
+            ValueType::Matrix(MatrixType::MAT2X2F)
+        );
+        assert_eq!(
             Value::Matrix(Mat3::IDENTITY.into()).value_type(),
             ValueType::Matrix(MatrixType::MAT3X3F)
+        );
+        assert_eq!(
+            Value::Matrix(Mat4::IDENTITY.into()).value_type(),
+            ValueType::Matrix(MatrixType::MAT4X4F)
         );
     }
 
@@ -1965,7 +1974,7 @@ mod tests {
         );
         assert_eq!(
             calc_hash(&Into::<VectorValue>::into(Vec4::new(
-                3.5, -42., 999.99, -0.01,
+                3.5, -42., 999.99, -0.01
             ))),
             calc_f32_vector_hash(VectorType::VEC4F, &[3.5, -42., 999.99, -0.01])
         );

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -350,8 +350,8 @@ pub trait ElemType {
     ///
     /// This is only valid for numeric types, and will panic for a boolean type.
     fn get_all(storage: &[u32; 4], count: usize) -> &[Self]
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 
     /// Get a mutable reference to the given component of the vector from within
     /// its raw storage.
@@ -1329,10 +1329,7 @@ impl std::hash::Hash for MatrixValue {
 
 impl ToWgslString for MatrixValue {
     fn to_wgsl_string(&self) -> String {
-        let mut vals = format!(
-            "{}(",
-            self.matrix_type().to_wgsl_string(),
-        );
+        let mut vals = format!("{}(", self.matrix_type().to_wgsl_string(),);
         for j in 0..self.matrix_type.cols() {
             for i in 0..self.matrix_type.rows() {
                 vals.push_str(&self.value(i, j).to_wgsl_string());
@@ -1600,11 +1597,11 @@ impl_vec_value!(IVec4, VEC4I, as_ivec4);
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::{
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
     };
-    use super::*;
 
     #[test]
     fn as_bytes() {
@@ -1760,13 +1757,19 @@ mod tests {
         for (m, expected) in [
             (Mat3::IDENTITY, "mat3x3<f32>(1.,0.,0.,0.,1.,0.,0.,0.,1.)"),
             (Mat3::ZERO, "mat3x3<f32>(0.,0.,0.,0.,0.,0.,0.,0.,0.)"),
-            (Mat3::from_cols(
-                Vec3::new(1., 2., 3.),
-                Vec3::new(4., 5., 6.),
-                Vec3::new(7., 8., 9.),
-            ), "mat3x3<f32>(1.,2.,3.,4.,5.,6.,7.,8.,9.)"),
+            (
+                Mat3::from_cols(
+                    Vec3::new(1., 2., 3.),
+                    Vec3::new(4., 5., 6.),
+                    Vec3::new(7., 8., 9.),
+                ),
+                "mat3x3<f32>(1.,2.,3.,4.,5.,6.,7.,8.,9.)",
+            ),
         ] {
-            assert_eq!(Value::Matrix(m.into()).to_wgsl_string(), expected.to_string());
+            assert_eq!(
+                Value::Matrix(m.into()).to_wgsl_string(),
+                expected.to_string()
+            );
         }
     }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -351,8 +351,8 @@ pub trait ElemType {
     ///
     /// This is only valid for numeric types, and will panic for a boolean type.
     fn get_all(storage: &[u32; 4], count: usize) -> &[Self]
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 
     /// Get a mutable reference to the given component of the vector from within
     /// its raw storage.
@@ -1728,6 +1728,18 @@ mod tests {
         ] {
             assert_eq!(Value::Vector(v.into()).to_wgsl_string(), v.to_wgsl_string());
         }
+
+        for (m, expected) in [
+            (Mat3::IDENTITY, "mat3x3<f32>(1.,0.,0.,0.,1.,0.,0.,0.,1.)"),
+            (Mat3::ZERO, "mat3x3<f32>(0.,0.,0.,0.,1.,0.,0.,0.,0.)"),
+            (Mat3::from_cols(
+                Vec3::new(1., 2., 3.),
+                Vec3::new(4., 5., 6.),
+                Vec3::new(7., 8., 9.),
+            ), "mat3x3<f32>(1.,2.,3.,4.,5.,6.,7.,8.,9.)"),
+        ] {
+            assert_eq!(Value::Matrix(m.into()).to_wgsl_string(), expected.to_string());
+        }
     }
 
     #[test]
@@ -1932,7 +1944,7 @@ mod tests {
         );
         assert_eq!(
             calc_hash(&Into::<VectorValue>::into(Vec4::new(
-                3.5, -42., 999.99, -0.01
+                3.5, -42., 999.99, -0.01,
             ))),
             calc_f32_vector_hash(VectorType::VEC4F, &[3.5, -42., 999.99, -0.01])
         );

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -61,6 +61,7 @@ pub use node::{
     AddNode, AttributeNode, DivNode, Graph, MulNode, Node, NormalizeNode, Slot, SlotDir, SlotId,
     SubNode, TimeNode,
 };
+use crate::prelude::Mat3;
 
 /// Variant storage for a scalar value.
 #[derive(Debug)]
@@ -1345,6 +1346,17 @@ impl ToWgslString for MatrixValue {
     }
 }
 
+impl From<Mat3> for MatrixValue {
+    fn from(value: Mat3) -> Self {
+        let mut s = Self {
+            matrix_type: MatrixType::MAT3X3F,
+            storage: [0.; 16],
+        };
+        value.write_cols_to_slice(&mut s.storage);
+        s
+    }
+}
+
 /// Variant storage for a simple value.
 ///
 /// The variant can store a scalar, vector, or matrix value.
@@ -1655,6 +1667,10 @@ mod tests {
         assert_eq!(
             Value::Vector(BVec4::TRUE.into()).value_type(),
             ValueType::Vector(VectorType::VEC4B)
+        );
+        assert_eq!(
+            Value::Matrix(Mat3::IDENTITY.into()).value_type(),
+            ValueType::Matrix(MatrixType::MAT3X3F)
         );
     }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1331,16 +1331,16 @@ impl std::hash::Hash for MatrixValue {
 impl ToWgslString for MatrixValue {
     fn to_wgsl_string(&self) -> String {
         let mut vals = format!(
-            "{}({}",
+            "{}(",
             self.matrix_type().to_wgsl_string(),
-            self.value_n::<0, 0>().to_wgsl_string()
         );
         for j in 0..self.matrix_type.cols() {
             for i in 0..self.matrix_type.rows() {
-                vals.push(',');
                 vals.push_str(&self.value(i, j).to_wgsl_string());
+                vals.push(',');
             }
         }
+        vals.pop(); // Remove the last comma
         vals.push(')');
         vals
     }
@@ -1731,7 +1731,7 @@ mod tests {
 
         for (m, expected) in [
             (Mat3::IDENTITY, "mat3x3<f32>(1.,0.,0.,0.,1.,0.,0.,0.,1.)"),
-            (Mat3::ZERO, "mat3x3<f32>(0.,0.,0.,0.,1.,0.,0.,0.,0.)"),
+            (Mat3::ZERO, "mat3x3<f32>(0.,0.,0.,0.,0.,0.,0.,0.,0.)"),
             (Mat3::from_cols(
                 Vec3::new(1., 2., 3.),
                 Vec3::new(4., 5., 6.),

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -42,16 +42,11 @@
 use std::fmt::Debug;
 
 use bevy::{
-    math::{BVec2, BVec3, BVec4, IVec2, IVec3, IVec4, Vec2, Vec3, Vec3A, Vec4},
+    math::{BVec2, BVec3, BVec4, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Vec2, Vec3, Vec3A, Vec4},
     reflect::Reflect,
     utils::FloatOrd,
 };
 use serde::{Deserialize, Serialize};
-
-use crate::{MatrixType, ScalarType, ToWgslString, ValueType, VectorType};
-
-pub mod expr;
-pub mod node;
 
 pub use expr::{
     AttributeExpr, BinaryOperator, BuiltInExpr, BuiltInOperator, EvalContext, Expr, ExprError,
@@ -61,7 +56,11 @@ pub use node::{
     AddNode, AttributeNode, DivNode, Graph, MulNode, Node, NormalizeNode, Slot, SlotDir, SlotId,
     SubNode, TimeNode,
 };
-use crate::prelude::Mat3;
+
+use crate::{MatrixType, ScalarType, ToWgslString, ValueType, VectorType};
+
+pub mod expr;
+pub mod node;
 
 /// Variant storage for a scalar value.
 #[derive(Debug)]
@@ -1346,10 +1345,32 @@ impl ToWgslString for MatrixValue {
     }
 }
 
+impl From<Mat2> for MatrixValue {
+    fn from(value: Mat2) -> Self {
+        let mut s = Self {
+            matrix_type: MatrixType::MAT2X2F,
+            storage: [0.; 16],
+        };
+        value.write_cols_to_slice(&mut s.storage);
+        s
+    }
+}
+
 impl From<Mat3> for MatrixValue {
     fn from(value: Mat3) -> Self {
         let mut s = Self {
             matrix_type: MatrixType::MAT3X3F,
+            storage: [0.; 16],
+        };
+        value.write_cols_to_slice(&mut s.storage);
+        s
+    }
+}
+
+impl From<Mat4> for MatrixValue {
+    fn from(value: Mat4) -> Self {
+        let mut s = Self {
+            matrix_type: MatrixType::MAT4X4F,
             storage: [0.; 16],
         };
         value.write_cols_to_slice(&mut s.storage);


### PR DESCRIPTION
I noticed a bug in the `to_wgsl_string` impl for Matrices, where the first element was added twice. I also introduced some basic `From` implementations for the most common matrix formats to be able to test & use matrix values.

Changes:
- Fixed bug in `MatrixValue.to_wgsl_string()`
- Introduced some test cases to verify the fix
- Added `From` implementations for `Mat2`, `Mat3` and `Mat4`