### PR TITLE
Fix new linter: remove `std::mem::`

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -259,17 +259,18 @@ impl EffectAsset {
     ///
     /// The effect assets requires 2 essential pieces:
     /// - The capacities of the effect, which together represent the maximum
-    /// number of particles which can be stored and simulated at the same time
-    /// for each group. There will be one capacity value per group; thus, the
-    /// `capacities` array also specifies the number of groups. All capacities
-    /// must be non-zero and should be the smallest possible values which allow
-    /// you to author the effect. These values directly impact the GPU memory
-    /// consumption of the effect, which will allocate some buffers to store
-    /// that many particles for as long as the effect exists. The capacities of
-    /// an effect are immutable. See also [`capacities()`] for more details.
+    ///   number of particles which can be stored and simulated at the same time
+    ///   for each group. There will be one capacity value per group; thus, the
+    ///   `capacities` array also specifies the number of groups. All capacities
+    ///   must be non-zero and should be the smallest possible values which
+    ///   allow you to author the effect. These values directly impact the GPU
+    ///   memory consumption of the effect, which will allocate some buffers to
+    ///   store that many particles for as long as the effect exists. The
+    ///   capacities of an effect are immutable. See also [`capacities()`] for
+    ///   more details.
     /// - The [`Spawner`], which defines when particles are emitted. All
-    /// spawners spawn particles into group 0. (To add particles to other
-    /// groups, use the [`crate::modifier::clone::CloneModifier`].)
+    ///   spawners spawn particles into group 0. (To add particles to other
+    ///   groups, use the [`crate::modifier::clone::CloneModifier`].)
     ///
     /// Additionally, if any modifier added to this effect uses some [`Expr`] to
     /// customize its behavior, then those [`Expr`] are stored into a [`Module`]

--- a/src/modifier/position.rs
+++ b/src/modifier/position.rs
@@ -39,12 +39,12 @@ pub struct SetPositionCircleModifier {
     /// Note the particular interpretation of the dimension for this shape,
     /// which unlike other shapes is a 2D one to begin with:
     /// - [`ShapeDimension::Volume`] randomly position the particle anywhere on
-    /// the "volume" of the shape, which here is understood to be the 2D disc
-    /// surface including its origin (`dist <= r`).
-    /// - [`ShapeDimension::Surface`] randomly position the particle
-    /// anywhere on the "surface" of the shape, which here is understood to
-    /// be the perimeter circle, the set of points at a distance from the center
-    /// exactly equal to the radius (`dist == r`).
+    ///   the "volume" of the shape, which here is understood to be the 2D disc
+    ///   surface including its origin (`dist <= r`).
+    /// - [`ShapeDimension::Surface`] randomly position the particle anywhere on
+    ///   the "surface" of the shape, which here is understood to be the
+    ///   perimeter circle, the set of points at a distance from the center
+    ///   exactly equal to the radius (`dist == r`).
     pub dimension: ShapeDimension,
 }
 

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -50,7 +50,7 @@ pub struct AlignedBufferVec<T: Pod + ShaderSize> {
 
 impl<T: Pod + ShaderType + ShaderSize> Default for AlignedBufferVec<T> {
     fn default() -> Self {
-        let item_size = std::mem::size_of::<T>();
+        let item_size = size_of::<T>();
         let aligned_size = <T as ShaderSize>::SHADER_SIZE.get() as usize;
         assert!(aligned_size >= item_size);
         Self {
@@ -263,12 +263,12 @@ mod tests {
     #[test]
     fn abv_sizes() {
         // Rust
-        assert_eq!(std::mem::size_of::<GpuDummy>(), 12);
-        assert_eq!(std::mem::align_of::<GpuDummy>(), 4);
-        assert_eq!(std::mem::size_of::<GpuDummyComposed>(), 16); // tight packing
-        assert_eq!(std::mem::align_of::<GpuDummyComposed>(), 4);
-        assert_eq!(std::mem::size_of::<GpuDummyLarge>(), 132 * 4); // tight packing
-        assert_eq!(std::mem::align_of::<GpuDummyLarge>(), 4);
+        assert_eq!(size_of::<GpuDummy>(), 12);
+        assert_eq!(align_of::<GpuDummy>(), 4);
+        assert_eq!(size_of::<GpuDummyComposed>(), 16); // tight packing
+        assert_eq!(align_of::<GpuDummyComposed>(), 4);
+        assert_eq!(size_of::<GpuDummyLarge>(), 132 * 4); // tight packing
+        assert_eq!(align_of::<GpuDummyLarge>(), 4);
 
         // GPU
         assert_eq!(<GpuDummy as ShaderType>::min_size().get(), 16); // Vec3 gets padded to 16 bytes
@@ -420,7 +420,7 @@ mod gpu_tests {
         for i in 0..3 {
             let offset = i * final_align as usize;
             let dummy_composed: &[GpuDummyComposed] =
-                cast_slice(&view[offset..offset + std::mem::size_of::<GpuDummyComposed>()]);
+                cast_slice(&view[offset..offset + size_of::<GpuDummyComposed>()]);
             assert_eq!(dummy_composed[0].tag, (i + 1) as u32);
         }
     }

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -116,7 +116,7 @@ pub struct BufferTable<T: Pod + ShaderSize> {
 
 impl<T: Pod + ShaderSize> Default for BufferTable<T> {
     fn default() -> Self {
-        let item_size = std::mem::size_of::<T>();
+        let item_size = size_of::<T>();
         let aligned_size = <T as ShaderSize>::SHADER_SIZE.get() as usize;
         assert!(aligned_size >= item_size);
         Self {
@@ -553,12 +553,12 @@ mod tests {
     #[test]
     fn table_sizes() {
         // Rust
-        assert_eq!(std::mem::size_of::<GpuDummy>(), 12);
-        assert_eq!(std::mem::align_of::<GpuDummy>(), 4);
-        assert_eq!(std::mem::size_of::<GpuDummyComposed>(), 16); // tight packing
-        assert_eq!(std::mem::align_of::<GpuDummyComposed>(), 4);
-        assert_eq!(std::mem::size_of::<GpuDummyLarge>(), 132 * 4); // tight packing
-        assert_eq!(std::mem::align_of::<GpuDummyLarge>(), 4);
+        assert_eq!(size_of::<GpuDummy>(), 12);
+        assert_eq!(align_of::<GpuDummy>(), 4);
+        assert_eq!(size_of::<GpuDummyComposed>(), 16); // tight packing
+        assert_eq!(align_of::<GpuDummyComposed>(), 4);
+        assert_eq!(size_of::<GpuDummyLarge>(), 132 * 4); // tight packing
+        assert_eq!(align_of::<GpuDummyLarge>(), 4);
 
         // GPU
         assert_eq!(<GpuDummy as ShaderType>::min_size().get(), 16); // Vec3 gets padded to 16 bytes
@@ -815,7 +815,7 @@ mod gpu_tests {
                 assert_eq!(view.len(), final_align as usize * table.capacity());
                 for i in 0..len {
                     let offset = i * final_align as usize;
-                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let item_size = size_of::<GpuDummyComposed>();
                     let src = &view[offset..offset + 16];
                     println!("{}", to_hex_string(src));
                     let dummy_composed: &[GpuDummyComposed] =
@@ -884,7 +884,7 @@ mod gpu_tests {
                 assert_eq!(view.len(), final_align as usize * table.capacity());
                 for i in 0..len {
                     let offset = i * final_align as usize;
-                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let item_size = size_of::<GpuDummyComposed>();
                     let src = &view[offset..offset + 16];
                     println!("{}", to_hex_string(src));
                     let dummy_composed: &[GpuDummyComposed] =
@@ -938,7 +938,7 @@ mod gpu_tests {
                 assert!(view.len() >= final_align as usize * table.capacity()); // note the >=, the buffer is over-allocated
                 for i in 0..len {
                     let offset = i * final_align as usize;
-                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let item_size = size_of::<GpuDummyComposed>();
                     let src = &view[offset..offset + 16];
                     println!("{}", to_hex_string(src));
                     let dummy_composed: &[GpuDummyComposed] =
@@ -992,7 +992,7 @@ mod gpu_tests {
                 assert!(view.len() >= final_align as usize * table.capacity()); // note the >=, the buffer is over-allocated
                 for i in 0..len {
                     let offset = i * final_align as usize;
-                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let item_size = size_of::<GpuDummyComposed>();
                     let src = &view[offset..offset + 16];
                     println!("{}", to_hex_string(src));
                     if i > 0 {
@@ -1053,7 +1053,7 @@ mod gpu_tests {
                 assert!(view.len() >= final_align as usize * table.capacity());
                 for i in 0..len {
                     let offset = i * final_align as usize;
-                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let item_size = size_of::<GpuDummyComposed>();
                     let src = &view[offset..offset + 16];
                     println!("{}", to_hex_string(src));
                     let dummy_composed: &[GpuDummyComposed] =
@@ -1112,7 +1112,7 @@ mod gpu_tests {
                 assert!(view.len() >= final_align as usize * table.capacity());
                 for i in 0..len {
                     let offset = i * final_align as usize;
-                    let item_size = std::mem::size_of::<GpuDummyComposed>();
+                    let item_size = size_of::<GpuDummyComposed>();
                     let src = &view[offset..offset + 16];
                     println!("{}", to_hex_string(src));
                     let dummy_composed: &[GpuDummyComposed] =

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -73,9 +73,9 @@ impl AllocatedBuffer {
 ///
 /// - During the [`RenderStage::Prepare`] stage, call
 ///   [`clear_previous_frame_resizes()`] to clear any stale buffer from the
-/// previous frame. Then insert new rows with [`insert()`] and if you made
-/// changes call [`allocate_gpu()`] at the end to allocate any new buffer
-/// needed.
+///   previous frame. Then insert new rows with [`insert()`] and if you made
+///   changes call [`allocate_gpu()`] at the end to allocate any new buffer
+///   needed.
 /// - During the [`RenderStage::Render`] stage, call [`write_buffer()`] from a
 ///   command encoder before using any row, to perform any buffer resize copy
 ///   pending.

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -322,7 +322,7 @@ impl EffectBuffer {
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: true },
                     has_dynamic_offset: false,
-                    min_binding_size: BufferSize::new(std::mem::size_of::<u32>() as u64),
+                    min_binding_size: BufferSize::new(size_of::<u32>() as u64),
                 },
                 count: None,
             },


### PR DESCRIPTION
Fixes #351