### PR TITLE
Only emit error if pipeline failed creation

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -492,8 +492,8 @@ impl VectorValue {
         Self {
             vector_type: VectorType::VEC2F,
             storage: [
-                unsafe { std::mem::transmute(value.x) },
-                unsafe { std::mem::transmute(value.y) },
+                unsafe { std::mem::transmute::<f32, u32>(value.x) },
+                unsafe { std::mem::transmute::<f32, u32>(value.y) },
                 0u32,
                 0u32,
             ],
@@ -506,9 +506,9 @@ impl VectorValue {
         Self {
             vector_type: VectorType::VEC3F,
             storage: [
-                unsafe { std::mem::transmute(value.x) },
-                unsafe { std::mem::transmute(value.y) },
-                unsafe { std::mem::transmute(value.z) },
+                unsafe { std::mem::transmute::<f32, u32>(value.x) },
+                unsafe { std::mem::transmute::<f32, u32>(value.y) },
+                unsafe { std::mem::transmute::<f32, u32>(value.z) },
                 0u32,
             ],
         }
@@ -519,7 +519,7 @@ impl VectorValue {
     pub const fn new_vec4(value: Vec4) -> Self {
         Self {
             vector_type: VectorType::VEC4F,
-            storage: unsafe { std::mem::transmute(value.to_array()) },
+            storage: unsafe { std::mem::transmute::<[f32; 4], [u32; 4]>(value.to_array()) },
         }
     }
 
@@ -529,8 +529,8 @@ impl VectorValue {
         Self {
             vector_type: VectorType::VEC2I,
             storage: [
-                unsafe { std::mem::transmute(value.x) },
-                unsafe { std::mem::transmute(value.y) },
+                unsafe { std::mem::transmute::<i32, u32>(value.x) },
+                unsafe { std::mem::transmute::<i32, u32>(value.y) },
                 0u32,
                 0u32,
             ],
@@ -543,9 +543,9 @@ impl VectorValue {
         Self {
             vector_type: VectorType::VEC3I,
             storage: [
-                unsafe { std::mem::transmute(value.x) },
-                unsafe { std::mem::transmute(value.y) },
-                unsafe { std::mem::transmute(value.z) },
+                unsafe { std::mem::transmute::<i32, u32>(value.x) },
+                unsafe { std::mem::transmute::<i32, u32>(value.y) },
+                unsafe { std::mem::transmute::<i32, u32>(value.z) },
                 0u32,
             ],
         }
@@ -556,7 +556,7 @@ impl VectorValue {
     pub const fn new_ivec4(value: IVec4) -> Self {
         Self {
             vector_type: VectorType::VEC4I,
-            storage: unsafe { std::mem::transmute(value.to_array()) },
+            storage: unsafe { std::mem::transmute::<[i32; 4], [u32; 4]>(value.to_array()) },
         }
     }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3405,11 +3405,16 @@ impl Node for VfxSimulateNode {
                     let Some(init_pipeline) =
                         pipeline_cache.get_compute_pipeline(batches.init_pipeline_id)
                     else {
-                        error!(
-                            "Failed to find init pipeline #{} for effect {:?}",
-                            batches.init_pipeline_id.id(),
-                            entity
-                        );
+                        if let CachedPipelineState::Err(err) =
+                            pipeline_cache.get_compute_pipeline_state(batches.init_pipeline_id)
+                        {
+                            error!(
+                                "Failed to find init pipeline #{} for effect {:?}: {:?}",
+                                batches.init_pipeline_id.id(),
+                                entity,
+                                err
+                            );
+                        }
                         continue;
                     };
 
@@ -3608,12 +3613,17 @@ impl Node for VfxSimulateNode {
                     let Some(update_pipeline) =
                         pipeline_cache.get_compute_pipeline(*update_pipeline_id)
                     else {
-                        error!(
-                            "Failed to find update pipeline #{} for effect {:?}, group {}",
-                            update_pipeline_id.id(),
-                            entity,
-                            group_index
-                        );
+                        if let CachedPipelineState::Err(err) =
+                            pipeline_cache.get_compute_pipeline_state(*update_pipeline_id)
+                        {
+                            error!(
+                                "Failed to find update pipeline #{} for effect {:?}, group {}: {:?}",
+                                update_pipeline_id.id(),
+                                entity,
+                                group_index,
+                                err
+                            );
+                        }
                         continue;
                     };
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 #[cfg(feature = "gpu_tests")]
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 


### PR DESCRIPTION
Only emit an error about failing to find an init or update pipeline if the pipeline creation state reports it failed. Otherwise (queued, creating) silently skip the frame until it's ready.

Fixes #341