### PR TITLE
Improve serialization format of `EffectAsset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merged the `InitModifier` and `UpdateModifier` traits into the `Modifier` subtrait; see other changelog entries for details. This helps manage modifiers in a unified way, and generally simplifies writing and maintain modifiers compatible with both the init and update contexts.
 - `EffectAsset::init()` and `EffectAsset::update()` now take a `Modifier`-bound type, and validate its `ModifierContext` is compatible (and panics if not).
 - `EffectAsset::render()` now panics if the modifier is not compatible with the `ModifierContext::Render`. Note that this indicates a malformed render modifier, because all objects implementing `RenderModifier` must include `ModifierContext::Render` in their `Modifier::context()`.
+- Improved the serialization format to reduce verbosity, by making the following types `#[serde(transparent)]`: `ExprHandle`, `LiteralExpr`, `Module`.
 
 ### Removed
 

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -125,6 +125,7 @@ type Index = NonZeroU32;
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect, Serialize, Deserialize,
 )]
 #[repr(transparent)]
+#[serde(transparent)]
 pub struct ExprHandle {
     index: Index,
 }
@@ -161,6 +162,7 @@ impl ExprHandle {
 /// [`lit()`]: Module::lit
 /// [`attr()`]: Module::attr
 #[derive(Debug, Default, Clone, PartialEq, Hash, Reflect, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Module {
     expressions: Vec<Expr>,
 }
@@ -870,6 +872,7 @@ impl Expr {
 ///
 /// [`is_const()`]: LiteralExpr::is_const
 #[derive(Debug, Clone, Copy, PartialEq, Hash, Reflect, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct LiteralExpr {
     value: Value,
 }


### PR DESCRIPTION
This change makes a few improvements to the serialized representation of an `EffectAsset`:
- `LiteralExpr`, `ExprHandle`, and `Module` are now `#[serde(transparent)]`, which makes them less verbose.
- `VectorValue` is serialized as its glam math type representation, making it a lot more readable in text format (_e.g._ RON).

Before:

```
module: (
    expressions: [
        Literal((
            value: Vector((
                vector_type: (
                    elem_type: Float,
                    count: 3,
                ),
                storage: (1067030938, 3227307213, 1118770935, 0),
            )),
        )),
        Literal((
            value: Vector((
                vector_type: (
                    elem_type: Bool,
                    count: 2,
                ),
                storage: (0, 4294967295, 0, 0),
            )),
        )),
        Binary(
            op: Add,
            left: (
                index: 2,
            ),
            right: (
                index: 1,
            ),
        ),
    ],
),
```

After:

```
module: [
    Literal(Vector(Vec3((1.2, -3.45, 87.54485)))),
    Literal(Vector(BVec2((false, true)))),
    Binary(
        op: Add,
        left: 2,
        right: 1,
    ),
]
```