### PR TITLE
Move properties into `Module`

### DIFF
--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -306,9 +306,12 @@ fn setup(
 
     // Sphere repulsor pushing particles away. The acceleration is negative to
     // repulse partices.
-    let repulsor_accel = writer.prop("repulsor_accel");
+    let repulsor_accel = writer.add_property("repulsor_accel", Value::Scalar((-15.0).into()));
+    let repulsor_position =
+        writer.add_property("repulsor_position", Value::Vector(REPULSOR_POS.into()));
+    let repulsor_accel = writer.prop(repulsor_accel);
     let update_repulsor = ConformToSphereModifier {
-        origin: writer.prop("repulsor_position").expr(),
+        origin: writer.prop(repulsor_position).expr(),
         radius: writer.lit(BALL_RADIUS).expr(),
         influence_dist: writer.lit(BALL_RADIUS * 10.).expr(),
         attraction_accel: repulsor_accel.expr(),
@@ -319,26 +322,26 @@ fn setup(
 
     // Sphere attractor with conforming. The particles are attracted to the sphere
     // surface, and tend to "stick" onto it.
+    let attraction_accel = writer.add_property("attraction_accel", Value::Scalar(20.0.into()));
+    let max_attraction_speed =
+        writer.add_property("max_attraction_speed", Value::Scalar(5.0.into()));
+    let sticky_factor = writer.add_property("sticky_factor", Value::Scalar(2.0.into()));
+    let shell_half_thickness =
+        writer.add_property("shell_half_thickness", Value::Scalar(0.1.into()));
     let update_attractor = ConformToSphereModifier {
         origin: writer.lit(ATTRACTOR_POS).expr(),
         radius: writer.lit(BALL_RADIUS * 6.).expr(),
         influence_dist: writer.lit(BALL_RADIUS * 100.).expr(),
-        attraction_accel: writer.prop("attraction_accel").expr(),
-        max_attraction_speed: writer.prop("max_attraction_speed").expr(),
-        sticky_factor: Some(writer.prop("sticky_factor").expr()),
-        shell_half_thickness: Some(writer.prop("shell_half_thickness").expr()),
+        attraction_accel: writer.prop(attraction_accel).expr(),
+        max_attraction_speed: writer.prop(max_attraction_speed).expr(),
+        sticky_factor: Some(writer.prop(sticky_factor).expr()),
+        shell_half_thickness: Some(writer.prop(shell_half_thickness).expr()),
     };
 
     // Force field effects
     let effect = effects.add(
         EffectAsset::new(vec![32768], spawner, writer.finish())
             .with_name("force_field")
-            .with_property("repulsor_position", Value::Vector(REPULSOR_POS.into()))
-            .with_property("attraction_accel", Value::Scalar(20.0.into()))
-            .with_property("max_attraction_speed", Value::Scalar(5.0.into()))
-            .with_property("sticky_factor", Value::Scalar(2.0.into()))
-            .with_property("shell_half_thickness", Value::Scalar(0.1.into()))
-            .with_property("repulsor_accel", Value::Scalar((-15.0).into()))
             .init(init_pos)
             .init(init_vel)
             .init(init_age)

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -137,7 +137,6 @@ fn setup(
     let effect1 = effects.add(
         EffectAsset::new(vec![32768], Spawner::rate(500.0.into()), writer1.finish())
             .with_name("emit:rate")
-            .with_property("my_accel", Vec3::new(0., -3., 0.).into())
             .init(init_pos1)
             // Make spawned particles move away from the emitter origin
             .init(init_vel1)
@@ -254,7 +253,8 @@ fn setup(
     let init_size3 = SetAttributeModifier::new(Attribute::SIZE, size3);
 
     // Add property-driven acceleration
-    let accel3 = writer3.prop("my_accel").expr();
+    let my_accel = writer3.add_property("my_accel", Vec3::new(0., -3., 0.).into());
+    let accel3 = writer3.prop(my_accel).expr();
     let update_accel3 = AccelModifier::new(accel3);
 
     let init_pos3 = SetPositionSphereModifier {
@@ -275,7 +275,6 @@ fn setup(
             writer3.finish(),
         )
         .with_name("emit:burst")
-        .with_property("my_accel", Vec3::new(0., -3., 0.).into())
         .init(init_pos3)
         .init(init_vel3)
         .init(init_age3)

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -138,10 +138,12 @@ fn setup(
     // when the particle spawns. The particle will keep that color afterward,
     // even if the property changes, because the color will be saved
     // per-particle (due to the Attribute::COLOR).
-    let color = writer.prop("spawn_color").expr();
+    let spawn_color = writer.add_property("spawn_color", 0xFFFFFFFFu32.into());
+    let color = writer.prop(spawn_color).expr();
     let init_color = SetAttributeModifier::new(Attribute::COLOR, color);
 
-    let normal = writer.prop("normal");
+    let normal = writer.add_property("normal", Vec3::ZERO.into());
+    let normal = writer.prop(normal);
 
     // Set the position to be the collision point, which in this example is always
     // the emitter position (0,0,0) at the ball center, minus the ball radius
@@ -170,8 +172,6 @@ fn setup(
     let effect = effects.add(
         EffectAsset::new(vec![32768], spawner, writer.finish())
             .with_name("spawn_on_command")
-            .with_property("spawn_color", 0xFFFFFFFFu32.into())
-            .with_property("normal", Vec3::ZERO.into())
             .init(init_pos)
             .init(init_vel)
             .init(init_age)

--- a/src/modifier/accel.rs
+++ b/src/modifier/accel.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     calc_func_id,
+    expr::PropertyHandle,
     graph::{BuiltInExpr, EvalContext, ExprError},
     Attribute, BoxedModifier, ExprHandle, Modifier, ModifierContext, Module, ShaderWriter,
 };
@@ -46,9 +47,11 @@ impl AccelModifier {
     }
 
     /// Create a new modifier with an acceleration derived from a property.
-    pub fn via_property(module: &mut Module, property_name: impl Into<String>) -> Self {
+    ///
+    /// To create a new property, use [`Module::add_property()`].
+    pub fn via_property(module: &mut Module, property: PropertyHandle) -> Self {
         Self {
-            accel: module.prop(property_name),
+            accel: module.prop(property),
         }
     }
 
@@ -126,14 +129,12 @@ impl RadialAccelModifier {
     /// Create a new modifier with an acceleration derived from a property.
     ///
     /// The origin of the sphere defining the radial direction is constant.
-    pub fn via_property(
-        module: &mut Module,
-        origin: Vec3,
-        property_name: impl Into<String>,
-    ) -> Self {
+    ///
+    /// To create a new property, use [`Module::add_property()`].
+    pub fn via_property(module: &mut Module, origin: Vec3, property: PropertyHandle) -> Self {
         Self {
             origin: module.lit(origin),
-            accel: module.prop(property_name),
+            accel: module.prop(property),
         }
     }
 
@@ -241,16 +242,18 @@ impl TangentAccelModifier {
     /// Create a new modifier with an acceleration derived from a property.
     ///
     /// The origin and axis are constant.
+    ///
+    /// To create a new property, use [`Module::add_property()`].
     pub fn via_property(
         module: &mut Module,
         origin: Vec3,
         axis: Vec3,
-        property_name: impl Into<String>,
+        property: PropertyHandle,
     ) -> Self {
         Self {
             origin: module.lit(origin),
             axis: module.lit(axis),
-            accel: module.prop(property_name),
+            accel: module.prop(property),
         }
     }
 
@@ -344,7 +347,8 @@ mod tests {
         assert!(context.extra_code.contains(&accel.to_wgsl_string()));
 
         let origin = module.attr(Attribute::POSITION);
-        let accel = module.prop("my_prop");
+        let my_prop = module.add_property("my_prop", 3.0.into());
+        let accel = module.prop(my_prop);
         let modifier = RadialAccelModifier::new(origin, accel);
         let mut context =
             ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);

--- a/src/modifier/attr.rs
+++ b/src/modifier/attr.rs
@@ -37,8 +37,10 @@ use crate::{
 /// let init_pos = SetAttributeModifier::new(Attribute::POSITION, pos);
 ///
 /// // Each frame, assign the value of the "my_velocity" property to the velocity
-/// // of the particle.
-/// let vel = module.prop("my_velocity");
+/// // of the particle. The property is assigned from CPU, and uploaded to GPU
+/// // automatically when its value changed.
+/// let my_velocity = module.add_property("my_velocity", Vec3::ZERO.into());
+/// let vel = module.prop(my_velocity);
 /// let update_vel = SetAttributeModifier::new(Attribute::VELOCITY, vel);
 /// ```
 ///


### PR DESCRIPTION
Move the declaration of properties from `EffectAsset` into `Module`. Properties are only used in the context of expressions owned by a `Module`, so it makes more sense for them to be owned by the `Module` itself. This also forces them to be declared upfront with a type, which enables adding type checking during expression building (not in this change) instead of generating invalid shader code and only observing issues when actually spawning an effect.