### PR TITLE
Customizable image sample mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added implementations of `ToWgslString` for the missing vector types (`UVec2/3/4`, `IVec2/3/4`, `BVec2/3/4`).
 - Added new `CastExpr` expression to cast an operand expression to another `ValueType`. This adds a new variant `Expr::Cast` too.
 - Added new `BinaryOperator::Remainder` to calculate the remainder (`%` operator) of two expressions.
+- Added the `ImageSampleMapping` enum to determine how samples of the image of a `ParticleTextureModifier` are mapped to and modulated with the particle's base color. The new default behavior is `ImageSampleMapping::Modulate`, corresponding to a full modulate of all RGBA components. To restore the previous behavior, and use the Red channel of the texture as an opacity mask, set `ParticleTextureModifier::sample_mapping` to `ImageSampleMapping::ModulateOpacityFromR`.
 
 ### Changed
 

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -112,6 +112,7 @@ fn setup(
             .init(init_lifetime)
             .render(ParticleTextureModifier {
                 texture: texture_handle,
+                sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(OrientModifier {
                 mode: OrientMode::ParallelCameraDepthPlane,

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -96,6 +96,7 @@ fn setup(
             .init(init_lifetime)
             .render(ParticleTextureModifier {
                 texture: texture_handle.clone(),
+                sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(ColorOverLifetimeModifier { gradient })
             .render(SizeOverLifetimeModifier {

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -103,6 +103,7 @@ fn setup(
             .init(init_lifetime)
             .render(ParticleTextureModifier {
                 texture: texture_handle.clone(),
+                sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(ColorOverLifetimeModifier { gradient }),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -937,6 +937,7 @@ impl EffectShaderSource {
             alpha_cutoff_code,
             particle_texture,
             layout_flags,
+            image_sample_mapping_code,
         ) = {
             let mut render_context = RenderContext::new(&property_layout, &particle_layout);
             for m in asset.render_modifiers() {
@@ -990,6 +991,7 @@ impl EffectShaderSource {
                 alpha_cutoff_code,
                 render_context.particle_texture,
                 layout_flags,
+                render_context.image_sample_mapping_code,
             )
         };
 
@@ -1067,7 +1069,11 @@ impl EffectShaderSource {
                 "{{SIMULATION_SPACE_TRANSFORM_PARTICLE}}",
                 &render_sim_space_transform_code,
             )
-            .replace("{{ALPHA_CUTOFF}}", &alpha_cutoff_code);
+            .replace("{{ALPHA_CUTOFF}}", &alpha_cutoff_code)
+            .replace(
+                "{{PARTICLE_TEXTURE_SAMPLE_MAPPING}}",
+                &image_sample_mapping_code,
+            );
         trace!("Configured render shader:\n{}", render_shader_source);
 
         Ok(EffectShaderSource {

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -466,6 +466,9 @@ pub struct RenderContext<'a> {
     pub render_extra: String,
     /// Texture modulating the particle color.
     pub particle_texture: Option<Handle<Image>>,
+    /// WGSL code describing how to modulate the base color of the particle with
+    /// the image texture sample, if any.
+    pub image_sample_mapping_code: String,
     /// Color gradients.
     pub gradients: HashMap<u64, Gradient<Vec4>>,
     /// Size gradients.
@@ -490,6 +493,7 @@ impl<'a> RenderContext<'a> {
             fragment_code: String::new(),
             render_extra: String::new(),
             particle_texture: None,
+            image_sample_mapping_code: String::new(),
             gradients: HashMap::new(),
             size_gradients: HashMap::new(),
             screen_space_size: false,

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -19,7 +19,7 @@ pub enum ImageSampleMapping {
     /// Modulate the particle's base color with the full RGBA sample of the
     /// texture image.
     ///
-    /// ```
+    /// ```wgsl
     /// color = baseColor * texColor;
     /// ```
     #[default]
@@ -28,7 +28,7 @@ pub enum ImageSampleMapping {
     /// Modulate the particle's base color with the RGB sample of the texture
     /// image, leaving the alpha component unmodified.
     ///
-    /// ```
+    /// ```wgsl
     /// color.rgb = baseColor.rgb * texColor.rgb;
     /// ```
     ModulateRGB,
@@ -36,7 +36,7 @@ pub enum ImageSampleMapping {
     /// Modulate the alpha component (opacity) of the particle's base color with
     /// the red component of the sample of the texture image.
     ///
-    /// ```
+    /// ```wgsl
     /// color.a = baseColor.a * texColor.r;
     /// ```
     ModulateOpacityFromR,

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -250,12 +250,11 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 
 {{FRAGMENT_MODIFIERS}}
 
-#ifdef PARTICLE_TEXTURE
-    var color = textureSample(particle_texture, particle_sampler, in.uv);
-    color = vec4<f32>(1.0, 1.0, 1.0, color.r); // FIXME - grayscale modulate
-    color = in.color * color;
-#else
     var color = in.color;
+
+#ifdef PARTICLE_TEXTURE
+    var texColor = textureSample(particle_texture, particle_sampler, in.uv);
+    {{PARTICLE_TEXTURE_SAMPLE_MAPPING}}
 #endif
 
 #ifdef USE_ALPHA_MASK


### PR DESCRIPTION
Add a new `ImageSampleMapping` enum to customize the way a sample of the image of a `ParticleTextureModifier` is mapped to and modulated with the particle's base color.

The previous behavior was always using the Red channel of the texture as an opacity mask, modulating the sample's Alpha component only. This legacy behavior can be restored with the `ModulateOpacityFromR` value.

The new default is `Modulate`, which corresponds to a full component-wise multiply of all components of the image sample by the particle's base color.