### PR TITLE
Change `debug_assert_eq` to `assert_approx_eq`

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -208,7 +208,8 @@ pub(crate) struct GpuCompressedTransform {
 impl From<Mat4> for GpuCompressedTransform {
     fn from(value: Mat4) -> Self {
         let tr = value.transpose();
-        debug_assert_eq!(tr.w_axis, Vec4::W);
+        #[cfg(test)]
+        crate::test_utils::assert_approx_eq!(tr.w_axis, Vec4::W);
         Self {
             x_row: tr.x_axis,
             y_row: tr.y_axis,
@@ -220,7 +221,8 @@ impl From<Mat4> for GpuCompressedTransform {
 impl From<&Mat4> for GpuCompressedTransform {
     fn from(value: &Mat4) -> Self {
         let tr = value.transpose();
-        debug_assert_eq!(tr.w_axis, Vec4::W);
+        #[cfg(test)]
+        crate::test_utils::assert_approx_eq!(tr.w_axis, Vec4::W);
         Self {
             x_row: tr.x_axis,
             y_row: tr.y_axis,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -102,11 +102,11 @@ macro_rules! assert_approx_eq {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 assert!(
-                    AbsDiffEq::abs_diff_eq(left_val, right_val, 1e-5),
+                    crate::test_utils::AbsDiffEq::abs_diff_eq(left_val, right_val, 1e-5),
                     "assertion failed: expected={} actual={} delta={} tol=1e-5(default)",
                     left_val,
                     right_val,
-                    AbsDiffEq::abs_diff(left_val, right_val),
+                    crate::test_utils::AbsDiffEq::abs_diff(left_val, right_val),
                 );
             }
         }
@@ -115,11 +115,11 @@ macro_rules! assert_approx_eq {
         match (&$left, &$right, &$tol) {
             (left_val, right_val, tol_val) => {
                 assert!(
-                    AbsDiffEq::abs_diff_eq(left_val, right_val, *tol_val),
+                    crate::test_utils::AbsDiffEq::abs_diff_eq(left_val, right_val, *tol_val),
                     "assertion failed: expected={} actual={} delta={} tol={}",
                     left_val,
                     right_val,
-                    AbsDiffEq::abs_diff(left_val, right_val),
+                    crate::test_utils::AbsDiffEq::abs_diff(left_val, right_val),
                     tol_val
                 );
             }


### PR DESCRIPTION
This assert can fail with an error like this in practice:

```
thread 'Compute Task Pool (8)' panicked at /home/sludge/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_hanabi-0.8.0/src/render/mod.rs:211:9:
assertion `left == right` failed
  left: Vec4(-0.0, -0.0, -0.0, 1.0000001)
 right: Vec4(0.0, 0.0, 0.0, 1.0)
```

Change it to a `assert_approx_eq!` to fix that.