### PR TITLE
Add flipbook animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new `CastExpr` expression to cast an operand expression to another `ValueType`. This adds a new variant `Expr::Cast` too.
 - Added new `BinaryOperator::Remainder` to calculate the remainder (`%` operator) of two expressions.
 - Added the `ImageSampleMapping` enum to determine how samples of the image of a `ParticleTextureModifier` are mapped to and modulated with the particle's base color. The new default behavior is `ImageSampleMapping::Modulate`, corresponding to a full modulate of all RGBA components. To restore the previous behavior, and use the Red channel of the texture as an opacity mask, set `ParticleTextureModifier::sample_mapping` to `ImageSampleMapping::ModulateOpacityFromR`.
+- Added new `FlipbookModifier` to treat the image of a `ParticleTextureModifier` as a grid sprite sheet, and allow rendering a sprite from that sheet. By animating the selected sprite, this creates a flipbook animation for the particle.
+- Added new `Attribute::SPRITE_INDEX` holding the `i32` index of a sprite inside a sprite sheet texture. This is used with the `FlipbookModifier` to render sprite-based animated particles.
 
 ### Changed
 
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `RenderContext` to implement `EvalContext`. This allows render modifiers to use the expression API.
 - `PropertyLayout::generate_code()` has no more extra empty line at the end of the struct in the generated code.
 - `EvalContext::eval()` now caches the evaluation of an `ExprHandle` and guarantees that the evaluation is only ever performed once. This ensures that cloned `ExprHandle` making a same expression used in multiple places all reference the same evaluation, which is stored inside a local variable. This fixes an unexpected behavior where expressions with side effect like `rand()` where emitted multiple times, leading to different values, even though a single expression was used (via cloned handles). To restore the old behavior, simply generating separate expressions from a `Module` or an `ExprWriter` instead of cloning and reusing a same `ExprHandle`.
