### PR TITLE
Clarify license with SPDX

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,0 @@
-Hanabi is dual-licensed under either
-
-* MIT License (LICENSE-MIT or http://opensource.org/licenses/MIT)
-* Apache License, Version 2.0 (LICENSE-APACHE2 or http://www.apache.org/licenses/LICENSE-2.0)
-
-at your option.

--- a/README.md
+++ b/README.md
@@ -401,3 +401,14 @@ Compatibility of `bevy_hanabi` versions:
 | `0.3`-`0.4`   | `0.8`  |
 | `0.2`         | `0.7`  |
 | `0.1`         | `0.6`  |
+
+## License
+
+🎆 Hanabi is dual-licensed under either:
+
+* MIT License ([`LICENSE-MIT`](./LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+* Apache License, Version 2.0 ([`LICENSE-APACHE2`](./LICENSE-APACHE2) or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+at your option.
+
+`SPDX-License-Identifier: MIT OR Apache-2.0`


### PR DESCRIPTION
Clarify the licensing without changing it, by deleting the `LICENSE` file and moving its content into `README.md` (this should help GitHub stop confusing that file for a third type of license). Also add some SPDX identifier for further clarity.

THIS DOESN'T CHANGE IN ANY WAY THE LICENSING TERMS; this is only a clarification.