### PR TITLE
Fix shader binding bug

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1154,7 +1154,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
             .create_bind_group_layout("hanabi:buffer_layout_render", &entries);
 
         let mut layout = vec![self.view_layout.clone(), particles_buffer_layout];
-        let mut shader_defs = vec![];
+        let mut shader_defs = vec!["SPAWNER_READONLY".into()];
 
         // Key: PARTICLE_TEXTURE
         if key.has_image {

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -22,7 +22,12 @@ struct Spawner {
     inverse_transform: mat3x4<f32>, // transposed (row-major)
     spawn: i32,
     seed: u32,
+    // Can't use storage<read> with atomics
+#ifdef SPAWNER_READONLY
+    count: i32,
+#else
     count: atomic<i32>,
+#endif
     effect_index: u32,
 #ifdef SPAWNER_PADDING
     {{SPAWNER_PADDING}}


### PR DESCRIPTION
Fix a bug where the render shader attempts to bind the `Spawner` storage buffer as read-only, but that struct is defined as containing an atomic variable, which according to the WGSL specification requires write access. Add a pipeline define `SPAWNER_READONLY` to redefine that struct field as non-atomic, to allow read-only binding.