### PR TITLE
Fix regression in flipbook

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,7 +960,8 @@ impl EffectShaderSource {
                 render_context.sprite_grid_size
             {
                 layout_flags |= LayoutFlags::FLIPBOOK;
-                let flipbook_row_count_code = grid_size.x.to_wgsl_string();
+                // Note: row_count needs to be i32, not u32, because of sprite_index
+                let flipbook_row_count_code = (grid_size.x as i32).to_wgsl_string();
                 let flipbook_scale_code =
                     Vec2::new(1.0 / grid_size.x as f32, 1.0 / grid_size.y as f32).to_wgsl_string();
                 (flipbook_scale_code, flipbook_row_count_code)


### PR DESCRIPTION
Fix a regression in the flipbook shader code where some variable previously emitted as `i32` by error instead of its actual `u32` type is now producing the correct literal value, resulting in an invalid shader operation between mismatching operand types. Cast the value to `i32` explicitly before emitting the shader code to ensure the value is emitted in the expected type.