### PR TITLE
Add missing `VectorValue::as_uvecX()` and `From`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `ScreenSpaceSizeModifier` which negates the effect of perspective projection, and makes the particle's size a pixel size in screen space, instead of a Bevy world unit size. This replaces the hard-coded behavior previously available on the `SetSizeModifier`.
 - Added a new `ConformToSphereModifier` acting as an attractor applying a force toward a point (sphere center) to all particles in range, and making particles conform ("stick") to the sphere surface.
 - Added `vec2` and `vec3` functions that allow construction of vectors from dynamic parts.
+- Added missing `VectorValue::as_uvecX()` and `impl From<UVecX> for VectorValue` for all `X=2,3,4`.
 
 ### Changed
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -778,6 +778,36 @@ impl VectorValue {
         IVec4::from_slice(bytemuck::cast_slice::<u32, i32>(&self.storage))
     }
 
+    /// Cast this vector value to a [`UVec2`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the current vector type is not [`VectorType::VEC2U`].
+    pub fn as_uvec2(&self) -> UVec2 {
+        assert_eq!(self.vector_type, VectorType::VEC2U);
+        UVec2::from_slice(&self.storage)
+    }
+
+    /// Cast this vector value to a [`UVec3`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the current vector type is not [`VectorType::VEC3U`].
+    pub fn as_uvec3(&self) -> UVec3 {
+        assert_eq!(self.vector_type, VectorType::VEC3U);
+        UVec3::from_slice(&self.storage)
+    }
+
+    /// Cast this vector value to a [`UVec4`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the current vector type is not [`VectorType::VEC4U`].
+    pub fn as_uvec4(&self) -> UVec4 {
+        assert_eq!(self.vector_type, VectorType::VEC4U);
+        UVec4::from_slice(&self.storage)
+    }
+
     /// Get the value as a binary blob ready for GPU upload.
     pub fn as_bytes(&self) -> &[u8] {
         let count = self.vector_type.count();
@@ -1016,16 +1046,8 @@ impl From<BVec2> for VectorValue {
         Self {
             vector_type: VectorType::new(ScalarType::Bool, 2),
             storage: [
-                if value.x {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
-                if value.y {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
+                ScalarValue::BOOL_STORAGE[value.x as usize],
+                ScalarValue::BOOL_STORAGE[value.y as usize],
                 0,
                 0,
             ],
@@ -1038,21 +1060,9 @@ impl From<BVec3> for VectorValue {
         Self {
             vector_type: VectorType::new(ScalarType::Bool, 3),
             storage: [
-                if value.x {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
-                if value.y {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
-                if value.z {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
+                ScalarValue::BOOL_STORAGE[value.x as usize],
+                ScalarValue::BOOL_STORAGE[value.y as usize],
+                ScalarValue::BOOL_STORAGE[value.z as usize],
                 0,
             ],
         }
@@ -1064,28 +1074,84 @@ impl From<BVec4> for VectorValue {
         Self {
             vector_type: VectorType::new(ScalarType::Bool, 4),
             storage: [
-                if value.x {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
-                if value.y {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
-                if value.z {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
-                if value.w {
-                    ScalarValue::BOOL_TRUE_STORAGE
-                } else {
-                    0
-                },
+                ScalarValue::BOOL_STORAGE[value.x as usize],
+                ScalarValue::BOOL_STORAGE[value.y as usize],
+                ScalarValue::BOOL_STORAGE[value.z as usize],
+                ScalarValue::BOOL_STORAGE[value.w as usize],
             ],
         }
+    }
+}
+
+impl From<IVec2> for VectorValue {
+    fn from(value: IVec2) -> Self {
+        let mut s = Self {
+            vector_type: VectorType::VEC2I,
+            storage: [0u32; 4],
+        };
+        let v = bytemuck::cast_slice_mut::<u32, i32>(&mut s.storage);
+        value.write_to_slice(v);
+        s
+    }
+}
+
+impl From<IVec3> for VectorValue {
+    fn from(value: IVec3) -> Self {
+        let mut s = Self {
+            vector_type: VectorType::VEC3I,
+            storage: [0u32; 4],
+        };
+        let v = bytemuck::cast_slice_mut::<u32, i32>(&mut s.storage);
+        value.write_to_slice(v);
+        s
+    }
+}
+
+impl From<IVec4> for VectorValue {
+    fn from(value: IVec4) -> Self {
+        let mut s = Self {
+            vector_type: VectorType::VEC4I,
+            storage: [0u32; 4],
+        };
+        let v = bytemuck::cast_slice_mut::<u32, i32>(&mut s.storage);
+        value.write_to_slice(v);
+        s
+    }
+}
+
+impl From<UVec2> for VectorValue {
+    fn from(value: UVec2) -> Self {
+        let mut s = Self {
+            vector_type: VectorType::VEC2U,
+            storage: [0u32; 4],
+        };
+        let v = &mut s.storage;
+        value.write_to_slice(v);
+        s
+    }
+}
+
+impl From<UVec3> for VectorValue {
+    fn from(value: UVec3) -> Self {
+        let mut s = Self {
+            vector_type: VectorType::VEC3U,
+            storage: [0u32; 4],
+        };
+        let v = &mut s.storage;
+        value.write_to_slice(v);
+        s
+    }
+}
+
+impl From<UVec4> for VectorValue {
+    fn from(value: UVec4) -> Self {
+        let mut s = Self {
+            vector_type: VectorType::VEC4U,
+            storage: [0u32; 4],
+        };
+        let v = &mut s.storage;
+        value.write_to_slice(v);
+        s
     }
 }
 
@@ -1132,42 +1198,6 @@ impl From<Vec4> for VectorValue {
             storage: [0u32; 4],
         };
         let v = bytemuck::cast_slice_mut::<u32, f32>(&mut s.storage);
-        value.write_to_slice(v);
-        s
-    }
-}
-
-impl From<IVec2> for VectorValue {
-    fn from(value: IVec2) -> Self {
-        let mut s = Self {
-            vector_type: VectorType::VEC2I,
-            storage: [0u32; 4],
-        };
-        let v = bytemuck::cast_slice_mut::<u32, i32>(&mut s.storage);
-        value.write_to_slice(v);
-        s
-    }
-}
-
-impl From<IVec3> for VectorValue {
-    fn from(value: IVec3) -> Self {
-        let mut s = Self {
-            vector_type: VectorType::VEC3I,
-            storage: [0u32; 4],
-        };
-        let v = bytemuck::cast_slice_mut::<u32, i32>(&mut s.storage);
-        value.write_to_slice(v);
-        s
-    }
-}
-
-impl From<IVec4> for VectorValue {
-    fn from(value: IVec4) -> Self {
-        let mut s = Self {
-            vector_type: VectorType::VEC4I,
-            storage: [0u32; 4],
-        };
-        let v = bytemuck::cast_slice_mut::<u32, i32>(&mut s.storage);
         value.write_to_slice(v);
         s
     }
@@ -1546,6 +1576,9 @@ impl_vec_value!(Vec4, VEC4F, as_vec4);
 impl_vec_value!(IVec2, VEC2I, as_ivec2);
 impl_vec_value!(IVec3, VEC3I, as_ivec3);
 impl_vec_value!(IVec4, VEC4I, as_ivec4);
+impl_vec_value!(UVec2, VEC2U, as_uvec2);
+impl_vec_value!(UVec3, VEC3U, as_uvec3);
+impl_vec_value!(UVec4, VEC4U, as_uvec4);
 
 #[cfg(test)]
 mod tests {
@@ -1727,6 +1760,27 @@ mod tests {
 
     #[test]
     fn vector_value() {
+        let v = BVec2::new(false, true);
+        let vv = VectorValue::new_bvec2(v);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[0]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        assert_eq!(0u32, vv.storage[2]);
+        assert_eq!(0u32, vv.storage[3]);
+
+        let v = BVec3::new(false, true, false);
+        let vv = VectorValue::new_bvec3(v);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[0]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[2]);
+        assert_eq!(0u32, vv.storage[3]);
+
+        let v = BVec4::new(false, true, false, true);
+        let vv = VectorValue::new_bvec4(v);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[0]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[2]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[3]);
+
         let v = Vec2::new(-3.2, 5.);
         let vv = VectorValue::new_vec2(v);
         assert_eq!(v.x.to_bits(), vv.storage[0]);
@@ -1748,26 +1802,77 @@ mod tests {
         assert_eq!(v.z.to_bits(), vv.storage[2]);
         assert_eq!(v.w.to_bits(), vv.storage[3]);
 
-        let v = BVec2::new(false, true);
-        let vv = VectorValue::new_bvec2(v);
-        assert_eq!(0u32, vv.storage[0]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        #[allow(unsafe_code)]
+        {
+            let v = IVec2::new(-3, 5);
+            let vv = VectorValue::new_ivec2(v);
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.x) },
+                vv.storage[0]
+            );
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.y) },
+                vv.storage[1]
+            );
+            assert_eq!(0u32, vv.storage[2]);
+            assert_eq!(0u32, vv.storage[3]);
+
+            let v = IVec3::new(-3, 5, 64);
+            let vv = VectorValue::new_ivec3(v);
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.x) },
+                vv.storage[0]
+            );
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.y) },
+                vv.storage[1]
+            );
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.z) },
+                vv.storage[2]
+            );
+            assert_eq!(0u32, vv.storage[3]);
+
+            let v = IVec4::new(-3, 5, 64, -42);
+            let vv = VectorValue::new_ivec4(v);
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.x) },
+                vv.storage[0]
+            );
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.y) },
+                vv.storage[1]
+            );
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.z) },
+                vv.storage[2]
+            );
+            assert_eq!(
+                unsafe { std::mem::transmute::<i32, u32>(v.w) },
+                vv.storage[3]
+            );
+        }
+
+        let v = UVec2::new(3, 5);
+        let vv = VectorValue::new_uvec2(v);
+        assert_eq!(v.x, vv.storage[0]);
+        assert_eq!(v.y, vv.storage[1]);
         assert_eq!(0u32, vv.storage[2]);
         assert_eq!(0u32, vv.storage[3]);
 
