### PR TITLE
Remove `ParticleEffect::spawner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the various helper macros `impl_mod_xxx!()` to implement modifier traits; simply implement the trait by hand instead.
 - Removed `EffectAsset::with_property()` and `EffectAsset::add_property()`; use `Module::add_property()` instead.
 - `PropertyExpr` doesn't implement anymore `ToWgslString` nor `From<String>`. To create a `PropertyExpr`, you need a valid `PropertyHandle`, which would have been created via `Module::add_property()` with a default value enforcing a type. This ensures property expressions are well-formed on creation, and cannot reference non-existent properties.
+- Removed `ParticleEffect::spawner`, which was used as a per-instance override of `EffectAsset::spawner`. Manual spawn an `EffectSpawner` component with overridden values to achieve the same feature.
 
 ### Fixed
 

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -152,7 +152,7 @@ fn setup(
     );
 
     ball.with_children(|node| {
-        node.spawn(ParticleEffectBundle::new(effect).with_spawner(spawner))
+        node.spawn(ParticleEffectBundle::new(effect))
             .insert(Name::new("effect"));
     });
 }

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -358,7 +358,7 @@ fn setup(
     );
 
     commands.spawn((
-        ParticleEffectBundle::new(effect).with_spawner(spawner),
+        ParticleEffectBundle::new(effect),
         // Note: regression as of 0.10, we need to explicitly add this component with the correct
         // properties.
         EffectProperties::default().with_properties([

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -187,7 +187,7 @@ fn setup(
 
     commands
         .spawn((
-            ParticleEffectBundle::new(effect).with_spawner(spawner),
+            ParticleEffectBundle::new(effect),
             EffectProperties::default(),
         ))
         .insert(Name::new("effect"));

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,4 +1,4 @@
-use crate::{CompiledParticleEffect, EffectAsset, ParticleEffect, Spawner};
+use crate::{CompiledParticleEffect, EffectAsset, ParticleEffect};
 use bevy::prelude::*;
 
 /// A component bundle for a particle effect.
@@ -94,19 +94,6 @@ impl ParticleEffectBundle {
             view_visibility: ViewVisibility::default(),
         }
     }
-
-    /// Override the particle spawner of this instance.
-    ///
-    /// By default the [`ParticleEffect`] instance will inherit the [`Spawner`]
-    /// configuration of the [`EffectAsset`]. With this method, you can override
-    /// that configuration for the current effect instance alone.
-    ///
-    /// This method is a convenience helper, and is equivalent to assigning the
-    /// [`ParticleEffect::spawner`] field.
-    pub fn with_spawner(mut self, spawner: Spawner) -> Self {
-        self.effect.spawner = Some(spawner);
-        self
-    }
 }
 
 #[cfg(test)]
@@ -125,13 +112,5 @@ mod tests {
         let handle = Handle::default();
         let bundle = ParticleEffectBundle::new(handle.clone());
         assert_eq!(bundle.effect.handle, handle);
-    }
-
-    #[test]
-    fn bundle_with_spawner() {
-        let spawner = Spawner::once(5.0.into(), true);
-        let bundle = ParticleEffectBundle::default().with_spawner(spawner);
-        assert!(bundle.effect.spawner.is_some());
-        assert_eq!(bundle.effect.spawner.unwrap(), spawner);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@
 //!   .render(ColorOverLifetimeModifier { gradient });
 //!
 //!   // Insert into the asset system
-//!   let effect_handle = effects.add(effect);
+//!   let effect_asset = effects.add(effect);
 //! }
 //! ```
 //!
@@ -131,20 +131,14 @@
 //! # use bevy::prelude::*;
 //! # use bevy_hanabi::prelude::*;
 //! # fn spawn_effect(mut commands: Commands) {
