### PR TITLE
Cache bind group across frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Module::add_property()`, `Module::get_property()`, and `Module::properties()`.
 - Added a new `PropertyHandle`, which is to `Property` what the existing `ExprHandle` is to `Expr`: a unique handle into a owning `Module`.
 - Added a new `RoundModifier` that allows round particles to be constructed without having to create a texture.
+- Added a new `trace` feature enabling some `span_info!()` profiling annotations.
 
 ### Changed
 
@@ -38,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Expr` is now `Copy`, making it even more lightweight.
 - `ExprWriter::prop()` now panics if the property doesn't exist. This ensures the created `WriterExpr` is well-formed, which was impossible to validate at expression write time previously.
 - Effects rendered with `AlphaMode::Mask` now write to the depth buffer. Other effects continue to not write to it. This fixes particle flickering for alpha masked effects only.
+git
+- Bind groups for effect rendering are now created in a separate system in the `EffectSystems::PrepareBindGroups` set, itself part of Bevy's `RenderSet::PrepareBindGroups`. They're also cached, which increases the performance of rendering many effects.
+- Merged the init and update pass bind groups for the particle buffer and associated resources in `EffectBfufer`. The new unified resources use the `_sim` (simulation) suffix.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ default = ["2d", "3d", "gpu_tests", "examples_world_inspector"]
 # Enable support for rendering through a 3D camera (Camera3dBundle)
 3d = []
 
+# Enable tracing annotations
+trace = []
+
 # Special feature to enable GPU-based tests, which otherwise fail
 # on a CI machine without a graphic adapter or without proper drivers.
 # This is a testing-only feature, which has no effect on the build.
@@ -37,6 +40,7 @@ examples_world_inspector = []
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }
+fixedbitset = "0.4"
 copyless = "0.1"
 rand = "0.8"
 rand_pcg = "0.3"

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -435,11 +435,11 @@ impl EffectBuffer {
     /// The `buffer_index` must be the index of the current [`EffectBuffer`]
     /// inside the [`EffectCache`]. The `group_binding` is the binding resource
     /// for the particle groups of this buffer.
-    pub fn create_sim_bind_group<'a>(
+    pub fn create_sim_bind_group(
         &mut self,
         buffer_index: u32,
         render_device: &RenderDevice,
-        group_binding: BufferBinding<'a>,
+        group_binding: BufferBinding,
     ) {
         if self.simulate_bind_group.is_some() {
             return;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2939,7 +2939,7 @@ pub(crate) fn prepare_bind_groups(
         // TODO - move this creation in RenderSet::PrepareBindGroups
         effect_buffer.create_sim_bind_group(
             effect_batches.buffer_index,
-            &*render_device,
+            &render_device,
             group_binding,
         );
 


### PR DESCRIPTION
Increase the rendering performance by caching most bind groups across frames, and only regenerate them when any of the underlying buffers was re-allocated. Profiling with Tracy shows about 1ms saved on the `2d` example modified as per #272 (10'000 entities, 100 particle effects).

- The visibility check of entities now uses a `FixedBitSet`. There's no notable performance difference in itself in the above test, but using a bitfield saves some memory. The actual saving comes from using a `Local` parameter, which caches the bitset across system runs and prevent allocation/free each frame.
- Move `EffectCache` as a standalone resource on the render world. This is mostly for convenience to prevent issues with the borrow checked, as the `EffectsMeta` contains too many things.
- In `EffectBuffer`, merge the init and update layouts and bind groups for the particle buffer and associated buffers. They were duplicated for no good reason, as the bound resources are the same. Also cache the bind groups inside the `EffectBuffer` itself instead of using a separate `HashMap`.
- Move the creation of bind groups into a new `prepare_bind_groups()` system running in the `EffectSystems::PrepareBindGroups` set, itself part of the `RenderSet::PrepareBindGroups`. This aligns Hanabi to the standard Bevy rendering architecture, ensuring that bind groups are created last after any buffer might have been re-allocated.

This change adds a new `trace` feature adding `info_span!()` trace annotations when active. This allows profiling Hanabi, for example with one of the various methods described in the Bevy documentation. To profile with Tracy for example, run _e.g._:

```sh
cargo r --example 2d --no-default-features --release
--features="bevy/bevy_winit bevy/bevy_sprite 2d trace bevy/trace_tracy"
```

Note that this requires changing the default log level to Info, otherwise the trace annotations are not emitted. This is the same for Bevy and Wpgu.

Fixes #272