### PR TITLE
Use strong handle in `CompiledParticleEffect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Expr` is now `Copy`, making it even more lightweight.
 - `ExprWriter::prop()` now panics if the property doesn't exist. This ensures the created `WriterExpr` is well-formed, which was impossible to validate at expression write time previously.
 - Effects rendered with `AlphaMode::Mask` now write to the depth buffer. Other effects continue to not write to it. This fixes particle flickering for alpha masked effects only.
+- `CompiledParticleEffect` now holds a strong handle to the same `EffectAsset` as the `ParticleEffect` it's compiled from. This ensures the asset is not unloaded while in use during the frame. To allow an `EffectAsset` to unload, clear the handle of the `ParticleEffect`, then allow the `CompiledParticleEffect` to observe the change and clear its own handle too.
 
 ### Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1909,7 +1909,7 @@ else { return c1; }
 
             // `compile_effects()` always updates the CompiledParticleEffect
             assert_eq!(compiled_particle_effect.asset, handle);
-            assert!(compiled_particle_effect.asset.is_weak());
+            assert!(compiled_particle_effect.asset.is_strong());
             assert!(compiled_particle_effect.effect_shader.is_some());
         }
 
@@ -1944,7 +1944,7 @@ else { return c1; }
 
             // `compile_effects()` always updates the CompiledParticleEffect
             assert_eq!(compiled_particle_effect.asset, handle);
-            assert!(compiled_particle_effect.asset.is_weak());
+            assert!(compiled_particle_effect.asset.is_strong());
             assert!(compiled_particle_effect.effect_shader.is_some());
         }
     }
@@ -2047,7 +2047,7 @@ else { return c1; }
                 // `compile_effects()` always updates the CompiledParticleEffect of new effects,
                 // even if hidden
                 assert_eq!(compiled_particle_effect.asset, handle);
-                assert!(compiled_particle_effect.asset.is_weak());
+                assert!(compiled_particle_effect.asset.is_strong());
                 assert!(compiled_particle_effect.effect_shader.is_some());
 
                 // Toggle visibility and tick once more; this shouldn't panic (regression; #182)
@@ -2075,7 +2075,7 @@ else { return c1; }
 
                 // `compile_effects()` always updates the CompiledParticleEffect
                 assert_eq!(compiled_particle_effect.asset, handle);
-                assert!(compiled_particle_effect.asset.is_weak());
+                assert!(compiled_particle_effect.asset.is_strong());
                 assert!(compiled_particle_effect.effect_shader.is_some());
             }
         }


### PR DESCRIPTION
This fixes a panic in the extract code, where the `EffectAsset` was unloaded after the particle effect was compiled but before the extraction finished. The idea of using a weak handle was to avoid preventing the asset from unloading, but because
`CompiledParticleEffect` will anyway observe any change on the source `ParticleEffect` and its handle, clearing that handle will make `CompiledParticleEffect` also clear its own handle, even if strong, which will result in the asset being "freed" from references held by Hanabi.

Fixes #289