### PR TITLE
Add a global time scale for all effects

### DIFF
--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1062,13 +1062,20 @@ impl CastExpr {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 pub enum BuiltInOperator {
     /// Current effect system simulation time since startup, in seconds.
+    /// This is based on the [`Time<EffectSimulation>`](crate::time::EffectSimulation) clock.
     Time,
     /// Delta time, in seconds, since last effect system update.
     DeltaTime,
-    /// Current effect system simulation time since startup, in seconds.
-    UnscaledTime,
-    /// Delta time, in seconds, since last effect system update.
-    UnscaledDeltaTime,
+    /// Current virtual time since startup, in seconds.
+    /// This is based on the [`Time<Virtual>`](bevy::time::Virtual) clock.
+    VirtualTime,
+    /// Virtual delta time, in seconds, since last effect system update.
+    VirtualDeltaTime,
+    /// Current real time since startup, in seconds.
+    /// This is based on the [`Time<Time>`](bevy::time::Real) clock.
+    RealTime,
+    /// Real delta time, in seconds, since last effect system update.
+    RealDeltaTime,
     /// Random unit value of the given type.
     ///
     /// The type can be any scalar or vector type. Matrix types are not
@@ -1101,8 +1108,10 @@ impl BuiltInOperator {
         match self {
             BuiltInOperator::Time => "time",
             BuiltInOperator::DeltaTime => "delta_time",
-            BuiltInOperator::UnscaledTime => "unscaled_time",
-            BuiltInOperator::UnscaledDeltaTime => "unscaled_delta_time",
+            BuiltInOperator::VirtualTime => "virtual_time",
+            BuiltInOperator::VirtualDeltaTime => "virtual_delta_time",
+            BuiltInOperator::RealTime => "real_time",
+            BuiltInOperator::RealDeltaTime => "real_delta_time",
             BuiltInOperator::Rand(value_type) => match value_type {
                 ValueType::Scalar(s) => match s {
                     ScalarType::Bool => "brand",
@@ -1138,8 +1147,10 @@ impl BuiltInOperator {
         match self {
             BuiltInOperator::Time => ValueType::Scalar(ScalarType::Float),
             BuiltInOperator::DeltaTime => ValueType::Scalar(ScalarType::Float),
-            BuiltInOperator::UnscaledTime => ValueType::Scalar(ScalarType::Float),
-            BuiltInOperator::UnscaledDeltaTime => ValueType::Scalar(ScalarType::Float),
+            BuiltInOperator::VirtualTime => ValueType::Scalar(ScalarType::Float),
+            BuiltInOperator::VirtualDeltaTime => ValueType::Scalar(ScalarType::Float),
+            BuiltInOperator::RealTime => ValueType::Scalar(ScalarType::Float),
+            BuiltInOperator::RealDeltaTime => ValueType::Scalar(ScalarType::Float),
             BuiltInOperator::Rand(value_type) => *value_type,
             BuiltInOperator::AlphaCutoff => ValueType::Scalar(ScalarType::Float),
         }

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1065,6 +1065,10 @@ pub enum BuiltInOperator {
     Time,
     /// Delta time, in seconds, since last effect system update.
     DeltaTime,
+    /// Current effect system simulation time since startup, in seconds.
+    UnscaledTime,
+    /// Delta time, in seconds, since last effect system update.
+    UnscaledDeltaTime,
     /// Random unit value of the given type.
     ///
     /// The type can be any scalar or vector type. Matrix types are not
@@ -1097,6 +1101,8 @@ impl BuiltInOperator {
         match self {
             BuiltInOperator::Time => "time",
             BuiltInOperator::DeltaTime => "delta_time",
+            BuiltInOperator::UnscaledTime => "unscaled_time",
+            BuiltInOperator::UnscaledDeltaTime => "unscaled_delta_time",
             BuiltInOperator::Rand(value_type) => match value_type {
                 ValueType::Scalar(s) => match s {
                     ScalarType::Bool => "brand",
@@ -1132,6 +1138,8 @@ impl BuiltInOperator {
         match self {
             BuiltInOperator::Time => ValueType::Scalar(ScalarType::Float),
             BuiltInOperator::DeltaTime => ValueType::Scalar(ScalarType::Float),
+            BuiltInOperator::UnscaledTime => ValueType::Scalar(ScalarType::Float),
+            BuiltInOperator::UnscaledDeltaTime => ValueType::Scalar(ScalarType::Float),
             BuiltInOperator::Rand(value_type) => *value_type,
             BuiltInOperator::AlphaCutoff => ValueType::Scalar(ScalarType::Float),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,16 @@ pub(crate) fn next_multiple_of(value: usize, align: usize) -> usize {
     count * align
 }
 
+/// Global time scale for all effects.
+#[derive(Debug, Clone, Copy, Deref, DerefMut, Resource)]
+pub struct EffectTimeScale(f64);
+
+impl Default for EffectTimeScale {
+    fn default() -> Self {
+        Self(1.0)
+    }
+}
+
 /// Extension trait to convert an object to WGSL code.
 ///
 /// This is mainly used for floating-point constants. This is required because

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ mod plugin;
 pub mod properties;
 mod render;
 mod spawn;
+mod time;
 
 #[cfg(test)]
 mod test_utils;
@@ -208,6 +209,7 @@ pub use plugin::HanabiPlugin;
 pub use properties::*;
 pub use render::{EffectSystems, LayoutFlags, ShaderCache};
 pub use spawn::{tick_spawners, CpuValue, EffectSpawner, Random, Spawner};
+pub use time::{EffectSimulation, EffectSimulationTime};
 
 #[allow(missing_docs)]
 pub mod prelude {
@@ -232,16 +234,6 @@ pub(crate) fn next_multiple_of(value: usize, align: usize) -> usize {
     assert!(align & (align - 1) == 0); // power of 2
     let count = (value + align - 1) / align;
     count * align
-}
-
-/// Global time scale for all effects.
-#[derive(Debug, Clone, Copy, Deref, DerefMut, Resource)]
-pub struct EffectTimeScale(f64);
-
-impl Default for EffectTimeScale {
-    fn default() -> Self {
-        Self(1.0)
-    }
 }
 
 /// Extension trait to convert an object to WGSL code.

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -1009,8 +1009,10 @@ struct ParticleBuffer {{
 struct SimParams {{
     delta_time: f32,
     time: f32,
-    unscaled_delta_time: f32,
-    unscaled_time: f32,
+    virtual_delta_time: f32,
+    virtual_time: f32,
+    real_delta_time: f32,
+    real_time: f32,
 }};
 
 struct ForceFieldSource {{

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -1009,6 +1009,8 @@ struct ParticleBuffer {{
 struct SimParams {{
     delta_time: f32,
     time: f32,
+    unscaled_delta_time: f32,
+    unscaled_time: f32,
 }};
 
 struct ForceFieldSource {{

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -136,7 +136,8 @@ impl Plugin for HanabiPlugin {
         app.register_type::<EffectAsset>()
             .register_type::<ParticleEffect>()
             .register_type::<EffectProperties>()
-            .register_type::<Spawner>();
+            .register_type::<Spawner>()
+            .register_type::<Time<EffectSimulation>>();
     }
 
     fn finish(&self, app: &mut App) {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -29,7 +29,7 @@ use crate::{
     spawn::{self, Random},
     tick_spawners,
     time::effect_simulation_time_system,
-    update_properties_from_asset, ParticleEffect, RemovedEffectsEvent, Spawner,
+    update_properties_from_asset, EffectSimulation, ParticleEffect, RemovedEffectsEvent, Spawner,
 };
 
 pub mod main_graph {
@@ -100,6 +100,7 @@ impl Plugin for HanabiPlugin {
             .insert_resource(Random(spawn::new_rng()))
             .init_resource::<ShaderCache>()
             .init_asset_loader::<EffectAssetLoader>()
+            .init_resource::<Time<EffectSimulation>>()
             .configure_sets(
                 PostUpdate,
                 (

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,6 +12,7 @@ use bevy::{
         view::{prepare_view_uniforms, visibility::VisibilitySystems},
         Render, RenderApp, RenderSet,
     },
+    time::{virtual_time_system, TimeSystem},
 };
 
 use crate::{
@@ -26,8 +27,9 @@ use crate::{
         VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
-    tick_spawners, update_properties_from_asset, EffectTimeScale, ParticleEffect,
-    RemovedEffectsEvent, Spawner,
+    tick_spawners,
+    time::effect_simulation_time_system,
+    update_properties_from_asset, ParticleEffect, RemovedEffectsEvent, Spawner,
 };
 
 pub mod main_graph {
@@ -92,8 +94,6 @@ impl HanabiPlugin {
 
 impl Plugin for HanabiPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<EffectTimeScale>();
-
         // Register asset
         app.init_asset::<EffectAsset>()
             .add_event::<RemovedEffectsEvent>()
@@ -114,6 +114,12 @@ impl Plugin for HanabiPlugin {
             .configure_sets(
                 bevy::asset::UpdateAssets,
                 EffectSystems::UpdatePropertiesFromAsset.after(bevy::asset::TrackAssets),
+            )
+            .add_systems(
+                First,
+                effect_simulation_time_system
+                    .after(virtual_time_system)
+                    .in_set(TimeSystem),
             )
             .add_systems(
                 PostUpdate,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -26,7 +26,8 @@ use crate::{
         VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
-    tick_spawners, update_properties_from_asset, ParticleEffect, RemovedEffectsEvent, Spawner,
+    tick_spawners, update_properties_from_asset, EffectTimeScale, ParticleEffect,
+    RemovedEffectsEvent, Spawner,
 };
 
 pub mod main_graph {
@@ -91,6 +92,8 @@ impl HanabiPlugin {
 
 impl Plugin for HanabiPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<EffectTimeScale>();
+
         // Register asset
         app.init_asset::<EffectAsset>()
             .add_event::<RemovedEffectsEvent>()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -48,7 +48,7 @@ use crate::{
     render::batch::{BatchInput, BatchState, Batcher, EffectBatch},
     spawn::EffectSpawner,
     CompiledParticleEffect, EffectProperties, EffectShader, EffectSimulation, HanabiPlugin,
-    ParticleLayout, PropertyLayout, RemovedEffectsEvent, SimulationCondition, SimulationSpace,
+    ParticleLayout, PropertyLayout, RemovedEffectsEvent, SimulationCondition,
 };
 
 mod aligned_buffer_vec;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1299,8 +1299,8 @@ pub(crate) fn extract_effect_events(
 ///
 /// [`ParticleEffect`]: crate::ParticleEffect
 pub(crate) fn extract_effects(
-    real_time: Extract<Res<Time<EffectSimulation>>>,
-    virtual_time: Extract<Res<Time<EffectSimulation>>>,
+    real_time: Extract<Res<Time<Real>>>,
+    virtual_time: Extract<Res<Time<Virtual>>>,
     time: Extract<Res<Time<EffectSimulation>>>,
     effects: Extract<Res<Assets<EffectAsset>>>,
     _images: Extract<Res<Assets<Image>>>,

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -5,6 +5,10 @@ struct SimParams {
     delta_time: f32,
     /// Time in seconds since the start of simulation.
     time: f32,
+    /// Delta time in seconds since last simulation tick.
+    unscaled_delta_time: f32,
+    /// Time in seconds since the start of simulation.
+    unscaled_time: f32,
 //#ifdef SIM_PARAMS_INDIRECT_DATA
     /// Number of effects batched together.
     num_effects: u32,

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -5,10 +5,14 @@ struct SimParams {
     delta_time: f32,
     /// Time in seconds since the start of simulation.
     time: f32,
-    /// Delta time in seconds since last simulation tick.
-    unscaled_delta_time: f32,
-    /// Time in seconds since the start of simulation.
-    unscaled_time: f32,
+    /// Virtual delta time in seconds since last simulation tick.
+    virtual_delta_time: f32,
+    /// Virtual time in seconds since the start of simulation.
+    virtual_time: f32,
+    /// Real delta time in seconds since last simulation tick.
+    real_delta_time: f32,
+    /// Real time in seconds since the start of simulation.
+    real_time: f32,
 //#ifdef SIM_PARAMS_INDIRECT_DATA
     /// Number of effects batched together.
     num_effects: u32,

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -8,7 +8,7 @@ use rand::{
 use rand_pcg::Pcg32;
 use serde::{Deserialize, Serialize};
 
-use crate::{EffectAsset, ParticleEffect, SimulationCondition};
+use crate::{EffectAsset, EffectTimeScale, ParticleEffect, SimulationCondition};
 
 /// An RNG to be used in the CPU for the particle system engine
 pub(crate) fn new_rng() -> Pcg32 {
@@ -562,6 +562,7 @@ impl EffectSpawner {
 pub fn tick_spawners(
     mut commands: Commands,
     time: Res<Time>,
+    time_scale: Res<EffectTimeScale>,
     effects: Res<Assets<EffectAsset>>,
     mut rng: ResMut<Random>,
     mut query: Query<(
@@ -573,7 +574,7 @@ pub fn tick_spawners(
 ) {
     trace!("tick_spawners");
 
-    let dt = time.delta_seconds();
+    let dt = (**time_scale * time.delta_seconds_f64()) as f32;
 
     for (entity, effect, maybe_inherited_visibility, maybe_spawner) in query.iter_mut() {
         // TODO - maybe cache simulation_condition so we don't need to unconditionally
@@ -805,6 +806,7 @@ mod test {
         app.init_resource::<DeterministicRenderingConfig>();
         app.add_plugins(VisibilityPlugin);
         app.init_resource::<Time>();
+        app.init_resource::<EffectTimeScale>();
         app.insert_resource(Random(new_rng()));
         app.init_asset::<EffectAsset>();
         app.add_systems(

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,172 @@
+use bevy::prelude::*;
+
+/// The effect simulation clock.
+///
+/// This is a specialization of the [`Time`] structure and uses the virtual clock
+/// [`Time<Virtual>`](Virtual) as its base.
+///
+/// The speed of this clock is therefore the product of the speed of the virtual clock and the
+/// speed of this clock itself. To change the speed of the entire app (including the effects),
+/// use [`Time<Virtual>`](Virtual). To influence only the speed of the effects, use
+/// [`Time<EffectSimulation>`](EffectSimulation).
+///
+/// # Example
+///
+/// ```
+/// # use bevy_hanabi::*;
+/// fn my_system(mut time: ResMut<Time<EffectSimulation>>) {
+///     // Pause the effects
+///     time.pause();
+///
+///     // Unpause the effects
+///     time.unpause();
+///
+///     // Set the speed to 2.0
+///     time.set_relative_speed(2.0);
+/// }
+/// ```
+#[derive(Debug, Copy, Clone, Reflect)]
+pub struct EffectSimulation {
+    paused: bool,
+    relative_speed: f64,
+    effective_speed: f64,
+}
+
+impl Default for EffectSimulation {
+    fn default() -> Self {
+        Self {
+            paused: false,
+            relative_speed: 1.0,
+            effective_speed: 1.0,
+        }
+    }
+}
+
+/// All methods for the effect simulation clock.
+pub trait EffectSimulationTime {
+    /// Returns the speed the clock advances relative to the virtual clock, as [`f32`].
+    fn relative_speed(&self) -> f32;
+
+    /// Returns the speed the clock advances relative to the virtual clock, as [`f64`].
+    fn relative_speed_f64(&self) -> f64;
+
+    /// Returns the speed the clock advanced relative to the virtual clock in
+    /// this update, as [`f32`].
+    ///
+    /// Returns `0.0` if the game was paused or what the `relative_speed` value
+    /// was at the start of this update.
+    fn effective_speed(&self) -> f32;
+
+    /// Returns the speed the clock advanced relative to the virtual clock in
+    /// this update, as [`f64`].
+    ///
+    /// Returns `0.0` if the game was paused or what the `relative_speed` value
+    /// was at the start of this update.
+    fn effective_speed_f64(&self) -> f64;
+
+    /// Sets the speed the clock advances relative to the virtual clock, given as an [`f32`].
+    ///
+    /// For example, setting this to `2.0` will make the clock advance twice as fast as the virtual
+    /// clock.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ratio` is negative or not finite.
+    fn set_relative_speed(&mut self, ratio: f32);
+
+    /// Sets the speed the clock advances relative to the virtual clock, given as an [`f64`].
+    ///
+    /// For example, setting this to `2.0` will make the clock advance twice as fast as the virtual
+    /// clock.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ratio` is negative or not finite.
+    fn set_relative_speed_f64(&mut self, ratio: f64);
+
+    /// Stops the clock, preventing it from advancing until resumed.
+    fn pause(&mut self);
+
+    /// Resumes the clock if paused.
+    fn unpause(&mut self);
+
+    /// Returns `true` if the clock is currently paused.
+    fn is_paused(&self) -> bool;
+
+    /// Returns `true` if the clock was paused at the start of this update.
+    fn was_paused(&self) -> bool;
+}
+
+impl EffectSimulationTime for Time<EffectSimulation> {
+    #[inline]
+    fn relative_speed(&self) -> f32 {
+        self.relative_speed_f64() as f32
+    }
+
+    #[inline]
+    fn relative_speed_f64(&self) -> f64 {
+        self.context().relative_speed
+    }
+
+    #[inline]
+    fn effective_speed(&self) -> f32 {
+        self.context().effective_speed as f32
+    }
+
+    #[inline]
+    fn effective_speed_f64(&self) -> f64 {
+        self.context().effective_speed
+    }
+
+    #[inline]
+    fn set_relative_speed(&mut self, ratio: f32) {
+        self.set_relative_speed_f64(ratio as f64);
+    }
+
+    #[inline]
+    fn set_relative_speed_f64(&mut self, ratio: f64) {
+        assert!(ratio.is_finite(), "tried to go infinitely fast");
+        assert!(ratio >= 0.0, "tried to go back in time");
+        self.context_mut().relative_speed = ratio;
+    }
+
+    #[inline]
+    fn pause(&mut self) {
+        self.context_mut().paused = true;
+    }
+
+    #[inline]
+    fn unpause(&mut self) {
+        self.context_mut().paused = false;
+    }
+
+    #[inline]
+    fn is_paused(&self) -> bool {
+        self.context().paused
+    }
+
+    #[inline]
+    fn was_paused(&self) -> bool {
+        self.context().effective_speed == 0.0
+    }
+}
+
+pub(crate) fn effect_simulation_time_system(
+    virt: Res<Time<Virtual>>,
+    mut effect_simulation: ResMut<Time<EffectSimulation>>,
+) {
+    let virt_delta = virt.delta();
+    let effective_speed = if effect_simulation.context().paused {
+        0.0
+    } else {
+        effect_simulation.context().relative_speed
+    };
+    let delta = if effective_speed != 1.0 {
+        virt_delta.mul_f64(effective_speed)
+    } else {
+        // avoid rounding when at normal speed
+        virt_delta
+    };
+    effect_simulation.context_mut().effective_speed = effective_speed;
+    effect_simulation.advance_by(delta);
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -167,6 +167,6 @@ pub(crate) fn effect_simulation_time_system(
         // avoid rounding when at normal speed
         virt_delta
     };
-    effect_simulation.context_mut().effective_speed = effective_speed;
+    effect_simulation.context_mut().effective_speed = effective_speed * virt.effective_speed_f64();
     effect_simulation.advance_by(delta);
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -42,7 +42,7 @@ impl Default for EffectSimulation {
     }
 }
 
-/// All methods for the effect simulation clock.
+/// All methods for the [`Time<EffectSimulation>`](EffectSimulation) clock.
 pub trait EffectSimulationTime {
     /// Returns the speed the clock advances relative to the virtual clock, as [`f32`].
     fn relative_speed(&self) -> f32;

--- a/src/time.rs
+++ b/src/time.rs
@@ -53,7 +53,7 @@ pub trait EffectSimulationTime {
     /// Returns the speed the clock advanced relative to your system clock in this update,
     /// as [`f32`].
     ///
-    /// Returns `0.0` if the either [`Time<Virtual>`](Virtual) or
+    /// Returns `0.0` if either the [`Time<Virtual>`](Virtual) or the
     /// [`Time<EffectSimulationTime>`](EffectSimulationTime) was paused
     /// and otherwise the product of the `relative_speed` of the clocks at the start of the update.
     fn effective_speed(&self) -> f32;
@@ -61,7 +61,7 @@ pub trait EffectSimulationTime {
     /// Returns the speed the clock advanced relative to your system clock in this update,
     /// as [`f64`].
     ///
-    /// Returns `0.0` if the either [`Time<Virtual>`](Virtual) or
+    /// Returns `0.0` if either the [`Time<Virtual>`](Virtual) or the
     /// [`Time<EffectSimulationTime>`](EffectSimulationTime) was paused
     /// and otherwise the product of the `relative_speed` of the clocks at the start of the update.
     fn effective_speed_f64(&self) -> f64;

--- a/src/time.rs
+++ b/src/time.rs
@@ -50,18 +50,20 @@ pub trait EffectSimulationTime {
     /// Returns the speed the clock advances relative to the virtual clock, as [`f64`].
     fn relative_speed_f64(&self) -> f64;
 
-    /// Returns the speed the clock advanced relative to the virtual clock in
-    /// this update, as [`f32`].
+    /// Returns the speed the clock advanced relative to your system clock in this update,
+    /// as [`f32`].
     ///
-    /// Returns `0.0` if the game was paused or what the `relative_speed` value
-    /// was at the start of this update.
+    /// Returns `0.0` if the either [`Time<Virtual>`](Virtual) or
+    /// [`Time<EffectSimulationTime>`](EffectSimulationTime) was paused
+    /// and otherwise the product of the `relative_speed` of the clocks at the start of the update.
     fn effective_speed(&self) -> f32;
 
-    /// Returns the speed the clock advanced relative to the virtual clock in
-    /// this update, as [`f64`].
+    /// Returns the speed the clock advanced relative to your system clock in this update,
+    /// as [`f64`].
     ///
-    /// Returns `0.0` if the game was paused or what the `relative_speed` value
-    /// was at the start of this update.
+    /// Returns `0.0` if the either [`Time<Virtual>`](Virtual) or
+    /// [`Time<EffectSimulationTime>`](EffectSimulationTime) was paused
+    /// and otherwise the product of the `relative_speed` of the clocks at the start of the update.
     fn effective_speed_f64(&self) -> f64;
 
     /// Sets the speed the clock advances relative to the virtual clock, given as an [`f32`].

--- a/src/time.rs
+++ b/src/time.rs
@@ -14,6 +14,7 @@ use bevy::prelude::*;
 ///
 /// ```
 /// # use bevy_hanabi::*;
+/// # use bevy::prelude::*;
 /// fn my_system(mut time: ResMut<Time<EffectSimulation>>) {
 ///     // Pause the effects
 ///     time.pause();


### PR DESCRIPTION
~~Add a global time scale for all effects. Currently very WIP. Probably needs:~~
- ~~Some tests/examples~~
- ~~More docs~~

Now reimplemented (and documented) using the `Time<T>` resource from bevy.

(Could still need some examples/tests when we have settled on the design)

Closes #239. Pausing should be possible by setting `EffectTimeScale` to zero.