### PR TITLE
Migrate to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,17 @@ documentation = "https://docs.rs/bevy_hanabi"
 keywords = ["bevy", "particle-system", "particles", "vfx"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-exclude = ["docs/*.svg", "docs/*.png", "examples/*.gif", "examples/*.png", ".github", "release.md", "run_examples.bat", "run_examples.sh", "deny.toml"]
+exclude = [
+    "docs/*.svg",
+    "docs/*.png",
+    "examples/*.gif",
+    "examples/*.png",
+    ".github",
+    "release.md",
+    "run_examples.bat",
+    "run_examples.sh",
+    "deny.toml",
+]
 autoexamples = false
 
 [features]
@@ -40,7 +50,7 @@ examples_world_inspector = []
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }
-fixedbitset = "0.4"
+fixedbitset = "0.5"
 copyless = "0.1"
 rand = "0.8"
 rand_pcg = "0.3"
@@ -51,25 +61,27 @@ bitflags = "2.3"
 typetag = "0.2"
 thiserror = "1.0"
 # Same versions as Bevy 0.13 (bevy_render)
-naga = "0.19"
-naga_oil = { version = "0.13", default-features = false, features = ["test_shader"] }
+naga = "0.20"
+naga_oil = { version = "0.14", default-features = false, features = [
+    "test_shader",
+] }
 
 [dependencies.bevy]
-version = "0.13"
+version = "0.14.0-rc.3"
 default-features = false
-features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset", "x11" ]
+features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "x11"]
 
 [package.metadata.docs.rs]
 all-features = true
 
 [dev-dependencies]
-# Same versions as Bevy 0.13 (bevy_render)
-wgpu = "0.19.1"
+# Same versions as Bevy 0.14 (bevy_render)
+wgpu = "0.20.1"
 
 # For world inspector; required if "examples_world_inspector" is used.
-bevy-inspector-egui = "0.23"
-bevy_egui = "0.25"
-egui = "0.26"
+bevy-inspector-egui = "0.24"
+bevy_egui = "0.27"
+egui = "0.27"
 
 # For procedural texture generation in examples
 noise = "0.8"
@@ -78,83 +90,89 @@ futures = "0.3"
 
 [[example]]
 name = "firework"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "portal"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "expr"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "spawn"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "multicam"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "visibility"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "random"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "spawn_on_command"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "activate"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/bevy_ui", "bevy/default_font", "3d" ]
+required-features = [
+    "bevy/bevy_winit",
+    "bevy/bevy_pbr",
+    "bevy/bevy_ui",
+    "bevy/default_font",
+    "3d",
+]
 
 [[example]]
 name = "force_field"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "lifetime"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "init"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "instancing"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d"]
 
 [[example]]
 name = "gradient"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d"]
 
 [[example]]
 name = "circle"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d"]
 
 [[example]]
 name = "billboard"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d"]
 
 [[example]]
 name = "2d"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_sprite", "2d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_sprite", "2d"]
 
 [[example]]
 name = "worms"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "bevy/png", "3d"]
 
 [[example]]
 name = "ribbon"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [[example]]
 name = "ordering"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
