### PR TITLE
Implement simple ribbon rendering.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,10 @@ required-features = [ "bevy/bevy_winit", "bevy/bevy_sprite", "2d" ]
 name = "worms"
 required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
+[[example]]
+name = "ribbon"
+required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+
 [workspace]
 resolver = "2"
 members = ["."]

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -1,0 +1,145 @@
+//! Draws a trail and connects the trails using a ribbon.
+
+use bevy::math::vec4;
+use bevy::prelude::*;
+use bevy::{
+    core_pipeline::{bloom::BloomSettings, tonemapping::Tonemapping},
+    math::vec3,
+};
+use bevy_hanabi::prelude::*;
+
+#[cfg(feature = "examples_world_inspector")]
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+
+// These determine the shape of the Spirograph:
+// https://en.wikipedia.org/wiki/Spirograph#Mathematical_basis
+const K: f32 = 0.64;
+const L: f32 = 0.384;
+
+const TIME_SCALE: f32 = 10.0;
+const SHAPE_SCALE: f32 = 25.0;
+const LIFETIME: f32 = 2.5;
+const TRAIL_SPAWN_RATE: f32 = 256.0;
+
+fn main() {
+    let mut app = App::default();
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            title: "🎆 Hanabi — ribbon".to_string(),
+            ..default()
+        }),
+        ..default()
+    }))
+    .add_plugins(HanabiPlugin)
+    .add_systems(Update, bevy::window::close_on_esc)
+    .add_systems(Startup, setup)
+    .add_systems(Update, move_particle_effect);
+
+    #[cfg(feature = "examples_world_inspector")]
+    app.add_plugins(WorldInspectorPlugin::default());
+
+    app.run();
+}
+
+fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0., 0., 50.)),
+            camera: Camera {
+                hdr: true,
+                clear_color: Color::BLACK.into(),
+                ..default()
+            },
+            tonemapping: Tonemapping::None,
+            ..default()
+        },
+        BloomSettings::default(),
+    ));
+
+    let writer = ExprWriter::new();
+
+    let init_position_attr = SetAttributeModifier {
+        attribute: Attribute::POSITION,
+        value: writer.lit(Vec3::ZERO).expr(),
+    };
+
+    let init_velocity_attr = SetAttributeModifier {
+        attribute: Attribute::VELOCITY,
+        value: writer.lit(Vec3::ZERO).expr(),
+    };
+
+    let init_age_attr = SetAttributeModifier {
+        attribute: Attribute::AGE,
+        value: writer.lit(0.0).expr(),
+    };
+
+    let init_lifetime_attr = SetAttributeModifier {
+        attribute: Attribute::LIFETIME,
+        value: writer.lit(999999.0).expr(),
+    };
+
+    let init_size_attr = SetAttributeModifier {
+        attribute: Attribute::SIZE,
+        value: writer.lit(0.5).expr(),
+    };
+
+    let clone_modifier = CloneModifier::new(1.0 / TRAIL_SPAWN_RATE, 1);
+
+    let time = writer.time().mul(writer.lit(TIME_SCALE));
+
+    let move_modifier = SetAttributeModifier {
+        attribute: Attribute::POSITION,
+        value: (WriterExpr::vec3(
+            writer.lit(1.0 - K).mul(time.clone().cos())
+                + writer.lit(L * K) * (writer.lit((1.0 - K) / K) * time.clone()).cos(),
+            writer.lit(1.0 - K).mul(time.clone().sin())
+                - writer.lit(L * K) * (writer.lit((1.0 - K) / K) * time.clone()).sin(),
+            writer.lit(0.0),
+        ) * writer.lit(SHAPE_SCALE))
+        .expr(),
+    };
+
+    let update_lifetime_attr = SetAttributeModifier {
+        attribute: Attribute::LIFETIME,
+        value: writer.lit(LIFETIME).expr(),
+    };
+
+    let render_color = ColorOverLifetimeModifier {
+        gradient: Gradient::linear(vec4(3.0, 0.0, 0.0, 1.0), vec4(3.0, 0.0, 0.0, 0.0)),
+    };
+
+    let effect = EffectAsset::new(
+        vec![256, 32768],
+        Spawner::once(1.0.into(), true),
+        writer.finish(),
+    )
+    .with_name("ribbon")
+    .with_simulation_space(SimulationSpace::Global)
+    .init(init_position_attr)
+    .init(init_velocity_attr)
+    .init(init_age_attr)
+    .init(init_lifetime_attr)
+    .init(init_size_attr)
+    .update_groups(move_modifier, ParticleGroupSet::single(0))
+    .update_groups(clone_modifier, ParticleGroupSet::single(0))
+    .update_groups(update_lifetime_attr, ParticleGroupSet::single(1))
+    .render(RibbonModifier)
+    .render_groups(render_color, ParticleGroupSet::single(1));
+
+    let effect = effects.add(effect);
+
+    commands
+        .spawn(ParticleEffectBundle {
+            effect: ParticleEffect::new(effect),
+            transform: Transform::IDENTITY,
+            ..default()
+        })
+        .insert(Name::new("ribbon"));
+}
+
+fn move_particle_effect(mut query: Query<&mut Transform, With<ParticleEffect>>, timer: Res<Time>) {
+    let theta = timer.elapsed_seconds() * 1.0;
+    for mut transform in query.iter_mut() {
+        transform.translation = vec3(f32::cos(theta), f32::sin(theta), 0.0) * 5.0;
+    }
+}

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -97,6 +97,7 @@ fn setup(
 
     // Update modifiers
 
+    // Clone the particle every so often. This creates the trail.
     let clone_modifier = CloneModifier::new(1.0 / 8.0, 1);
 
     // Make the particle wiggle, following a sine wave.

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -14,6 +14,7 @@ cargo r --example force_field --no-default-features --features="bevy/bevy_winit 
 cargo r --example init --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
 cargo r --example lifetime --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
 cargo r --example instancing --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
+cargo r --example ribbon --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
 REM 3D + PNG
 cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d examples_world_inspector"
 cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d examples_world_inspector"

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -13,6 +13,7 @@ cargo r --example force_field --no-default-features --features="bevy/bevy_winit 
 cargo r --example init --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
 cargo r --example lifetime --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
 cargo r --example instancing --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
+cargo r --example ribbon --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d examples_world_inspector"
 # 3D + PNG
 cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d examples_world_inspector"
 cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d examples_world_inspector"

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -536,6 +536,16 @@ impl AttributeInner {
         Value::Vector(VectorValue::new_vec2(Vec2::ONE)),
     );
 
+    pub const PREV: &'static AttributeInner = &AttributeInner::new(
+        Cow::Borrowed("prev"),
+        Value::Scalar(ScalarValue::Uint(!0u32)),
+    );
+
+    pub const NEXT: &'static AttributeInner = &AttributeInner::new(
+        Cow::Borrowed("next"),
+        Value::Scalar(ScalarValue::Uint(!0u32)),
+    );
+
     pub const AXIS_X: &'static AttributeInner = &AttributeInner::new(
         Cow::Borrowed("axis_x"),
         Value::Vector(VectorValue::new_vec3(Vec3::X)),
