### PR TITLE
Flush `Commands` in between `prepare_effects` and `queue_effects`.

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -205,7 +205,9 @@ impl Plugin for HanabiPlugin {
                 Render,
                 (
                     prepare_effects.in_set(EffectSystems::PrepareEffectAssets),
-                    queue_effects.in_set(EffectSystems::QueueEffects),
+                    queue_effects
+                        .in_set(EffectSystems::QueueEffects)
+                        .after(prepare_effects),
                     prepare_resources
                         .in_set(EffectSystems::PrepareEffectGpuResources)
                         .after(prepare_view_uniforms),


### PR DESCRIPTION
This was causing nondeterministic failures due to the commands that `prepare_effects` added not running before `queue_effects`. Using the `.after()` method explicitly ensures that they're applied.