### PR TITLE
Write to depth buffer in alpha mask mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following modifiers' `via_property()` function now takes a `PropertyHandle` instead of a property name: `AccelModifier`, `RadialAccelModifier`, `TangentAccelModifier`.
 - `Expr` is now `Copy`, making it even more lightweight.
 - `ExprWriter::prop()` now panics if the property doesn't exist. This ensures the created `WriterExpr` is well-formed, which was impossible to validate at expression write time previously.
+- Effects rendered with `AlphaMode::Mask` now write to the depth buffer. Other effects continue to not write to it. This fixes particle flickering for alpha masked effects only.
 
 ### Removed
 
@@ -54,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a panic in rendering randomly occurring when no effect is present.
 - Fixed invalid WGSL being generated for large `u32` values.
+- Fixed particle flickering, only for particles rendered through the `AlphaMask3d` render pass (`EffectAsset::alpha_mode == AlphaMode::Mask`). (#183)
 
 ## [0.10.0] 2024-02-24
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1184,7 +1184,8 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
             PipelineMode::Camera2d => None,
             PipelineMode::Camera3d => Some(DepthStencilState {
                 format: TextureFormat::Depth32Float,
-                depth_write_enabled: false,
+                // Use depth buffer with alpha-masked particles, not with transparent ones
+                depth_write_enabled: key.use_alpha_mask,
                 // Bevy uses reverse-Z, so Greater really means closer
                 depth_compare: CompareFunction::Greater,
                 stencil: StencilState::default(),
@@ -1198,7 +1199,8 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         #[cfg(all(feature = "3d", not(feature = "2d")))]
         let depth_stencil = Some(DepthStencilState {
             format: TextureFormat::Depth32Float,
-            depth_write_enabled: false,
+            // Use depth buffer with alpha-masked particles, not with transparent ones
+            depth_write_enabled: key.use_alpha_mask,
             // Bevy uses reverse-Z, so Greater really means closer
             depth_compare: CompareFunction::Greater,
             stencil: StencilState::default(),


### PR DESCRIPTION
When rendering particles in alpha mask mode, there's no transparency involved; each fragment is either fully opaque or fully transparent. Therefore we can use the depth buffer, and don't need some fancy order independent transparency rendering or distance based sorting (which are not implemented).

This change enables depth writing when rendering particles through the `AlphaMask3d` render pass. This prevents particles from flickering, as visible in the `billboard.rs` example.

Partially fixes #183 (for non-transparent effects)