### PR TITLE
Remove `VERTEX_WRITABLE_STORAGE` from examples

### DIFF
--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -7,9 +7,7 @@
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{
-        camera::ScalingMode, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
-    },
+    render::camera::ScalingMode,
     sprite::{MaterialMesh2dBundle, Mesh2dHandle},
 };
 use bevy_hanabi::prelude::*;
@@ -19,11 +17,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -32,10 +25,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,2d=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -11,12 +11,8 @@
 //! are despawned when reaching the surface.
 
 use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{
-        camera::ScalingMode, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
-    },
+    core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*,
+    render::camera::ScalingMode,
 };
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
@@ -25,11 +21,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -38,10 +29,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,activate=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -30,12 +30,7 @@
 use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{
-        camera::Projection, render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin,
-    },
+    core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*, render::camera::Projection,
 };
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
@@ -44,11 +39,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -57,10 +47,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,billboard=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -5,12 +5,7 @@
 
 use std::f32::consts::FRAC_PI_2;
 
-use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
-};
+use bevy::{core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -21,11 +16,6 @@ mod utils;
 use texutils::make_anim_img;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -34,10 +24,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,circle=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -14,12 +14,7 @@
 //! to the projection on screen; however those particles are actually at a
 //! different depth, in front or behind the sphere.
 
-use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
-};
+use bevy::{core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -27,11 +22,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -40,10 +30,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,force_field=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -1,12 +1,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{
-        render_resource::WgpuFeatures, settings::WgpuSettings, view::RenderLayers, RenderPlugin,
-    },
+    core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*, render::view::RenderLayers,
 };
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
@@ -15,11 +10,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -28,10 +18,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,gradient=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -7,12 +7,7 @@
 
 use std::f32::consts::PI;
 
-use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
-};
+use bevy::{core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -23,11 +18,6 @@ mod utils;
 struct RotateSpeed(pub f32);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -36,10 +26,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,init=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -11,12 +11,7 @@
 //!   quickly, and during 2.25 seconds there's no particle, until the next burst
 //!   spawns some more.
 
-use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
-};
+use bevy::{core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -24,11 +19,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -37,10 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,lifetime=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -1,12 +1,7 @@
 //! Example of using random spawner params.
 //! Spawns a random number of particles at random times.
 
-use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
-};
+use bevy::{core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -14,11 +9,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -27,10 +17,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,random=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -10,12 +10,7 @@ use bevy::{
     log::LogPlugin,
     math::Vec3Swizzles,
     prelude::*,
-    render::{
-        camera::{Projection, ScalingMode},
-        render_resource::WgpuFeatures,
-        settings::WgpuSettings,
-        RenderPlugin,
-    },
+    render::camera::{Projection, ScalingMode},
 };
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
@@ -24,11 +19,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::linear_rgb(0.1, 0.1, 0.1)))
         .add_plugins(
@@ -37,10 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,spawn_on_command=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -12,12 +12,7 @@
 
 use std::time::Duration;
 
-use bevy::{
-    core_pipeline::tonemapping::Tonemapping,
-    log::LogPlugin,
-    prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
-};
+use bevy::{core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
 use bevy_hanabi::prelude::*;
 #[cfg(feature = "examples_world_inspector")]
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -25,11 +20,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 mod utils;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut wgpu_settings = WgpuSettings::default();
-    wgpu_settings
-        .features
-        .set(WgpuFeatures::VERTEX_WRITABLE_STORAGE, true);
-
     let mut app = App::default();
     app.insert_resource(ClearColor(Color::BLACK))
         .add_plugins(
@@ -38,10 +28,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     level: bevy::log::Level::INFO,
                     filter: "bevy_hanabi=warn,visibility=trace".to_string(),
                     ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {


### PR DESCRIPTION
The requesting of `VERTEX_WRITABLE_STORAGE` in all examples is a legacy from the very start of the project, which has no reason to be. We have already validated that everything works without it, and this creates confusion for users.

Fixes #317