### PR TITLE
Switch screen space size to be a modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a new `ScreenSpaceSizeModifier` which negates the effect of perspective projection, and makes the particle's size a pixel size in screen space, instead of a Bevy world unit size. This replaces the hard-coded behavior previously available on the `SetSizeModifier`.
+
+### Removed
+
+- Removed the `screen_space_size` field from the `SetSizeModifier`. Use the new `ScreenSpaceSizeModifier` to use a screen-space size.
+
 ## [0.10.0] 2024-02-24
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.10.0"
+version = "0.11.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Hanabi GPU particle system for the Bevy game engine"

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -80,10 +80,7 @@ where
         .render(SetColorModifier {
             color: COLOR.into(),
         })
-        .render(SetSizeModifier {
-            size: SIZE.into(),
-            screen_space_size: false,
-        })
+        .render(SetSizeModifier { size: SIZE.into() })
 }
 
 fn spawn_effect(

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -181,8 +181,8 @@ fn setup(
             // Set a size of 3 (logical) pixels, constant in screen space, independent of projection
             .render(SetSizeModifier {
                 size: Vec2::splat(3.).into(),
-                screen_space_size: true,
-            }),
+            })
+            .render(ScreenSpaceSizeModifier),
     );
 
     commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,9 +960,6 @@ impl EffectShaderSource {
             if let AlphaMode::Mask(_) = &asset.alpha_mode {
                 layout_flags |= LayoutFlags::USE_ALPHA_MASK;
             }
-            if render_context.screen_space_size {
-                layout_flags |= LayoutFlags::SCREEN_SPACE_SIZE;
-            }
 
             let (flipbook_scale_code, flipbook_row_count_code) = if let Some(grid_size) =
                 render_context.sprite_grid_size

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -505,10 +505,6 @@ pub struct RenderContext<'a> {
     pub gradients: HashMap<u64, Gradient<Vec4>>,
     /// Size gradients.
     pub size_gradients: HashMap<u64, Gradient<Vec2>>,
-    /// Are particles using a fixed screen-space size (in logical pixels)? If
-    /// `true` then the particle size is not affected by the camera projection,
-    /// and in particular by the distance to the camera.
-    pub screen_space_size: bool,
     /// Counter for unique variable names.
     var_counter: u32,
     /// Cache of evaluated expressions.
@@ -531,7 +527,6 @@ impl<'a> RenderContext<'a> {
             sprite_grid_size: None,
             gradients: HashMap::new(),
             size_gradients: HashMap::new(),
-            screen_space_size: false,
             var_counter: 0,
             expr_cache: Default::default(),
             is_attribute_pointer: false,

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -304,9 +304,7 @@ impl EffectBuffer {
                 count: None,
             },
         ];
-        if layout_flags.contains(LayoutFlags::LOCAL_SPACE_SIMULATION)
-            || layout_flags.contains(LayoutFlags::SCREEN_SPACE_SIZE)
-        {
+        if layout_flags.contains(LayoutFlags::LOCAL_SPACE_SIMULATION) {
             entries.push(BindGroupLayoutEntry {
                 binding: 3,
                 visibility: ShaderStages::VERTEX,

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -135,17 +135,6 @@ fn vertex(
 
 {{VERTEX_MODIFIERS}}
 
-#ifdef PARTICLE_SCREEN_SPACE_SIZE
-    // Get perspective divide factor from clip space position. This is the "average" factor for the entire
-    // particle, taken at its position (mesh origin), and applied uniformly for all vertices.
-    let w_cs = transform_position_simulation_to_clip(particle.position).w;
-    // Scale size by w_cs to negate the perspective divide which will happen later after the vertex shader.
-    // The 2.0 factor is because clip space is in [-1:1] so we need to divide by the half screen size only.
-    let screen_size_pixels = view.viewport.zw;
-    let projection_scale = vec2<f32>(view.projection[0][0], view.projection[1][1]);
-    size = (size * w_cs * 2.0) / min(screen_size_pixels.x * projection_scale.x, screen_size_pixels.y * projection_scale.y);
-#endif
-
     // Expand particle mesh vertex based on particle position ("origin"), and local
     // orientation and size of the particle mesh (currently: only quad).
     let vpos = vertex_position * vec3<f32>(size.x, size.y, 1.0);


### PR DESCRIPTION
Remove the hard-coded path for scree-space size, and the field in `RenderContext`, and add instead a `ScreenSpaceSizeModifier`. Convert the previously hard-coded render shader code to a regular render modifier, now that the screen-space size calculation is decoupled from the orientation.