### PR TITLE
Expose `is_alive` particle flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `BuiltInOperator::IsAlive` exposing the current state of the `is_alive` particle flag,
+  which represents whether a particle is still alive or will be deallocated at the end of the update pass.
+
+### Fixed
+
+- Prevented an error from being emitted when a GPU pipeline is still being created. (#341)
+- Fixed a panic when a particle effect as an invalid asset handle. (#343)
+
 ## [0.11.0] 2024-05-29
 
 ### Added

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1314,7 +1314,7 @@ pub enum BuiltInOperator {
     /// [`Attribute::AGE`] and   [`Attribute::LIFETIME`], then the flag is
     /// re-evaluated as:
     ///
-    /// ```
+    /// ```wgsl
     /// is_alive = is_alive && (particle.age < particle.lifetime);
     /// ```
     ///


### PR DESCRIPTION
Expose the `is_alive` flag of particles in the update pass, to enable an expression to query the current alive state of the particle.