### PR TITLE
Fix invalid WGSL for large `u32` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new `ScreenSpaceSizeModifier` which negates the effect of perspective projection, and makes the particle's size a pixel size in screen space, instead of a Bevy world unit size. This replaces the hard-coded behavior previously available on the `SetSizeModifier`.
 - Added a new `ConformToSphereModifier` acting as an attractor applying a force toward a point (sphere center) to all particles in range, and making particles conform ("stick") to the sphere surface.
+- Added `vec2` and `vec3` functions that allow construction of vectors from dynamic parts.
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a panic in rendering randomly occurring when no effect is present.
+- Fixed invalid WGSL being generated for large `u32` values.
 
 ## [0.10.0] 2024-02-24
 

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -3425,8 +3425,8 @@ mod tests {
             (sign, "sign", "vec3<f32>(1.,-3.1,6.99)"),
             (sin, "sin", "vec3<f32>(1.,-3.1,6.99)"),
             (tan, "tan", "vec3<f32>(1.,-3.1,6.99)"),
-            (unpack4x8snorm, "unpack4x8snorm", "0"),
-            (unpack4x8unorm, "unpack4x8unorm", "0"),
+            (unpack4x8snorm, "unpack4x8snorm", "0u"),
+            (unpack4x8unorm, "unpack4x8unorm", "0u"),
         ] {
             let expr = ctx.eval(&m, expr);
             assert!(expr.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ impl ToWgslString for IVec4 {
 
 impl ToWgslString for u32 {
     fn to_wgsl_string(&self) -> String {
-        format!("{}", self)
+        format!("{}u", self)
     }
 }
 
@@ -1532,11 +1532,11 @@ mod tests {
     #[test]
     fn to_wgsl_uvec() {
         let s = UVec2::new(1, 2).to_wgsl_string();
-        assert_eq!(s, "vec2<u32>(1,2)");
+        assert_eq!(s, "vec2<u32>(1u,2u)");
         let s = UVec3::new(1, 2, 42).to_wgsl_string();
-        assert_eq!(s, "vec3<u32>(1,2,42)");
+        assert_eq!(s, "vec3<u32>(1u,2u,42u)");
         let s = UVec4::new(1, 2, 42, 5).to_wgsl_string();
-        assert_eq!(s, "vec4<u32>(1,2,42,5)");
+        assert_eq!(s, "vec4<u32>(1u,2u,42u,5u)");
     }
 
     #[test]


### PR DESCRIPTION
Before this patch, the following code:

```
SetAttributeModifier::new(Attribute::COLOR, module.lit(0xffffffffu32))
```

would panic with:

```
2024-02-26T03:17:31.630083Z ERROR bevy_render::render_resource::pipeline_cache: failed to process shader:
error: failed to convert expression to a concrete type: the concrete type `i32` cannot represent the abstract value `4294967295` accurately
   ┌─ hanabi/worms_15332001714877325580.wgsl:83:18
   │
83 │ particle.color = 4294967295;
   │                  ^^^^^^^^^^ this expression has type {AbstractInt}
   │
   = failed to convert expression to a concrete type: the concrete type `i32` cannot represent the abstract value `4294967295` accurately
```

This one-character change fixes the issue.