### PR TITLE
Register `CompiledParticleEffect` type to inspect properties

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1131,25 +1131,39 @@ impl EffectShaderSource {
 /// ([`Visibility::Visible`]).
 ///
 /// [`set_property()`]: crate::CompiledParticleEffect::set_property
-#[derive(Debug, Clone, Component)]
+#[derive(Debug, Clone, Component, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct CompiledParticleEffect {
     /// Weak handle to the underlying asset.
     asset: Handle<EffectAsset>,
+
     /// Cached simulation condition, to avoid having to query the asset each
     /// time we need it.
+    #[reflect(ignore)]
     simulation_condition: SimulationCondition,
-    /// Handle to the effect shader for his effect instance, if configured.
+
+    /// Handle to the effect shader for this effect instance, if configured.
+    #[reflect(ignore)]
     effect_shader: Option<EffectShader>,
+
     /// Instances of all exposed properties.
     properties: Vec<PropertyInstance>,
+
     /// Force field modifier values.
+    #[reflect(ignore)]
     force_field: [ForceFieldSource; ForceFieldSource::MAX_SOURCES],
+
     /// Main particle texture.
+    #[reflect(ignore)]
     particle_texture: Option<Handle<Image>>,
+
     /// 2D layer for the effect instance.
     #[cfg(feature = "2d")]
+    #[reflect(ignore)]
     z_layer_2d: FloatOrd,
+
     /// Layout flags.
+    #[reflect(ignore)]
     layout_flags: LayoutFlags,
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -24,7 +24,7 @@ use crate::{
         ParticlesUpdatePipeline, ShaderCache, SimParams, VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
-    tick_spawners, ParticleEffect, RemovedEffectsEvent, Spawner,
+    tick_spawners, CompiledParticleEffect, ParticleEffect, RemovedEffectsEvent, Spawner,
 };
 
 pub mod main_graph {
@@ -80,6 +80,7 @@ impl Plugin for HanabiPlugin {
         // Register the component reflection
         app.register_type::<EffectAsset>();
         app.register_type::<ParticleEffect>();
+        app.register_type::<CompiledParticleEffect>();
         app.register_type::<Spawner>();
     }
 


### PR DESCRIPTION
Thanks so much for this awesome crate!

I was wanting to experiment with custom properties, which are awesome by the way, but realised that `CompiledParticleEffect` didn't implement `Reflect`.
This PR simply implements `Reflect` (not `FromReflect`) and adds the type into the registry, so that I can experiment with different values at runtime.