+- The default texture sampling mode for `ParticleTextureModifier` is now a full RGBA modulate. See `ImageSampleMapping` for details. Use `ImageSampleMapping::ModulateOpacityFromR` to restore the previous behavior.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["bevy", "particle-system", "particles", "vfx"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = ["examples/*.gif", "examples/*.png", ".github", "release.md", "run_examples.bat", "run_examples.sh"]
+autoexamples = false
 
 [features]
 default = ["2d", "3d", "gpu_tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ wgpu = "0.16"
 naga = "0.12"
 naga_oil = "0.8"
 
+# For procedural texture generation in examples
+noise = "0.8"
+
 futures = "0.3"
 bevy-inspector-egui = "0.19"
 

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,6 +1,7 @@
 //! Example of using the circle spawner with random velocity.
 //!
-//! A sphere spawns dust in a circle.
+//! A sphere spawns dust in a circle. Each dust particle is animated with a
+//! [`FlipbookModifier`], from a procedurally generated sprite sheet.
 
 use bevy::{
     core_pipeline::tonemapping::Tonemapping,
@@ -11,6 +12,10 @@ use bevy::{
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_hanabi::prelude::*;
+
+mod texutils;
+
+use texutils::make_anim_img;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut wgpu_settings = WgpuSettings::default();
@@ -45,8 +50,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn setup(
-    asset_server: Res<AssetServer>,
     mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
     mut effects: ResMut<Assets<EffectAsset>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -59,16 +64,24 @@ fn setup(
         Transform::from_xyz(3.0, 3.0, 5.0).looking_at(Vec3::new(0.0, 1.0, 0.0), Vec3::Y);
     commands.spawn(camera);
 
-    let texture_handle: Handle<Image> = asset_server.load("cloud.png");
+    // Procedurally create a sprite sheet representing an animated texture
+    let sprite_size = UVec2::new(64, 64);
+    let sprite_grid_size = UVec2::new(8, 8);
+    let anim_img = make_anim_img(sprite_size, sprite_grid_size, Vec3::new(0.1, 0.1, 0.1));
+    let texture_handle = images.add(anim_img);
+
+    let frame_count = sprite_grid_size.x * sprite_grid_size.y;
 
     let mut gradient = Gradient::new();
-    gradient.add_key(0.0, Vec4::splat(0.5));
-    gradient.add_key(0.5, Vec4::splat(0.5));
-    gradient.add_key(1.0, Vec4::new(0.5, 0.5, 0.5, 0.0));
+    gradient.add_key(0.0, Vec4::ONE);
+    gradient.add_key(0.5, Vec4::ONE);
+    gradient.add_key(1.0, Vec3::ONE.extend(0.));
 
     let writer = ExprWriter::new();
 
-    let age = writer.lit(0.).expr();
+    // Initialize the AGE to a random [0:1] value to ensure not all particles start
+    // their animation at the same frame. Otherwise they all animate in sync.
+    let age = writer.rand(ScalarType::Float).expr();
     let init_age = SetAttributeModifier::new(Attribute::AGE, age);
 
     let lifetime = writer.lit(5.).expr();
@@ -87,6 +100,35 @@ fn setup(
         speed: (writer.lit(1.) + writer.lit(0.5) * writer.rand(ScalarType::Float)).expr(),
     };
 
+    // Animate the SPRITE_INDEX attribute of each particle based on its age.
+    // We want to animate back and forth the index in [0:N-1] where N is the total
+    // number of sprites in the sprite sheet.
+    // - For the back and forth, we build a linear ramp z 1 -> 0 -> 1 with abs(x)
+    //   and y linear in [-1:1]
+    // - To get that linear cyclic y variable in [-1:1], we build a linear cyclic x
+    //   variable in [0:1]
+    // - To get that linear cyclic x variable in [0:1], we take the fractional part
+    //   of the age
+    // - Because we want to have one full cycle every couple of seconds, we need to
+    //   scale down the age value (0.02)
+    // - Finally the linear ramp z is scaled to the [0:N-1] range
+    // Putting it together we get:
+    //   sprite_index = i32(
+    //       abs(fract(particle.age * 0.02) * 2. - 1.) * frame_count
+    //     ) % frame_count;
+    let sprite_index = writer
+        .attr(Attribute::AGE)
+        .mul(writer.lit(0.1))
+        .fract()
+        .mul(writer.lit(2.))
+        .sub(writer.lit(1.))
+        .abs()
+        .mul(writer.lit(frame_count as f32))
+        .cast(ScalarType::Int)
+        .rem(writer.lit(frame_count as i32))
+        .expr();
+    let update_sprite_index = SetAttributeModifier::new(Attribute::SPRITE_INDEX, sprite_index);
+
     let effect = effects.add(
         EffectAsset::new(32768, Spawner::once(32.0.into(), true), writer.finish())
             .with_name("circle")
@@ -94,13 +136,15 @@ fn setup(
             .init(init_vel)
             .init(init_age)
             .init(init_lifetime)
+            .update(update_sprite_index)
             .render(ParticleTextureModifier {
                 texture: texture_handle.clone(),
                 sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
+            .render(FlipbookModifier { sprite_grid_size })
             .render(ColorOverLifetimeModifier { gradient })
             .render(SizeOverLifetimeModifier {
-                gradient: Gradient::constant([0.2; 2].into()),
+                gradient: Gradient::constant([0.5; 2].into()),
                 screen_space_size: false,
             }),
     );

--- a/examples/texutils.rs
+++ b/examples/texutils.rs
@@ -1,0 +1,70 @@
+use bevy::{
+    prelude::*,
+    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+};
+use noise::{NoiseFn, Perlin};
+
+/// Create an animated sprite sheet texture.
+///
+/// Create a texture composed of individual sprites of size `size` pixels,
+/// arranged into a grid of `grid` size into the texture image. The final image
+/// has a pixel size of `size * grid`.
+///
+/// The texture is based on a 3D Perlin noise scaled with `scale.xy`. Each
+/// sprite is a layer at a different height, scaled by `scale.z`, giving the
+/// impression of animation.
+///
+/// The final image is convoluted by a falloff disk to ensure the square border
+/// of the texture are hidden. Instead the texture appears roughly circular.
+///
+/// This produces an R8Unorm texture where the R component is equal to the
+/// opacity, to be used with the [`ImageSampleMapping::ModulateOpacityFromR`]
+/// mode of the [`ParticleTextureModifier`].
+///
+/// This code is a utility for examples. It's nowhere near efficient or clean as
+/// could be for production.
+pub fn make_anim_img(size: UVec2, grid: UVec2, scale: Vec3) -> Image {
+    let w = Perlin::new(42);
+    let tile_cols = size.x as usize;
+    let tile_rows = size.y as usize;
+    let grid_cols = grid.x as usize;
+    let grid_rows = grid.y as usize;
+    let tex_cols = tile_cols * grid_cols;
+    let tex_rows = tile_rows * grid_rows;
+    let tex_len = tex_cols * tex_rows;
+    let mut data = vec![0; tex_len];
+    let mut k = 0.;
+    let dk = scale.z as f64;
+    let tile_half_size = Vec2::new(size.x as f32 * scale.x, size.y as f32 * scale.y) / 2.;
+    let tile_radius = tile_half_size.x.abs().max(tile_half_size.y.abs()) * 0.9;
+    for v in 0..grid.y as usize {
+        let index0 = v * tex_cols * tile_rows;
+        for u in 0..grid.x as usize {
+            let index1 = index0 + u * tile_cols;
+            for j in 0..size.y as usize {
+                let index2 = index1 + j * tex_cols;
+                for i in 0..size.x as usize {
+                    let index3 = index2 + i;
+                    let pt = Vec2::new(i as f32 * scale.x, j as f32 * scale.y);
+                    let dist = pt.distance(tile_half_size);
+                    let falloff = (dist / tile_radius).clamp(0., 1.);
+                    let value = w.get([pt.x as f64, pt.y as f64, k]) * 256.;
+                    let falloff_value = value * (1.0 - falloff as f64);
+                    let falloff_height = (falloff_value as u32).clamp(0, 255) as u8;
+                    data[index3] = falloff_height;
+                }
+            }
+            k += dk;
+        }
+    }
+    Image::new(
+        Extent3d {
+            width: tex_cols as u32,
+            height: tex_rows as u32,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        data,
+        TextureFormat::R8Unorm,
+    )
+}

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -419,6 +419,11 @@ impl AttributeInner {
         Value::Vector(VectorValue::new_vec3(Vec3::Z)),
     );
 
+    pub const SPRITE_INDEX: &'static AttributeInner = &AttributeInner::new(
+        Cow::Borrowed("sprite_index"),
+        Value::Scalar(ScalarValue::Int(0)),
+    );
+
     #[inline]
     pub(crate) const fn new(name: Cow<'static, str>, default_value: Value) -> Self {
         Self {
@@ -637,6 +642,10 @@ impl FromReflect for Attribute {
 impl Attribute {
     /// The particle position in [simulation space].
     ///
+    /// # Name
+    ///
+    /// `position`
+    ///
     /// # Type
     ///
     /// [`VectorType::VEC3F`] representing the XYZ coordinates of the position.
@@ -645,6 +654,10 @@ impl Attribute {
     pub const POSITION: Attribute = Attribute(AttributeInner::POSITION);
 
     /// The particle velocity in [simulation space].
+    ///
+    /// # Name
+    ///
+    /// `velocity`
     ///
     /// # Type
     ///
@@ -655,7 +668,7 @@ impl Attribute {
 
     /// The age of the particle.
     ///
-    /// Each time the particle is updated, the current simualtion delta time is
+    /// Each time the particle is updated, the current simulation delta time is
     /// added to the particle's age. The age can be used to animate some other
     /// quantities; see the [`ColorOverLifetimeModifier`] for example.
     ///
@@ -664,6 +677,10 @@ impl Attribute {
     /// [`Attribute::LIFETIME`] attribute), then when the age of the particle
     /// exceeds its lifetime, the particle dies and is not simulated nor
     /// rendered anymore.
+    ///
+    /// # Name
+    ///
+    /// `age`
     ///
     /// # Type
     ///
@@ -679,6 +696,10 @@ impl Attribute {
     /// simulated and rendered. This requires the [`Attribute::AGE`]
     /// attribute to be used too.
     ///
+    /// # Name
+    ///
+    /// `lifetime`
+    ///
     /// # Type
     ///
     /// [`ScalarType::Float`]
@@ -689,6 +710,10 @@ impl Attribute {
     /// This attribute stores a per-particle color, which can be used for
     /// various purposes, generally as the base color for rendering the
     /// particle.
+    ///
+    /// # Name
+    ///
+    /// `color`
     ///
     /// # Type
     ///
@@ -702,6 +727,10 @@ impl Attribute {
     /// various purposes, generally as the base color for rendering the
     /// particle.
     ///
+    /// # Name
+    ///
+    /// `hdr_color`
+    ///
     /// # Type
     ///
     /// [`VectorType::VEC4F`] representing the RGBA components of the color.
@@ -709,14 +738,27 @@ impl Attribute {
     /// represent HDR values.
     pub const HDR_COLOR: Attribute = Attribute(AttributeInner::HDR_COLOR);
 
-    /// The particle's transparency (alpha).
+    /// The particle's opacity (alpha).
     ///
-    /// Type: [`ScalarType::Float`]
+    /// This is a value in \[0:1\], where `0` corresponds to a fully transparent
+    /// particle, and `1` to a fully opaque one.
+    ///
+    /// # Name
+    ///
+    /// `alpha`
+    ///
+    /// # Type
+    ///
+    /// [`ScalarType::Float`]
     pub const ALPHA: Attribute = Attribute(AttributeInner::ALPHA);
 
     /// The particle's uniform size.
     ///
     /// The particle is uniformly scaled by this size.
+    ///
+    /// # Name
+    ///
+    /// `size`
     ///
     /// # Type
     ///
@@ -728,6 +770,10 @@ impl Attribute {
     /// The particle, when drawn as a quad, is scaled along its local X and Y
     /// axes by these values.
     ///
+    /// # Name
+    ///
+    /// `size2`
+    ///
     /// # Type
     ///
     /// [`VectorType::VEC2F`] representing the XY sizes of the particle.
@@ -738,11 +784,18 @@ impl Attribute {
     /// This attribute stores a per-particle X axis, which defines the
     /// horizontal direction of a quad particle. This is generally used to
     /// re-orient the particle during rendering, for example to face the camera
-    /// or another point of interest.
+    /// or another point of interest. For example, the [`OrientModifier`]
+    /// modifies this attribute to make the particle face a specific item.
+    ///
+    /// # Name
+    ///
+    /// `axis_x`
     ///
     /// # Type
     ///
     /// [`VectorType::VEC3F`]
+    ///
+    /// [`OrientModifier`]: crate::modifier::output::OrientModifier
     pub const AXIS_X: Attribute = Attribute(AttributeInner::AXIS_X);
 
     /// The local Y axis of the particle.
@@ -750,11 +803,18 @@ impl Attribute {
     /// This attribute stores a per-particle Y axis, which defines the vertical
     /// direction of a quad particle. This is generally used to re-orient the
     /// particle during rendering, for example to face the camera or another
-    /// point of interest.
+    /// point of interest. For example, the [`OrientModifier`] modifies this
+    /// attribute to make the particle face a specific item.
+    ///
+    /// # Name
+    ///
+    /// `axis_y`
     ///
     /// # Type
     ///
     /// [`VectorType::VEC3F`]
+    ///
+    /// [`OrientModifier`]: crate::modifier::output::OrientModifier
     pub const AXIS_Y: Attribute = Attribute(AttributeInner::AXIS_Y);
 
     /// The local Z axis of the particle.
@@ -762,15 +822,38 @@ impl Attribute {
     /// This attribute stores a per-particle Z axis, which defines the normal to
     /// a quad particle's plane. This is generally used to re-orient the
     /// particle during rendering, for example to face the camera or another
-    /// point of interest.
+    /// point of interest. For example, the [`OrientModifier`] modifies this
+    /// attribute to make the particle face a specific item.
+    ///
+    /// # Name
+    ///
+    /// `axis_z`
     ///
     /// # Type
     ///
     /// [`VectorType::VEC3F`]
+    ///
+    /// [`OrientModifier`]: crate::modifier::output::OrientModifier
     pub const AXIS_Z: Attribute = Attribute(AttributeInner::AXIS_Z);
 
+    /// The sprite index in a flipbook animation.
+    ///
+    /// This attribute stores the index of the sprite of a flipbook animation.
+    /// This is used with the [`FlipbookModifier`].
+    ///
+    /// # Name
+    ///
+    /// `sprite_index`
+    ///
+    /// # Type
+    ///
+    /// [`ScalarType::Int`]
+    ///
+    /// [`FlipbookModifier`]: crate::modifier::output::FlipbookModifier
+    pub const SPRITE_INDEX: Attribute = Attribute(AttributeInner::SPRITE_INDEX);
+
     /// Collection of all the existing particle attributes.
-    pub const ALL: [Attribute; 12] = [
+    pub const ALL: [Attribute; 13] = [
         Attribute::POSITION,
         Attribute::VELOCITY,
         Attribute::AGE,
@@ -783,6 +866,7 @@ impl Attribute {
         Attribute::AXIS_X,
         Attribute::AXIS_Y,
         Attribute::AXIS_Z,
+        Attribute::SPRITE_INDEX,
     ];
 
     /// Retrieve an attribute by its name.

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -26,7 +26,7 @@
 
 use bevy::{
     asset::Handle,
-    math::{Vec2, Vec3, Vec4},
+    math::{UVec2, Vec2, Vec3, Vec4},
     reflect::Reflect,
     render::texture::Image,
     utils::{FloatOrd, HashMap},
@@ -469,6 +469,8 @@ pub struct RenderContext<'a> {
     /// WGSL code describing how to modulate the base color of the particle with
     /// the image texture sample, if any.
     pub image_sample_mapping_code: String,
+    /// Flipbook sprite sheet grid size, if any.
+    pub sprite_grid_size: Option<UVec2>,
     /// Color gradients.
     pub gradients: HashMap<u64, Gradient<Vec4>>,
     /// Size gradients.
@@ -494,6 +496,7 @@ impl<'a> RenderContext<'a> {
             render_extra: String::new(),
             particle_texture: None,
             image_sample_mapping_code: String::new(),
+            sprite_grid_size: None,
             gradients: HashMap::new(),
             size_gradients: HashMap::new(),
             screen_space_size: false,

--- a/src/modifier/position.rs
+++ b/src/modifier/position.rs
@@ -328,7 +328,7 @@ impl SetPositionCone3dModifier {
             },
         )?;
 
-        let code = format!("{}(&particle);\n", func_name);
+        let code = format!("{}(transform, &particle);\n", func_name);
 
         Ok(code)
     }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -203,7 +203,13 @@ fn vertex(
     var particle = particle_buffer.particles[index];
     var out: VertexOutput;
 #ifdef PARTICLE_TEXTURE
-    out.uv = vertex_uv;
+    var uv = vertex_uv;
+#ifdef FLIPBOOK
+    let row_count = {{FLIPBOOK_ROW_COUNT}};
+    let ij = vec2<f32>(f32(particle.sprite_index % row_count), f32(particle.sprite_index / row_count));
+    uv = (ij + uv) * {{FLIPBOOK_SCALE}};
+#endif
+    out.uv = uv;
 #endif
 
 {{INPUTS}}


### PR DESCRIPTION
Add a new `Attribute::SPRITE_INDEX` and a new `FlipbookModifier` to enable spritesheet-based "flipbook" animation of particles.
- The texture from a `ParticleTextureModifier` is sliced into a grid as specified by the `FlipbookModifier`;
- Each frame, the renderer reads the `Attribute::SRITE_INDEX` of the particle and selects the Nth sprite in the spritesheet.

There is currently no built-in animation of `Attribute::SPRITE_INDEX`; instead you should use the Expression API to update the attribute each frame. This allows total control on the animation speed / framerate, any looping, or even allows non-linear framerate and complex indexing into the spritesheet.

Fixes #108