@@ -949,6 +959,30 @@ impl Attribute {
     /// [`VectorType::VEC2F`] representing the XY sizes of the particle.
     pub const SIZE2: Attribute = Attribute(AttributeInner::SIZE2);
 
+    /// The previous particle in the ribbon chain.
+    ///
+    /// # Name
+    ///
+    /// `prev`
+    ///
+    /// # Type
+    ///
+    /// [`ScalarType::Uint`] representing the index of the previous particle in
+    /// the chain.
+    pub const PREV: Attribute = Attribute(AttributeInner::PREV);
+
+    /// The next particle in the ribbon chain.
+    ///
+    /// # Name
+    ///
+    /// `next`
+    ///
+    /// # Type
+    ///
+    /// [`ScalarType::Uint`] representing the index of the next particle in the
+    /// chain.
+    pub const NEXT: Attribute = Attribute(AttributeInner::NEXT);
+
     /// The local X axis of the particle.
     ///
     /// This attribute stores a per-particle X axis, which defines the
@@ -1096,7 +1130,7 @@ impl Attribute {
     declare_custom_attr_pub!(F32X4_3, "f32x4_3", 4, VEC4F);
 
     /// Collection of all the existing particle attributes.
-    const ALL: [Attribute; 29] = [
+    const ALL: [Attribute; 31] = [
         Attribute::POSITION,
         Attribute::VELOCITY,
         Attribute::AGE,
@@ -1106,6 +1140,8 @@ impl Attribute {
         Attribute::ALPHA,
         Attribute::SIZE,
         Attribute::SIZE2,
+        Attribute::PREV,
+        Attribute::NEXT,
         Attribute::AXIS_X,
         Attribute::AXIS_Y,
         Attribute::AXIS_Z,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -834,6 +834,18 @@ impl EffectShaderSource {
                     return Err(ShaderGenerateError::Expr(err));
                 }
             }
+
+            // If there are linked list attributes, clear them out.
+            // Not doing this is always a bug, so we might as well save the user
+            // some trouble.
+            for attribute in [Attribute::PREV, Attribute::NEXT] {
+                if particle_layout.contains(attribute) {
+                    init_context
+                        .main_code
+                        .push_str(&format!("particle.{} = 0xffffffffu;", attribute.name()));
+                }
+            }
+
             let sim_space_transform_code = match asset.simulation_space.eval(&init_context) {
                 Ok(s) => s,
                 Err(err) => {

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -45,6 +45,7 @@ pub mod force;
 pub mod kill;
 pub mod output;
 pub mod position;
+pub mod ribbon;
 pub mod velocity;
 
 pub use accel::*;
@@ -54,6 +55,7 @@ pub use force::*;
 pub use kill::*;
 pub use output::*;
 pub use position::*;
+pub use ribbon::*;
 pub use velocity::*;
 
 use crate::{

--- a/src/modifier/ribbon.rs
+++ b/src/modifier/ribbon.rs
@@ -1,0 +1,50 @@
+//! Renders particles as ribbons.
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    impl_mod_render, Attribute, EvalContext, ExprError, Modifier, ModifierContext, Module,
+    RenderContext, RenderModifier, ShaderWriter,
+};
+
+/// Renders particles as ribbons, drawing a quad in between each particle
+/// instead of at each particle.
+///
+/// Internally, this threads particles into a linked list, using the
+/// [`Attribute::PREV`] and [`Attribute::NEXT`] fields.
+#[derive(Debug, Clone, Copy, Reflect, Serialize, Deserialize)]
+pub struct RibbonModifier;
+
+impl_mod_render!(RibbonModifier, &[Attribute::PREV, Attribute::NEXT]);
+
+#[typetag::serde]
+impl RenderModifier for RibbonModifier {
+    fn apply_render(&self, _: &mut Module, context: &mut RenderContext) {
+        context.vertex_code += r##"
+    let next_index = particle.next;
+    if (next_index >= arrayLength(&particle_buffer.particles)) {
+        out.position = vec4(0.0);
+        return out;
+    }
+
+    let next_particle = particle_buffer.particles[next_index];
+    var delta = next_particle.position - particle.position;
+
+    axis_x = normalize(delta);
+    axis_y = normalize(cross(axis_x, axis_z));
+    axis_z = cross(axis_x, axis_y);
+
+    position = mix(next_particle.position, particle.position, 0.5);
+    size = vec2(length(delta), size.y);
+"##;
+    }
+
+    fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
+        Box::new(*self)
+    }
+
+    fn as_modifier(&self) -> &dyn Modifier {
+        self
+    }
+}

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -138,9 +138,7 @@ fn vertex(
     // Expand particle mesh vertex based on particle position ("origin"), and local
     // orientation and size of the particle mesh (currently: only quad).
     let vpos = vertex_position * vec3<f32>(size.x, size.y, 1.0);
-    let sim_position = particle.position
-        + axis_x * vpos.x
-        + axis_y * vpos.y;
+    let sim_position = position + axis_x * vpos.x + axis_y * vpos.y;
     out.position = transform_position_simulation_to_clip(sim_position);
 
     out.color = color;


### PR DESCRIPTION
This adds a new render modifier, the `RibbonModifier`. When it's present, quads are drawn between particles that are part of a trail created with the `CloneModifier`, instead of directly at the particle locations.

Internally, particles are threaded into a doubly linked list, with the `PREV` and `NEXT` attributes. I chose a linked list over fixed-size trails like the Unity VFX graph uses because (a) during ribbon rendering, a particle only needs to know the positions of its immediate neighbors; (b) linked lists better support variable-length trails. We need a doubly linked list instead of a singly linked list because (a) more sophisticated ribbon rendering will want to know about both the next and previous particles in order to implement line joins properly; (b) a singly linked list has difficulty dealing with dangling pointers to dead particles.

Each ribbon quad is initially oriented toward the average normal (`nlerp`) of the two particles that define it, modulo Gram-Schmidt normalization. Eventually, ribbon quads should be extended to support meshes with line joins, as well as perhaps curves, but the current approach should do for an initial implementation.

A new example, `ribbons`, has been added.

A screenshot *without* ribbons enabled:

<img width="962" alt="Screenshot 2024-03-11 024353" src="https://github.com/djeedai/bevy_hanabi/assets/157897/66a25655-72ac-4f99-8649-5564fd969da5">

And *with* ribbons enabled:

<img width="963" alt="Screenshot 2024-03-11 024412" src="https://github.com/djeedai/bevy_hanabi/assets/157897/4cc231bf-2a31-456c-bb37-75318c2d9173">

This is just a draft to get initial thoughts.

