### PR TITLE
Fix storage padding and re-enable buffer clean-up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,19 +147,19 @@ jobs:
           for example in .github/example-run/3d/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/bevy_ci_testing"
+            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_ui bevy/default_font 3d bevy/bevy_ci_testing"
             sleep 10
           done
           for example in .github/example-run/3dpng/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/bevy_ci_testing"
+            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_ui bevy/default_font bevy/png 3d bevy/bevy_ci_testing"
             sleep 10
           done
           for example in .github/example-run/2d/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d bevy/bevy_ci_testing"
+            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite bevy/bevy_ui bevy/default_font 2d bevy/bevy_ci_testing"
             sleep 10
           done
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,7 +234,7 @@ jobs:
       #   if: runner.os == 'linux'
       - name: Install cargo-tarpaulin
         run: |
-          RUST_BACKTRACE=1 cargo install --version 0.22.0 cargo-tarpaulin
+          RUST_BACKTRACE=1 cargo install --version 0.30.0 cargo-tarpaulin
       - name: Generate code coverage
         run: |
           RUST_BACKTRACE=1 cargo tarpaulin --engine llvm --verbose --timeout 120 --out Lcov --workspace --all-features

--- a/src/modifier/clone.rs
+++ b/src/modifier/clone.rs
@@ -100,6 +100,12 @@ impl Modifier for CloneModifier {
 
                     // Recycle a dead particle.
                     let dead_index = atomicSub(&render_group_indirect[{dest}u].dead_count, 1u) - 1u;
+                    // HACK - we have no limiter for dead_count, so could go negative (wrap around).
+                    // Assume that any value above 2^31 is a wrap around, undo the atomic op and return.
+                    if (dead_index >= 0xF0000000) {{
+                        atomicAdd(&render_group_indirect[{dest}u].dead_count, 1u);
+                        return;
+                    }}
                     let new_index = indirect_buffer.indices[3u * (base_index + dead_index) + 2u];
 
                     // Initialize the new particle.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,10 +22,10 @@ use crate::{
     render::{
         extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects,
         prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents,
-        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuParticleGroup,
-        GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline,
-        ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache, SimParams,
-        VfxSimulateDriverNode, VfxSimulateNode,
+        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuDispatchIndirect,
+        GpuParticleGroup, GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams,
+        ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache,
+        SimParams, VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_spawners,
@@ -130,6 +130,8 @@ impl HanabiPlugin {
     pub(crate) fn make_common_shader(min_storage_buffer_offset_alignment: usize) -> Shader {
         let spawner_padding_code =
             GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
+        let dispatch_indirect_padding_code =
+            GpuDispatchIndirect::padding_code(min_storage_buffer_offset_alignment);
         let render_effect_indirect_padding_code =
             GpuRenderEffectMetadata::padding_code(min_storage_buffer_offset_alignment);
         let render_group_indirect_padding_code =
@@ -138,6 +140,10 @@ impl HanabiPlugin {
             GpuParticleGroup::padding_code(min_storage_buffer_offset_alignment);
         let common_code = include_str!("render/vfx_common.wgsl")
             .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
+            .replace(
+                "{{DISPATCH_INDIRECT_PADDING}}",
+                &dispatch_indirect_padding_code,
+            )
             .replace(
                 "{{RENDER_EFFECT_INDIRECT_PADDING}}",
                 &render_effect_indirect_padding_code,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,7 +20,12 @@ use crate::{
     compile_effects, gather_removed_effects,
     properties::EffectProperties,
     render::{
-        extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects, prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuParticleGroup, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache, SimParams, VfxSimulateDriverNode, VfxSimulateNode
+        extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects,
+        prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents,
+        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuParticleGroup,
+        GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline,
+        ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache, SimParams,
+        VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_spawners,
@@ -125,19 +130,23 @@ impl HanabiPlugin {
     pub(crate) fn make_common_shader(min_storage_buffer_offset_alignment: usize) -> Shader {
         let spawner_padding_code =
             GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
+        let render_effect_indirect_padding_code =
+            GpuRenderEffectMetadata::padding_code(min_storage_buffer_offset_alignment);
         let render_group_indirect_padding_code =
             GpuRenderGroupIndirect::padding_code(min_storage_buffer_offset_alignment);
-            let particle_group_padding_code =
-                GpuParticleGroup::padding_code(min_storage_buffer_offset_alignment);
+        let particle_group_padding_code =
+            GpuParticleGroup::padding_code(min_storage_buffer_offset_alignment);
         let common_code = include_str!("render/vfx_common.wgsl")
             .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
             .replace(
+                "{{RENDER_EFFECT_INDIRECT_PADDING}}",
+                &render_effect_indirect_padding_code,
+            )
+            .replace(
                 "{{RENDER_GROUP_INDIRECT_PADDING}}",
                 &render_group_indirect_padding_code,
-            ).replace(
-                "{{PARTICLE_GROUP_PADDING}}",
-                &particle_group_padding_code,
-            );
+            )
+            .replace("{{PARTICLE_GROUP_PADDING}}", &particle_group_padding_code);
         Shader::from_wgsl(
             common_code,
             std::path::Path::new(file!())

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,11 +20,7 @@ use crate::{
     compile_effects, gather_removed_effects,
     properties::EffectProperties,
     render::{
-        extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects,
-        prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents,
-        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuRenderGroupIndirect,
-        GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
-        ShaderCache, SimParams, VfxSimulateDriverNode, VfxSimulateNode,
+        extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects, prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuParticleGroup, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache, SimParams, VfxSimulateDriverNode, VfxSimulateNode
     },
     spawn::{self, Random},
     tick_spawners,
@@ -131,11 +127,16 @@ impl HanabiPlugin {
             GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
         let render_group_indirect_padding_code =
             GpuRenderGroupIndirect::padding_code(min_storage_buffer_offset_alignment);
+            let particle_group_padding_code =
+                GpuParticleGroup::padding_code(min_storage_buffer_offset_alignment);
         let common_code = include_str!("render/vfx_common.wgsl")
             .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
             .replace(
                 "{{RENDER_GROUP_INDIRECT_PADDING}}",
                 &render_group_indirect_padding_code,
+            ).replace(
+                "{{PARTICLE_GROUP_PADDING}}",
+                &particle_group_padding_code,
             );
         Shader::from_wgsl(
             common_code,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,9 +22,9 @@ use crate::{
     render::{
         extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects,
         prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents,
-        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuSpawnerParams,
-        ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache,
-        SimParams, VfxSimulateDriverNode, VfxSimulateNode,
+        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuRenderGroupIndirect,
+        GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
+        ShaderCache, SimParams, VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_spawners,
@@ -129,8 +129,14 @@ impl HanabiPlugin {
     pub(crate) fn make_common_shader(min_storage_buffer_offset_alignment: usize) -> Shader {
         let spawner_padding_code =
             GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
+        let render_group_indirect_padding_code =
+            GpuRenderGroupIndirect::padding_code(min_storage_buffer_offset_alignment);
         let common_code = include_str!("render/vfx_common.wgsl")
-            .replace("{{SPAWNER_PADDING}}", &spawner_padding_code);
+            .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
+            .replace(
+                "{{RENDER_GROUP_INDIRECT_PADDING}}",
+                &render_group_indirect_padding_code,
+            );
         Shader::from_wgsl(
             common_code,
             std::path::Path::new(file!())

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -167,7 +167,8 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
             item_size
         };
         trace!(
-            "BufferTable: item_size={} aligned_size={}",
+            "BufferTable[\"{}\"]: item_size={} aligned_size={}",
+            label.as_ref().unwrap_or(&String::new()),
             item_size,
             aligned_size
         );

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -239,6 +239,7 @@ impl EffectBuffer {
 
         // TODO - Cache particle_layout and associated bind group layout, instead of
         // creating one bind group layout per buffer using that layout...
+        let padded_size = GpuParticleGroup::aligned_size(render_device.limits().min_storage_buffer_offset_alignment as usize);
         let mut entries = vec![
             BindGroupLayoutEntry {
                 binding: 0,
@@ -266,7 +267,9 @@ impl EffectBuffer {
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: true },
                     has_dynamic_offset: false,
-                    min_binding_size: Some(GpuParticleGroup::min_size()),
+                    // Despite no dynamic offset, we do bind a non-zero offset sometimes,
+                    // so keep this aligned
+                    min_binding_size: Some(NonZeroU64::new(padded_size as u64).unwrap()),
                 },
                 count: None,
             },

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -580,7 +580,7 @@ GpuDispatchIndirect: min_size={} padded_size={} | GpuParticleGroup: min_size={} 
             let shader_defs = default();
 
             match composer.make_naga_module(NagaModuleDescriptor {
-                source: &indirect_code,
+                source: indirect_code,
                 file_path: "vfx_indirect.wgsl",
                 shader_defs,
                 ..Default::default()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2340,6 +2340,7 @@ pub(crate) fn prepare_effects(
         let storage_align = effects_meta.gpu_limits.storage_buffer_align().get() as usize;
         let render_effect_stride =
             effects_meta.gpu_limits.render_effect_indirect_size().get() as u32;
+        let render_group_stride = effects_meta.gpu_limits.render_group_indirect_size().get() as u32;
 
         let gpu_sim_params = effects_meta.sim_params_uniforms.get_mut();
         let sim_params = *sim_params;
@@ -2351,6 +2352,7 @@ pub(crate) fn prepare_effects(
         // GPU adapter limits (so, fixed while the app runs). Stop wasting uniform
         // storage and hardcode into shader instead.
         gpu_sim_params.render_effect_stride = render_effect_stride;
+        gpu_sim_params.render_group_stride = render_group_stride;
         gpu_sim_params.dispatch_stride = next_multiple_of(
             GpuDispatchIndirect::min_size().get() as usize,
             storage_align,

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -136,7 +136,7 @@ struct RenderGroupIndirect {
     /// Number of dead particles, decremented during the init pass as new particles
     /// are spawned, and incremented during the update pass as existing particles die.
     dead_count: atomic<u32>,
-    pad: u32,
+    {{RENDER_GROUP_INDIRECT_PADDING}}
 }
 
 var<private> seed : u32 = 0u;

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -53,8 +53,7 @@ struct ParticleGroup {
     // The index of the first particle in this effect in the particle and
     // indirect buffers.
     effect_particle_offset: u32,
-    pad_a: u32,
-    pad_b: u32,
+    {{PARTICLE_GROUP_PADDING}}
 }
 
 struct IndirectBuffer {

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -82,6 +82,7 @@ struct DispatchIndirect {
     /// as an indirect draw source so cannot also be bound as regular storage
     /// buffer for reading.
     pong: u32,
+    {{DISPATCH_INDIRECT_PADDING}}
 }
 
 // Render indirect array offsets. Used when accessing an array of RenderIndirect

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -40,7 +40,9 @@ struct Spawner {
 #endif
 }
 
+// Per-group data for a single particle effect group inside an effect.
 struct ParticleGroup {
+    // Index of the group, generally zero unless CloneModifier is used.
     group_index: u32,
     effect_index: u32,
     // The index relative to the effect: e.g. 0 if this is the first group in
@@ -111,6 +113,7 @@ struct RenderEffectMetadata {
     /// always write into the ping buffer and read from the pong buffer. The buffers
     /// are swapped during the indirect dispatch.
     ping: u32,
+    {{RENDER_EFFECT_INDIRECT_PADDING}}
 }
 
 /// Render indirect parameters for GPU driven rendering.


### PR DESCRIPTION
Fix the padding of all storage buffers to comply with the GPU device requirements, which on most Desktop platforms is 32 bytes, but can be different (for example on macOS M1 and later, it's generally 256 bytes). This fixes a number of issues where effects are not rendering at all, or display strong artifacts. The change is likely over-doing it by padding all structures used in arrays, however this can be optimized as a later pass.

Fix a bug in the `CloneModifier` where the shader code was allocating cloned particles without checking the buffer capacity, leading to underflow error and stomping over other parts of the buffer.

Re-enable buffer cleaning up on effect deletion, which was commented out during the ribbon change but not fixed, and left disabled. This caused the buffers to fill, leaving no space for new effects even after some effects were deleting, which resulted in newly spawned effects not updating (code was dispatching 0 workground in update pass).

Fixes #322 