### PR TITLE
Make `BinaryOperator::UniformRand` work with vectors.

### DIFF
--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -200,8 +200,20 @@ fn frand4() -> vec4<f32> {
     return vec4<f32>(x, y, z, w);
 }
 
-fn rand_uniform(a: f32, b: f32) -> f32 {
+fn rand_uniform_f(a: f32, b: f32) -> f32 {
     return a + frand() * (b - a);
+}
+
+fn rand_uniform_vec2(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    return a + frand2() * (b - a);
+}
+
+fn rand_uniform_vec3(a: vec3<f32>, b: vec3<f32>) -> vec3<f32> {
+    return a + frand3() * (b - a);
+}
+
+fn rand_uniform_vec4(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
+    return a + frand4() * (b - a);
 }
 
 fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -1,7 +1,7 @@
 #import bevy_hanabi::vfx_common::{
     IndirectBuffer, ParticleGroup, RenderEffectMetadata, RenderGroupIndirect, SimParams, Spawner,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
-    rand_uniform, proj
+    rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4, proj
 }
 
 struct Particle {

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -2,7 +2,7 @@
 #import bevy_hanabi::vfx_common::{
     DispatchIndirect, IndirectBuffer, SimParams, Spawner,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
-    rand_uniform, proj
+    rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4, proj
 }
 
 struct Particle {

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -1,7 +1,7 @@
 #import bevy_hanabi::vfx_common::{
     IndirectBuffer, ParticleGroup, RenderEffectMetadata, RenderGroupIndirect, SimParams, Spawner,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
-    rand_uniform, proj
+    rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4, proj
 }
 
 struct Particle {


### PR DESCRIPTION
The documentation claims that `UniformRand` works with vectors, but it actually only works with scalars. This makes it hard to make particles with random colors, especially with the lack of dynamic `vec4` constructors.

This commit fixes the problem for float vectors only. It's still broken with matrices and non-float scalars, but those are less important.