### PR TITLE
Avoid `unwrap()` on invalid asset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,9 +56,9 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'linux' && matrix.dimensions != 'all'
-      - name: Build & run all tests (${{ matrix.dimensions }} DX12)
+      - name: Build & run lib tests (${{ matrix.dimensions }} DX12)
         shell: bash
-        run: WGPU_BACKEND=dx12 cargo test --no-default-features --features ${{ matrix.dimensions }} --features gpu_tests
+        run: WGPU_BACKEND=dx12 cargo test --lib --no-default-features --features ${{ matrix.dimensions }} --features gpu_tests
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'windows' && matrix.dimensions != 'all'
@@ -79,9 +79,9 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'windows' && matrix.dimensions == 'all'
-      - name: Build & run all tests (all METAL)
+      - name: Build & run lib tests (all METAL)
         shell: bash
-        run: WGPU_BACKEND=metal cargo test --no-default-features --features "2d 3d gpu_tests"
+        run: WGPU_BACKEND=metal cargo test --lib --no-default-features --features "2d 3d gpu_tests"
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'macos' && matrix.dimensions == 'all'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,35 +51,35 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - name: Build & run tests (${{ matrix.dimensions }} no GPU)
-        run: cargo test --no-default-features --features ${{ matrix.dimensions }}
+      - name: Build & run lib tests (${{ matrix.dimensions }} no GPU)
+        run: cargo test --lib --no-default-features --features ${{ matrix.dimensions }}
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'linux' && matrix.dimensions != 'all'
-      - name: Build & run tests (${{ matrix.dimensions }} DX12)
+      - name: Build & run all tests (${{ matrix.dimensions }} DX12)
         shell: bash
         run: WGPU_BACKEND=dx12 cargo test --no-default-features --features ${{ matrix.dimensions }} --features gpu_tests
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'windows' && matrix.dimensions != 'all'
-      - name: Build & run tests (${{ matrix.dimensions }} METAL)
+      - name: Build & run all tests (${{ matrix.dimensions }} METAL)
         shell: bash
         run: WGPU_BACKEND=metal cargo test --no-default-features --features ${{ matrix.dimensions }} --features gpu_tests
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'macos' && matrix.dimensions != 'all'
-      - name: Build & run tests (all no GPU)
-        run: cargo test --no-default-features --features "2d 3d"
+      - name: Build & run lib tests (all no GPU)
+        run: cargo test --lib --no-default-features --features "2d 3d"
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'linux' && matrix.dimensions == 'all'
-      - name: Build & run tests (all DX12)
+      - name: Build & run all tests (all DX12)
         shell: bash
         run: WGPU_BACKEND=dx12 cargo test --no-default-features --features "2d 3d gpu_tests"
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'windows' && matrix.dimensions == 'all'
-      - name: Build & run tests (all METAL)
+      - name: Build & run all tests (all METAL)
         shell: bash
         run: WGPU_BACKEND=metal cargo test --no-default-features --features "2d 3d gpu_tests"
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,15 +73,15 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'linux' && matrix.dimensions == 'all'
-      - name: Build & run all tests (all DX12)
+      - name: Build & run lib tests (all DX12)
         shell: bash
-        run: WGPU_BACKEND=dx12 cargo test --no-default-features --features "2d 3d gpu_tests"
+        run: WGPU_BACKEND=dx12 cargo test --lib --no-default-features --features "2d 3d gpu_tests"
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'windows' && matrix.dimensions == 'all'
-      - name: Build & run lib tests (all METAL)
+      - name: Build & run all tests (all METAL)
         shell: bash
-        run: WGPU_BACKEND=metal cargo test --lib --no-default-features --features "2d 3d gpu_tests"
+        run: WGPU_BACKEND=metal cargo test --no-default-features --features "2d 3d gpu_tests"
         env:
           CARGO_INCREMENTAL: 0
         if: runner.os == 'macos' && matrix.dimensions == 'all'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,11 @@ required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 name = "ordering"
 required-features = [ "bevy/bevy_winit", "bevy/bevy_pbr", "3d" ]
 
+[[test]]
+name = "empty_effect"
+path = "gpu_tests/empty_effect.rs"
+harness = false
+
 [workspace]
 resolver = "2"
 members = ["."]