-//! #   let effect_handle = Handle::<EffectAsset>::default();
-//! // Configure the emitter to spawn 100 particles / second
-//! let spawner = Spawner::rate(100_f32.into());
-//!
-//! commands
-//!     .spawn((
-//!         Name::new("MyEffectInstance"),
-//!         ParticleEffectBundle {
-//!             effect: ParticleEffect::new(effect_handle)
-//!                 .with_spawner(spawner),
-//!             transform: Transform::from_translation(Vec3::Y),
-//!             ..Default::default()
-//!         },
-//!     ));
+//! #   let effect_asset = Handle::<EffectAsset>::default();
+//! commands.spawn(
+//!     ParticleEffectBundle {
+//!         effect: ParticleEffect::new(effect_asset),
+//!         transform: Transform::from_translation(Vec3::Y),
+//!         ..Default::default()
+//!     },
+//! );
 //! # }
 //! ```
 //!
@@ -625,22 +619,18 @@ pub struct ParticleEffect {
     /// Handle of the effect to instantiate.
     pub handle: Handle<EffectAsset>,
     /// For 2D rendering, override the value of the Z coordinate of the layer at
-    /// which the particles are rendered present in the effect asset.
+    /// which the particles are rendered.
     ///
     /// This value is passed to the render pipeline and used when sorting
     /// transparent items to render, to order them. As a result, effects
     /// with different Z values cannot be batched together, which may
     /// negatively affect performance.
     ///
+    /// Note that this value is shared by all particles of the effect instance.
+    ///
     /// This is only available with the `2d` feature.
     #[cfg(feature = "2d")]
     pub z_layer_2d: Option<f32>,
-    /// Optional particle spawner override for this instance.
-    ///
-    /// If set, this overrides the spawner configured in the [`EffectAsset`].
-    /// Otherwise the spawner from the effect asset will be copied here when the
-    /// component is first processed.
-    pub spawner: Option<Spawner>,
 }
 
 impl ParticleEffect {
@@ -650,7 +640,6 @@ impl ParticleEffect {
             handle,
             #[cfg(feature = "2d")]
             z_layer_2d: None,
-            spawner: None,
         }
     }
 
@@ -677,16 +666,6 @@ impl ParticleEffect {
     #[cfg(feature = "2d")]
     pub fn with_z_layer_2d(mut self, z_layer_2d: Option<f32>) -> Self {
         self.z_layer_2d = z_layer_2d;
-        self
-    }
-
-    /// Set the spawner of this particle effect instance.
-    ///
-    /// By default particle effect instances inherit the spawner of the
-    /// [`EffectAsset`] they're derived from. This allows overriding the spawner
-    /// configuration per instance.
-    pub fn with_spawner(mut self, spawner: Spawner) -> Self {
-        self.spawner = Some(spawner);
         self
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1274,6 +1274,7 @@ pub(crate) struct ExtractedEffect {
     /// [`property_layout`]: crate::render::ExtractedEffect::property_layout
     pub property_data: Option<Vec<u8>>,
     /// Number of particles to spawn this frame for the effect.
+    ///
     /// Obtained from calling [`EffectSpawner::tick()`] on the source effect
     /// instance.
     ///
@@ -1475,9 +1476,6 @@ pub(crate) fn extract_effects(
             continue;
         }
 
-        // Retrieve other values from the compiled effect
-        let spawn_count = spawner.spawn_count();
-
         // Check if asset is available, otherwise silently ignore
         let Some(asset) = effects.get(&effect.asset) else {
             trace!(
@@ -1530,7 +1528,7 @@ pub(crate) fn extract_effects(
                 particle_layout: asset.particle_layout().clone(),
                 property_layout,
                 property_data,
-                spawn_count,
+                spawn_count: spawner.spawn_count,
                 transform: transform.compute_matrix(),
                 // TODO - more efficient/correct way than inverse()?
                 inverse_transform: transform.compute_matrix().inverse(),

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -424,7 +424,7 @@ pub struct EffectSpawner {
 impl EffectSpawner {
     /// Create a new spawner state from an asset definition.
     pub fn new(asset: &EffectAsset) -> Self {
-        let spawner = asset.spawner.clone();
+        let spawner = asset.spawner;
         Self {
             spawner,
             time: if spawner.is_once() && !spawner.starts_immediately {


### PR DESCRIPTION
Remove the override field `ParticleEffect::spawner`, and instead directly use the `EffectSpawner` component to override the spawner value(s) compared to the source `EffectAsset`. The extra indirection was a remanent of the time `EffectSpawner` didn't exist, but it makes little sense currently, and only complexifies things.