+required-features = ["bevy/bevy_winit", "bevy/bevy_pbr", "3d"]
 
 [workspace]
 resolver = "2"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,10 +1,11 @@
 use bevy::{
     asset::{io::Reader, Asset, AssetLoader, AsyncReadExt, LoadContext},
     reflect::Reflect,
-    utils::{default, thiserror::Error, BoxedFuture, HashSet},
+    utils::{default, BoxedFuture, HashSet},
 };
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
+use thiserror::Error;
 
 use crate::{
     modifier::{Modifier, RenderModifier},

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,7 +1,7 @@
 use bevy::{
     asset::{io::Reader, Asset, AssetLoader, AsyncReadExt, LoadContext},
     reflect::Reflect,
-    utils::{default, BoxedFuture, HashSet},
+    utils::{default, ConditionalSendFuture, HashSet},
 };
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -703,7 +703,7 @@ impl AssetLoader for EffectAssetLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -127,8 +127,8 @@ use bevy::{
     math::{Vec2, Vec3, Vec4},
     reflect::{
         utility::{GenericTypePathCell, NonGenericTypeInfoCell},
-        DynamicStruct, FieldIter, FromReflect, NamedField, Reflect, ReflectMut, ReflectOwned,
-        ReflectRef, Struct, StructInfo, TypeInfo, TypePath, Typed,
+        DynamicStruct, FieldIter, FromReflect, GetTypeRegistration, NamedField, Reflect,
+        ReflectMut, ReflectOwned, ReflectRef, Struct, StructInfo, TypeInfo, TypePath, Typed,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -794,7 +794,7 @@ impl Reflect for Attribute {
         ReflectOwned::Struct(self)
     }
 
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+    fn try_apply(&mut self, _value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
         todo!()
     }
 }
@@ -806,6 +806,12 @@ impl FromReflect for Attribute {
         } else {
             None
         }
+    }
+}
+
+impl GetTypeRegistration for Attribute {
+    fn get_type_registration() -> bevy::reflect::TypeRegistration {
+        todo!()
     }
 }
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -793,6 +793,10 @@ impl Reflect for Attribute {
     fn reflect_owned(self: Box<Self>) -> ReflectOwned {
         ReflectOwned::Struct(self)
     }
+
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+        todo!()
+    }
 }
 
 impl FromReflect for Attribute {

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,7 +1,6 @@
 use bevy::{
-    math::{Quat, Vec2, Vec3, Vec3A, Vec4},
+    math::{FloatOrd, Quat, Vec2, Vec3, Vec3A, Vec4},
     reflect::{FromReflect, Reflect},
-    utils::FloatOrd,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -104,8 +104,9 @@
 
 use std::{cell::RefCell, num::NonZeroU32, rc::Rc};
 
-use bevy::{reflect::Reflect, utils::thiserror::Error};
+use bevy::reflect::Reflect;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::{
     Attribute, ModifierContext, ParticleLayout, Property, PropertyLayout, ScalarType, ToWgslString,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -43,11 +43,10 @@ use std::fmt::Debug;
 
 use bevy::{
     math::{
-        BVec2, BVec3, BVec4, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, UVec2, UVec3, UVec4, Vec2,
-        Vec3, Vec3A, Vec4,
+        BVec2, BVec3, BVec4, FloatOrd, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, UVec2, UVec3, UVec4,
+        Vec2, Vec3, Vec3A, Vec4,
     },
     reflect::Reflect,
-    utils::FloatOrd,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,13 +169,11 @@
 //!    effect, without having to destroy the effect and re-create a new one.
 
 #[cfg(feature = "2d")]
-use bevy::utils::FloatOrd;
-use bevy::{
-    prelude::*,
-    utils::{thiserror::Error, HashSet},
-};
+use bevy::math::FloatOrd;
+use bevy::{prelude::*, utils::HashSet};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write as _; // import without risk of name clashing
+use thiserror::Error;
 
 mod asset;
 pub mod attributes;
@@ -1476,10 +1474,7 @@ mod tests {
             },
             AssetServerMode,
         },
-        render::{
-            deterministic::DeterministicRenderingConfig,
-            view::{VisibilityPlugin, VisibilitySystems},
-        },
+        render::view::{VisibilityPlugin, VisibilitySystems},
         tasks::{IoTaskPool, TaskPoolBuilder},
     };
     use naga_oil::compose::{Composer, NagaModuleDescriptor, ShaderDefValue};
@@ -1702,7 +1697,7 @@ else { return c1; }
 
         let watch_for_changes = false;
         let mut builders = app
-            .world
+            .world_mut()
             .get_resource_or_insert_with::<AssetSourceBuilders>(Default::default);
         let dir = Dir::default();
         let dummy_builder = AssetSourceBuilder::default()
@@ -1716,7 +1711,6 @@ else { return c1; }
         // app.add_plugins(DefaultPlugins);
         app.init_asset::<Mesh>();
         app.init_asset::<Shader>();
-        app.init_resource::<DeterministicRenderingConfig>();
         app.add_plugins(VisibilityPlugin);
         app.init_resource::<ShaderCache>();
         app.insert_resource(Random(new_rng()));
@@ -1814,7 +1808,7 @@ else { return c1; }
                 let mut dummy_app = App::new();
                 dummy_app.init_resource::<Assets<Shader>>();
                 dummy_app.add_plugins(bevy::render::view::ViewPlugin);
-                let shaders = dummy_app.world.get_resource::<Assets<Shader>>().unwrap();
+                let shaders = dummy_app.world().get_resource::<Assets<Shader>>().unwrap();
                 let view_shader = shaders.get(bevy::render::view::VIEW_TYPE_HANDLE).unwrap();
 
                 let res = composer.add_composable_module(view_shader.into());
@@ -1907,7 +1901,7 @@ else { return c1; }
 
         // Check
         {
-            let world = &mut app.world;
+            let world = app.world_mut();
 
             let (entity, particle_effect, compiled_particle_effect) = world
                 .query::<(Entity, &ParticleEffect, &CompiledParticleEffect)>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1809,7 +1809,7 @@ else { return c1; }
                 dummy_app.init_resource::<Assets<Shader>>();
                 dummy_app.add_plugins(bevy::render::view::ViewPlugin);
                 let shaders = dummy_app.world().get_resource::<Assets<Shader>>().unwrap();
-                let view_shader = shaders.get(bevy::render::view::VIEW_TYPE_HANDLE).unwrap();
+                let view_shader = shaders.get(&bevy::render::view::VIEW_TYPE_HANDLE).unwrap();
 
                 let res = composer.add_composable_module(view_shader.into());
                 assert!(res.is_ok());
@@ -1871,7 +1871,7 @@ else { return c1; }
         let mut app = make_test_app();
 
         let (effect_entity, handle) = {
-            let world = &mut app.world;
+            let world = app.world_mut();
 
             // Add effect asset
             let mut assets = world.resource_mut::<Assets<EffectAsset>>();
@@ -1919,7 +1919,7 @@ else { return c1; }
 
         // Mark as changed without actually changing anything
         {
-            let world = &mut app.world;
+            let world = app.world_mut();
 
             let mut particle_effect = world
                 .query::<&mut ParticleEffect>()
@@ -1936,7 +1936,7 @@ else { return c1; }
 
         // Check again, nothing changed
         {
-            let world = &mut app.world;
+            let world = app.world_mut();
 
             let (entity, particle_effect, compiled_particle_effect) = world
                 .query::<(Entity, &ParticleEffect, &CompiledParticleEffect)>()
@@ -1965,7 +1965,7 @@ else { return c1; }
             let mut app = make_test_app();
 
             let (effect_entity, handle) = {
-                let world = &mut app.world;
+                let world = app.world_mut();
 
                 // Add effect asset
                 let mut assets = world.resource_mut::<Assets<EffectAsset>>();
@@ -2011,7 +2011,7 @@ else { return c1; }
             // Tick once
             app.update();
 
-            let world = &mut app.world;
+            let world = app.world_mut();
 
             // Check the state of the components after `tick_spawners()` ran
             if let Some(test_visibility) = test_case.visibility {

--- a/src/modifier/clone.rs
+++ b/src/modifier/clone.rs
@@ -2,7 +2,7 @@
 
 use std::hash::{Hash, Hasher};
 
-use bevy::{prelude::*, utils::FloatOrd};
+use bevy::{math::FloatOrd, prelude::*};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,7 +12,7 @@ use bevy::{
         view::{prepare_view_uniforms, visibility::VisibilitySystems},
         Render, RenderApp, RenderSet,
     },
-    time::{update_virtual_time, TimeSystem},
+    time::{time_system, TimeSystem},
 };
 
 use crate::{
@@ -196,7 +196,7 @@ impl Plugin for HanabiPlugin {
             .add_systems(
                 First,
                 effect_simulation_time_system
-                    .after(update_virtual_time)
+                    .after(time_system)
                     .in_set(TimeSystem),
             )
             .add_systems(
@@ -225,7 +225,7 @@ impl Plugin for HanabiPlugin {
             .clone();
 
         let adapter_name = app
-            .world
+            .world()
             .get_resource::<RenderAdapterInfo>()
             .map(|ai| &ai.name[..])
             .unwrap_or("<unknown>");
@@ -247,7 +247,7 @@ impl Plugin for HanabiPlugin {
                 render_device.limits().min_storage_buffer_offset_alignment,
             );
             let mut assets = app.world_mut().resource_mut::<Assets<Shader>>();
-            assets.insert(HANABI_COMMON_TEMPLATE_HANDLE, common_shader);
+            assets.insert(&HANABI_COMMON_TEMPLATE_HANDLE, common_shader);
         }
 
         let effects_meta = EffectsMeta::new(render_device.clone());

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -1,5 +1,4 @@
 use bevy::{
-    core::{cast_slice, Pod},
     log::trace,
     render::{
         render_resource::{
@@ -8,6 +7,7 @@ use bevy::{
         renderer::{RenderDevice, RenderQueue},
     },
 };
+use bytemuck::{cast_slice, Pod};
 use copyless::VecHelper;
 use std::num::NonZeroU64;
 

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -6,7 +6,7 @@ use bevy::{
 };
 
 #[cfg(feature = "2d")]
-use bevy::utils::FloatOrd;
+use bevy::math::FloatOrd;
 
 use crate::{EffectAsset, EffectShader, ParticleLayout, PropertyLayout};
 

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -1,5 +1,4 @@
 use bevy::{
-    core::{cast_slice, Pod},
     log::trace,
     render::{
         render_resource::{
@@ -9,6 +8,7 @@ use bevy::{
         renderer::{RenderDevice, RenderQueue},
     },
 };
+use bytemuck::{cast_slice, Pod};
 use copyless::VecHelper;
 use std::num::NonZeroU64;
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-use bevy::{ecs::system::Resource, prelude::*, reflect::Reflect, utils::FloatOrd};
+use bevy::{ecs::system::Resource, math::FloatOrd, prelude::*, reflect::Reflect};
 use rand::{
     distributions::{uniform::SampleUniform, Distribution, Uniform},
     SeedableRng,
@@ -678,10 +678,7 @@ mod test {
             },
             AssetServerMode,
         },
-        render::{
-            deterministic::DeterministicRenderingConfig,
-            view::{VisibilityPlugin, VisibilitySystems},
-        },
+        render::view::{VisibilityPlugin, VisibilitySystems},
         tasks::{IoTaskPool, TaskPoolBuilder},
     };
 
@@ -852,7 +849,7 @@ mod test {
 
         let watch_for_changes = false;
         let mut builders = app
-            .world
+            .world_mut()
             .get_resource_or_insert_with::<AssetSourceBuilders>(Default::default);
         let dir = Dir::default();
         let dummy_builder = AssetSourceBuilder::default()
@@ -865,7 +862,6 @@ mod test {
         app.insert_resource(asset_server);
         // app.add_plugins(DefaultPlugins);
         app.init_asset::<Mesh>();
-        app.init_resource::<DeterministicRenderingConfig>();
         app.add_plugins(VisibilityPlugin);
         app.init_resource::<Time<EffectSimulation>>();
         app.insert_resource(Random(new_rng()));
@@ -909,7 +905,7 @@ mod test {
             let mut app = make_test_app();
 
             let (effect_entity, handle) = {
-                let world = &mut app.world;
+                let world = app.world_mut();
 
                 // Add effect asset
                 let mut assets = world.resource_mut::<Assets<EffectAsset>>();
@@ -957,13 +953,13 @@ mod test {
                 // Note that `Time` has this weird behavior where the common quantities like
                 // `Time::delta_seconds()` only update after the *second* update. So we tick the
                 // `Time` twice here to enforce this.
-                let mut time = app.world.resource_mut::<Time<EffectSimulation>>();
+                let mut time = app.world_mut().resource_mut::<Time<EffectSimulation>>();
                 time.advance_by(Duration::from_millis(16));
                 time.elapsed()
             };
             app.update();
 
-            let world = &mut app.world;
+            let world = app.world_mut();
 
             // Check the state of the components after `tick_spawners()` ran
             if let Some(test_visibility) = test_case.visibility {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,7 +3,10 @@
 #[cfg(feature = "gpu_tests")]
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 
-use bevy::prelude::{Quat, Vec2, Vec3, Vec4};
+use bevy::{
+    prelude::{Quat, Vec2, Vec3, Vec4},
+    render::renderer::WgpuWrapper,
+};
 use std::ops::Sub;
 
 /// Utility trait to compare floating-point values with a tolerance.
@@ -187,7 +190,7 @@ impl MockRenderer {
 
         // Turn into Bevy objects
         let device = RenderDevice::from(device);
-        let queue = RenderQueue(std::sync::Arc::new(queue));
+        let queue = RenderQueue(std::sync::Arc::new(WgpuWrapper::new(queue)));
 
         Self {
             instance,

--- a/src/time.rs
+++ b/src/time.rs
@@ -184,7 +184,7 @@ pub(crate) fn effect_simulation_time_system(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::time::{virtual_time_system, TimePlugin, TimeSystem};
+    use bevy::time::{time_system, TimePlugin, TimeSystem};
     use std::{thread::sleep, time::Duration};
 
     fn make_test_app() -> App {
@@ -195,7 +195,7 @@ mod tests {
         app.add_systems(
             First,
             effect_simulation_time_system
-                .after(virtual_time_system)
+                .after(TimeSystem)
                 .in_set(TimeSystem),
         );
 
@@ -216,35 +216,35 @@ mod tests {
         // Update with default speed
         sleep(Duration::from_millis(1));
         app.update();
-        let real = app.world.resource::<Time<Real>>();
-        let virt = app.world.resource::<Time<Virtual>>();
-        let effect_simulation = app.world.resource::<Time<EffectSimulation>>();
+        let real = app.world().resource::<Time<Real>>();
+        let virt = app.world().resource::<Time<Virtual>>();
+        let effect_simulation = app.world().resource::<Time<EffectSimulation>>();
         assert!(f32::abs(virt.delta_seconds() - real.delta_seconds()) < EPSILON);
         assert!(f32::abs(effect_simulation.delta_seconds() - real.delta_seconds()) < EPSILON);
 
         // Update with virtual speed 2.0
-        app.world
+        app.world_mut()
             .resource_mut::<Time<Virtual>>()
             .set_relative_speed(2.0);
         sleep(Duration::from_millis(1));
         app.update();
-        let real = app.world.resource::<Time<Real>>();
-        let virt = app.world.resource::<Time<Virtual>>();
-        let effect_simulation = app.world.resource::<Time<EffectSimulation>>();
+        let real = app.world().resource::<Time<Real>>();
+        let virt = app.world().resource::<Time<Virtual>>();
+        let effect_simulation = app.world().resource::<Time<EffectSimulation>>();
         assert!(f32::abs(virt.delta_seconds() - 2.0 * real.delta_seconds()) < EPSILON);
         assert!(f32::abs(effect_simulation.delta_seconds() - 2.0 * real.delta_seconds()) < EPSILON);
         assert!(f32::abs(virt.effective_speed() - 2.0) < EPSILON);
         assert!(f32::abs(effect_simulation.effective_speed() - 2.0) < EPSILON);
 
         // Update with virtual speed 2.0 and effect speed 3.0
-        app.world
+        app.world_mut()
             .resource_mut::<Time<EffectSimulation>>()
             .set_relative_speed(3.0);
         sleep(Duration::from_millis(1));
         app.update();
-        let real = app.world.resource::<Time<Real>>();
-        let virt = app.world.resource::<Time<Virtual>>();
-        let effect_simulation = app.world.resource::<Time<EffectSimulation>>();
+        let real = app.world().resource::<Time<Real>>();
+        let virt = app.world().resource::<Time<Virtual>>();
+        let effect_simulation = app.world().resource::<Time<EffectSimulation>>();
         assert!(f32::abs(virt.delta_seconds() - 2.0 * real.delta_seconds()) < EPSILON);
         assert!(f32::abs(effect_simulation.delta_seconds() - 6.0 * real.delta_seconds()) < EPSILON);
         assert!(f32::abs(virt.effective_speed() - 2.0) < EPSILON);


### PR DESCRIPTION
I tried doing a bunch of the boring work to migrate this to 0.14, but I didn't have time to sit down and grok all the rendering changes.

Stuff missing:
* Wait for https://github.com/bevyengine/bevy/pull/13879 (or create a separate SystemSet)
* Implement the new Reflect methods
* Fix the RenderPhase errors