--- a/gpu_tests/empty_effect.rs
+++ b/gpu_tests/empty_effect.rs
@@ -1,0 +1,41 @@
+//! Test that an empty (invalid) bundle doesn't produce any error.
+
+use bevy::{app::AppExit, core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
+
+use bevy_hanabi::prelude::*;
+
+#[derive(Default, Resource)]
+struct Frame(pub u32);
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::default();
+    app.insert_resource(ClearColor(Color::DARK_GRAY))
+        .add_plugins(DefaultPlugins.set(LogPlugin {
+            level: bevy::log::Level::INFO,
+            filter: "bevy_hanabi=debug".to_string(),
+            update_subscriber: None,
+        }))
+        .add_plugins(HanabiPlugin)
+        .init_resource::<Frame>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, timeout)
+        .run();
+
+    Ok(())
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera3dBundle {
+        tonemapping: Tonemapping::None,
+        ..default()
+    });
+    commands.spawn(ParticleEffectBundle::default());
+}
+
+fn timeout(mut frame: ResMut<Frame>, mut ev_app_exit: EventWriter<AppExit>) {
+    frame.0 += 1;
+    if frame.0 >= 10 {
+        info!("SUCCESS!");
+        ev_app_exit.send(AppExit);
+    }
+}

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 /// [`ParticleEffect`].
 ///
 /// [`EffectProperties`]: crate::EffectProperties
-#[derive(Bundle, Clone)]
+#[derive(Default, Bundle, Clone)]
 pub struct ParticleEffectBundle {
     /// The particle effect instance itself.
     pub effect: ParticleEffect,
@@ -73,12 +73,6 @@ pub struct ParticleEffectBundle {
     ///
     /// [`SimulationCondition::Always`]: crate::SimulationCondition::Always
     pub view_visibility: ViewVisibility,
-}
-
-impl Default for ParticleEffectBundle {
-    fn default() -> Self {
-        Self::new(Handle::<EffectAsset>::default())
-    }
 }
 
 impl ParticleEffectBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1878,9 +1878,7 @@ else { return c1; }
             let world = &mut app.world;
 
             // Spawn particle effect
-            let entity = world
-                .spawn(ParticleEffectBundle::default())
-                .id();
+            let entity = world.spawn(ParticleEffectBundle::default()).id();
 
             // Spawn a camera, otherwise ComputedVisibility stays at HIDDEN
             world.spawn(Camera3dBundle::default());
@@ -1904,7 +1902,10 @@ else { return c1; }
             assert_eq!(particle_effect.handle, Handle::<EffectAsset>::default());
 
             // `compile_effects()` cannot update the CompiledParticleEffect because the asset is invalid
-            assert_eq!(compiled_particle_effect.asset, Handle::<EffectAsset>::default());
+            assert_eq!(
+                compiled_particle_effect.asset,
+                Handle::<EffectAsset>::default()
+            );
             assert!(compiled_particle_effect.effect_shader.is_none());
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1428,9 +1428,9 @@ pub(crate) fn extract_effects(
     extracted_effects.added_effects = query
         .p1()
         .iter()
-        .map(|(entity, effect)| {
+        .filter_map(|(entity, effect)| {
             let handle = effect.asset.clone_weak();
-            let asset = effects.get(&effect.asset).unwrap();
+            let asset = effects.get(&effect.asset)?;
             let particle_layout = asset.particle_layout();
             assert!(
                 particle_layout.size() > 0,
@@ -1441,14 +1441,14 @@ pub(crate) fn extract_effects(
             let property_layout = asset.property_layout();
 
             trace!("Found new effect: entity {:?} | capacities {:?} | particle_layout {:?} | property_layout {:?} | layout_flags {:?}", entity, asset.capacities(), particle_layout, property_layout, effect.layout_flags);
-            AddedEffect {
+            Some(AddedEffect {
                 entity,
                 capacities: asset.capacities().to_vec(),
                 particle_layout,
                 property_layout,
                 layout_flags: effect.layout_flags,
                 handle,
-            }
+            })
         })
         .collect();
 


### PR DESCRIPTION
Prevent `extract_effects()` from attempting to `unwrap()` on an invalid asset handle, which causes a panic. Instead, use `filter_map()` to ignore compiled effects with an invalid handle. Add a regression test (no extraction) and an integration example of an empty effect to ensure there's no panic.

Fixes #343