### PR TITLE
Import Bevy types in Hanabi shaders

### DIFF
--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -1,27 +1,4 @@
-
-// FIXME - Use imports to get exact types from Bevy directly
-
-struct ColorGrading {
-    exposure: f32,
-    gamma: f32,
-    pre_saturation: f32,
-    post_saturation: f32,
-}
-
-struct View {
-    view_proj: mat4x4<f32>,
-    unjittered_view_proj: mat4x4<f32>,
-    inverse_view_proj: mat4x4<f32>,
-    view: mat4x4<f32>,
-    inverse_view: mat4x4<f32>,
-    projection: mat4x4<f32>,
-    inverse_projection: mat4x4<f32>,
-    world_position: vec3<f32>,
-    // viewport(x_origin, y_origin, width, height)
-    viewport: vec4<f32>,
-    color_grading: ColorGrading,
-    mip_bias: f32,
-}
+#import bevy_render::view::View
 
 struct Particle {
 {{ATTRIBUTES}}


### PR DESCRIPTION
Use `naga_oil`'s import mechanism to import the Bevy shader types (like `bevy_render::view::View`) into Hanabi shaders, instead of redefining the same types. This prevents silent breakage on upgrade, where the type defined in Hanabi doesn't match the content of the Bevy buffer. This also avoids code duplication.