-        let v = BVec3::new(false, true, false);
-        let vv = VectorValue::new_bvec3(v);
-        assert_eq!(0u32, vv.storage[0]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
-        assert_eq!(0u32, vv.storage[2]);
+        let v = UVec3::new(3, 5, 64);
+        let vv = VectorValue::new_uvec3(v);
+        assert_eq!(v.x, vv.storage[0]);
+        assert_eq!(v.y, vv.storage[1]);
+        assert_eq!(v.z, vv.storage[2]);
         assert_eq!(0u32, vv.storage[3]);
 
-        let v = BVec4::new(false, true, false, true);
-        let vv = VectorValue::new_bvec4(v);
-        assert_eq!(0u32, vv.storage[0]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
-        assert_eq!(0u32, vv.storage[2]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[3]);
+        let v = UVec4::new(3, 5, 64, 42);
+        let vv = VectorValue::new_uvec4(v);
+        assert_eq!(v.x, vv.storage[0]);
+        assert_eq!(v.y, vv.storage[1]);
+        assert_eq!(v.z, vv.storage[2]);
+        assert_eq!(v.w, vv.storage[3]);
     }
 
     #[test]
@@ -1776,6 +1881,30 @@ mod tests {
         assert_eq!(Value::Scalar(ScalarValue::Float(0.)), 0_f32.into());
         assert_eq!(Value::Scalar(ScalarValue::Int(-42)), (-42_i32).into());
         assert_eq!(Value::Scalar(ScalarValue::Uint(0)), 0_u32.into());
+
+        let v = BVec2::new(false, true);
+        let vv: VectorValue = v.into();
+        assert_eq!(vv, VectorValue::new_bvec2(v));
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[0]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        assert_eq!(0, vv.storage[2]);
+        assert_eq!(0, vv.storage[3]);
+
+        let v = BVec3::new(false, true, false);
+        let vv: VectorValue = v.into();
+        assert_eq!(vv, VectorValue::new_bvec3(v));
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[0]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[2]);
+        assert_eq!(0, vv.storage[3]);
+
+        let v = BVec4::new(false, true, false, true);
+        let vv: VectorValue = v.into();
+        assert_eq!(vv, VectorValue::new_bvec4(v));
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[0]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
+        assert_eq!(ScalarValue::BOOL_FALSE_STORAGE, vv.storage[2]);
+        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[3]);
 
         assert_eq!(
             Value::Vector(VectorValue::new_vec2(Vec2::Y)),
@@ -1790,29 +1919,31 @@ mod tests {
             Vec4::W.into()
         );
 
-        let v = BVec2::new(false, true);
-        let vv: VectorValue = v.into();
-        assert_eq!(vv, VectorValue::new_bvec2(v));
-        assert_eq!(0, vv.storage[0]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
-        assert_eq!(0, vv.storage[2]);
-        assert_eq!(0, vv.storage[3]);
+        assert_eq!(
+            Value::Vector(VectorValue::new_ivec2(IVec2::Y)),
+            IVec2::Y.into()
+        );
+        assert_eq!(
+            Value::Vector(VectorValue::new_ivec3(IVec3::Z)),
+            IVec3::Z.into()
+        );
+        assert_eq!(
+            Value::Vector(VectorValue::new_ivec4(IVec4::W)),
+            IVec4::W.into()
+        );
 
-        let v = BVec3::new(false, true, false);
-        let vv: VectorValue = v.into();
-        assert_eq!(vv, VectorValue::new_bvec3(v));
-        assert_eq!(0, vv.storage[0]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
-        assert_eq!(0, vv.storage[2]);
-        assert_eq!(0, vv.storage[3]);
-
-        let v = BVec4::new(false, true, false, true);
-        let vv: VectorValue = v.into();
-        assert_eq!(vv, VectorValue::new_bvec4(v));
-        assert_eq!(0, vv.storage[0]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[1]);
-        assert_eq!(0, vv.storage[2]);
-        assert_eq!(ScalarValue::BOOL_TRUE_STORAGE, vv.storage[3]);
+        assert_eq!(
+            Value::Vector(VectorValue::new_uvec2(UVec2::Y)),
+            UVec2::Y.into()
+        );
+        assert_eq!(
+            Value::Vector(VectorValue::new_uvec3(UVec3::Z)),
+            UVec3::Z.into()
+        );
+        assert_eq!(
+            Value::Vector(VectorValue::new_uvec4(UVec4::W)),
+            UVec4::W.into()
+        );
     }
 
     fn calc_hash<H: Hash>(value: &H) -> u64 {


### PR DESCRIPTION
Add missing `VectorValue::as_uvecX()` cast functions for unsigned integral vectors, and the `impl From<UVecX>`.