### PR TITLE
Add support for texture sampling as expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This allows disabling support on wasm, where `typetag` is not available.
   The feature is enabled by default, so the behavior doesn't change on non-wasm targets.
 - Added support for WebAssembly (`wasm`). This requires disabling the `serde` feature. (#41)
+- Added support for sampling textures in the Expression API via the `TextureSampleExpr` expression.
+  Currently only supports color textures (no depth texture) and only sampling via WGSL `textureSample()`. (#355)
+- Added a new `EffectMaterial` component holding the actual textures to bind to the various slots of a `Module`.
+- Added a new `Module::add_texture()` function to declare a new texture slot in a module.
+
+### Changed
+
+- The `ParticleTextureModifier` doesn't directly hold the texture handle to use anymore.
+  Instead, it holds an expression handle to the texture slot defined in the `Module` of the effect.
+  This allows dynamically changing the texture sampled.
+- `RenderModifier::apply_render()` now returns a `Result<String, ExprError>`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ naga = "0.20"
 naga_oil = { version = "0.14", default-features = false, features = ["test_shader"] }
 
 [dependencies.bevy]
-version = "0.14.0"
+version = "0.14"
 default-features = false
 features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset", "x11" ]
 

--- a/build_examples_wasm.bat
+++ b/build_examples_wasm.bat
@@ -30,26 +30,25 @@ cargo b --release --example instancing --target wasm32-unknown-unknown --no-defa
 REM 2D
 cargo b --release --example 2d --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d"
 
-echo Bindgen all examples...
-wasm-bindgen --out-name wasm_firework --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/firework.wasm
-wasm-bindgen --out-name wasm_portal --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/portal.wasm
-wasm-bindgen --out-name wasm_expr --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/expr.wasm
-wasm-bindgen --out-name wasm_spawn --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/spawn.wasm
-wasm-bindgen --out-name wasm_multicam --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/multicam.wasm
-wasm-bindgen --out-name wasm_visibility --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/visibility.wasm
-wasm-bindgen --out-name wasm_random --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/random.wasm
-wasm-bindgen --out-name wasm_spawn_on_command --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/spawn_on_command.wasm
-wasm-bindgen --out-name wasm_activate --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/activate.wasm
-wasm-bindgen --out-name wasm_force_field --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/force_field.wasm
-wasm-bindgen --out-name wasm_init --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/init.wasm
-wasm-bindgen --out-name wasm_lifetime --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/lifetime.wasm
-wasm-bindgen --out-name wasm_ordering --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/ordering.wasm
-wasm-bindgen --out-name wasm_ribbon --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/ribbon.wasm
-wasm-bindgen --out-name wasm_gradient --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/gradient.wasm
-wasm-bindgen --out-name wasm_circle --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/circle.wasm
-wasm-bindgen --out-name wasm_billboard --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/billboard.wasm
-wasm-bindgen --out-name wasm_worms --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/worms.wasm
-wasm-bindgen --out-name wasm_instancing --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/instancing.wasm
-wasm-bindgen --out-name wasm_2d --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/2d.wasm
+wasm-bindgen --out-name wasm_firework --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/firework.wasm
+wasm-bindgen --out-name wasm_portal --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/portal.wasm
+wasm-bindgen --out-name wasm_expr --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/expr.wasm
+wasm-bindgen --out-name wasm_spawn --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/spawn.wasm
+wasm-bindgen --out-name wasm_multicam --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/multicam.wasm
+wasm-bindgen --out-name wasm_visibility --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/visibility.wasm
+wasm-bindgen --out-name wasm_random --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/random.wasm
+wasm-bindgen --out-name wasm_spawn_on_command --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/spawn_on_command.wasm
+wasm-bindgen --out-name wasm_activate --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/activate.wasm
+wasm-bindgen --out-name wasm_force_field --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/force_field.wasm
+wasm-bindgen --out-name wasm_init --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/init.wasm
+wasm-bindgen --out-name wasm_lifetime --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/lifetime.wasm
+wasm-bindgen --out-name wasm_ordering --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/ordering.wasm
+wasm-bindgen --out-name wasm_ribbon --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/ribbon.wasm
+wasm-bindgen --out-name wasm_gradient --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/gradient.wasm
+wasm-bindgen --out-name wasm_circle --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/circle.wasm
+wasm-bindgen --out-name wasm_billboard --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/billboard.wasm
+wasm-bindgen --out-name wasm_worms --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/worms.wasm
+wasm-bindgen --out-name wasm_instancing --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/instancing.wasm
+wasm-bindgen --out-name wasm_2d --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/2d.wasm
 
 echo Done. See docs/wasm.md for help on running the examples locally.

--- a/deny.toml
+++ b/deny.toml
@@ -1,31 +1,26 @@
+[graph]
+all-features = true
+
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "deny"
-yanked = "deny"
-notice = "deny"
-ignore = [
-]
+ignore = []
 
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
 allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
     "MIT",
     "MIT-0",
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "ISC",
     "Zlib",
-    "0BSD",
-    "BSD-2-Clause",
-    "CC0-1.0",
 ]
 exceptions = [
     { name = "unicode-ident", allow = ["Unicode-DFS-2016"] },
 ]
-default = "deny"
 
 [bans]
 multiple-versions = "warn"

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -136,8 +136,13 @@ fn setup(
     // per-particle rotation)
     let rotation_attr = writer.attr(Attribute::F32_0).expr();
 
+    let texture_slot = writer.lit(0u32).expr();
+
+    let mut module = writer.finish();
+    module.add_texture("color");
+
     let effect = effects.add(
-        EffectAsset::new(vec![32768], Spawner::rate(64.0.into()), writer.finish())
+        EffectAsset::new(vec![32768], Spawner::rate(64.0.into()), module)
             .with_name("billboard")
             .with_alpha_mode(bevy_hanabi::AlphaMode::Mask(alpha_cutoff))
             .init(init_pos)
@@ -147,7 +152,7 @@ fn setup(
             .init(init_rotation)
             .init(init_color)
             .render(ParticleTextureModifier {
-                texture: texture_handle,
+                texture_slot: texture_slot,
                 sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(OrientModifier {
@@ -173,9 +178,13 @@ fn setup(
         })
         .insert(Name::new("ground"));
 
-    commands
-        .spawn(ParticleEffectBundle::new(effect))
-        .insert(Name::new("effect"));
+    commands.spawn((
+        ParticleEffectBundle::new(effect),
+        EffectMaterial {
+            images: vec![texture_handle],
+        },
+        Name::new("effect"),
+    ));
 }
 
 fn rotate_camera(time: Res<Time>, mut query: Query<&mut Transform, With<Camera>>) {

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -131,11 +131,12 @@ fn setup(
 
     // Make each particle round.
     let particle_texture_modifier = ParticleTextureModifier {
-        texture: circle,
+        texture_slot: writer.lit(0u32).expr(),
         sample_mapping: ImageSampleMapping::Modulate,
     };
 
-    let module = writer.finish();
+    let mut module = writer.finish();
+    module.add_texture("shape");
 
     // Allocate room for 32,768 trail particles. Give each particle a 5-particle
     // trail, and spawn a new trail particle every ⅛ of a second.
@@ -166,6 +167,9 @@ fn setup(
             effect: ParticleEffect::new(effect),
             transform: Transform::IDENTITY,
             ..default()
+        },
+        EffectMaterial {
+            images: vec![circle],
         },
     ));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -971,7 +971,7 @@ impl EffectShaderSource {
                     RenderContext::new(&property_layout, &particle_layout, &texture_layout);
                 for m in asset.render_modifiers_for_group(group_index) {
                     m.apply_render(&mut module, &mut render_context)
-                        .map_err(|expr_error| ShaderGenerateError::Expr(expr_error))?;
+                        .map_err(ShaderGenerateError::Expr)?;
                 }
 
                 if render_context.needs_uv {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,6 +666,39 @@ impl ParticleEffect {
     }
 }
 
+/// Material for an effect instance.
+///
+/// A material component contains the render resources (textures) actually bound
+/// to the slots defined in an effect's [`Module`]. That way, a same effect can
+/// be rendered multiple times with different sets of textures.
+///
+/// The [`EffectMaterial`] component needs to be spawned on the same entity as
+/// the [`ParticleEffect`].
+#[derive(Debug, Default, Clone, Component)]
+pub struct EffectMaterial {
+    /// List of images to use to render the effect instance.
+    pub images: Vec<Handle<Image>>,
+}
+
+/// Texture slot of a [`Module`].
+///
+/// A texture slot defines a named bind point where a texture can be attached
+/// and sampled by an effect during rendering.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+pub struct TextureSlot {
+    /// Unique slot name.
+    pub name: String,
+}
+
+/// Texture layout.
+///
+/// Defines the list of texture slots for an effect.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+pub struct TextureLayout {
+    /// The list of slots.
+    pub layout: Vec<TextureSlot>,
+}
+
 /// Effect shader.
 ///
 /// Contains the configured shaders for the init, update, and render passes.
@@ -688,7 +721,6 @@ struct EffectShaderSource {
     pub update: Vec<String>,
     pub render: Vec<String>,
     pub layout_flags: LayoutFlags,
-    pub particle_texture: Option<Handle<Image>>,
 }
 
 /// Error resulting from the generating of the WGSL shader code of an
@@ -842,13 +874,12 @@ impl EffectShaderSource {
                 }
             }
 
-            let sim_space_transform_code = match asset.simulation_space.eval(&init_context) {
-                Ok(s) => s,
-                Err(err) => {
+            let sim_space_transform_code =
+                asset.simulation_space.eval(&init_context).map_err(|err| {
                     error!("Failed to compile effect's simulation space: {:?}", err);
-                    return Err(ShaderGenerateError::Expr(err));
-                }
-            };
+                    ShaderGenerateError::Expr(err)
+                })?;
+
             (
                 init_context.main_code,
                 init_context.extra_code,
@@ -877,8 +908,6 @@ impl EffectShaderSource {
         if let AlphaMode::Mask(_) = &asset.alpha_mode {
             layout_flags |= LayoutFlags::USE_ALPHA_MASK;
         }
-
-        let mut effect_particle_texture = None;
 
         let (mut update_shader_sources, mut render_shader_sources) = (vec![], vec![]);
         for group_index in 0..(asset.capacities().len() as u32) {
@@ -935,11 +964,14 @@ impl EffectShaderSource {
                 alpha_cutoff_code,
                 flipbook_scale_code,
                 flipbook_row_count_code,
-                image_sample_mapping_code,
+                material_bindings_code,
             ) = {
-                let mut render_context = RenderContext::new(&property_layout, &particle_layout);
+                let texture_layout = module.texture_layout();
+                let mut render_context =
+                    RenderContext::new(&property_layout, &particle_layout, &texture_layout);
                 for m in asset.render_modifiers_for_group(group_index) {
-                    m.apply_render(&mut module, &mut render_context);
+                    m.apply_render(&mut module, &mut render_context)
+                        .map_err(|expr_error| ShaderGenerateError::Expr(expr_error))?;
                 }
 
                 if render_context.needs_uv {
@@ -978,9 +1010,17 @@ impl EffectShaderSource {
                         (String::new(), String::new())
                     };
 
-                // FIXME: What about multiple textures?
-                if let Some(particle_texture) = render_context.particle_texture {
-                    effect_particle_texture = Some(particle_texture);
+                trace!(
+                    "Generating material bindings code for layout: {:?}",
+                    texture_layout
+                );
+                let mut material_bindings_code = String::new();
+                for (slot, _) in texture_layout.layout.iter().enumerate() {
+                    material_bindings_code.push_str(&format!(
+                        "@group(2) @binding(0) var material_texture_{slot}: texture_2d<f32>;
+@group(2) @binding(1) var material_sampler_{slot}: sampler;
+"
+                    ));
                 }
 
                 (
@@ -990,7 +1030,7 @@ impl EffectShaderSource {
                     alpha_cutoff_code,
                     flipbook_scale_code,
                     flipbook_row_count_code,
-                    render_context.image_sample_mapping_code,
+                    material_bindings_code,
                 )
             };
 
@@ -1050,16 +1090,13 @@ impl EffectShaderSource {
             let render_shader_source = PARTICLES_RENDER_SHADER_TEMPLATE
                 .replace("{{ATTRIBUTES}}", &attributes_code)
                 .replace("{{INPUTS}}", &inputs_code)
+                .replace("{{MATERIAL_BINDINGS}}", &material_bindings_code)
                 .replace("{{VERTEX_MODIFIERS}}", &vertex_code)
                 .replace("{{FRAGMENT_MODIFIERS}}", &fragment_code)
                 .replace("{{RENDER_EXTRA}}", &render_extra)
                 .replace("{{ALPHA_CUTOFF}}", &alpha_cutoff_code)
                 .replace("{{FLIPBOOK_SCALE}}", &flipbook_scale_code)
-                .replace("{{FLIPBOOK_ROW_COUNT}}", &flipbook_row_count_code)
-                .replace(
-                    "{{PARTICLE_TEXTURE_SAMPLE_MAPPING}}",
-                    &image_sample_mapping_code,
-                );
+                .replace("{{FLIPBOOK_ROW_COUNT}}", &flipbook_row_count_code);
             trace!("Configured render shader:\n{}", render_shader_source);
 
             update_shader_sources.push(update_shader_source);
@@ -1071,7 +1108,6 @@ impl EffectShaderSource {
             update: update_shader_sources,
             render: render_shader_sources,
             layout_flags,
-            particle_texture: effect_particle_texture,
         })
     }
 }
@@ -1099,8 +1135,8 @@ pub struct CompiledParticleEffect {
     simulation_condition: SimulationCondition,
     /// Handle to the effect shader for his effect instance, if configured.
     effect_shader: Option<EffectShader>,
-    /// Main particle texture.
-    particle_texture: Option<Handle<Image>>,
+    /// Textures used by the effect, if any.
+    textures: Vec<Handle<Image>>,
     /// 2D layer for the effect instance.
     #[cfg(feature = "2d")]
     z_layer_2d: FloatOrd,
@@ -1116,7 +1152,7 @@ impl Default for CompiledParticleEffect {
             asset: default(),
             simulation_condition: SimulationCondition::default(),
             effect_shader: None,
-            particle_texture: None,
+            textures: vec![],
             #[cfg(feature = "2d")]
             z_layer_2d: FloatOrd(0.0),
             layout_flags: LayoutFlags::NONE,
@@ -1130,7 +1166,7 @@ impl CompiledParticleEffect {
     pub(crate) fn clear(&mut self) {
         self.asset = Handle::default();
         self.effect_shader = None;
-        self.particle_texture = None;
+        self.textures.clear();
     }
 
     /// Update the compiled effect from its asset and instance.
@@ -1138,7 +1174,8 @@ impl CompiledParticleEffect {
         &mut self,
         rebuild: bool,
         #[cfg(feature = "2d")] z_layer_2d: FloatOrd,
-        handle: Handle<EffectAsset>,
+        instance: &ParticleEffect,
+        material: Option<&EffectMaterial>,
         asset: &EffectAsset,
         shaders: &mut ResMut<Assets<Shader>>,
         shader_cache: &mut ResMut<ShaderCache>,
@@ -1147,21 +1184,21 @@ impl CompiledParticleEffect {
             "Updating (rebuild:{}) compiled particle effect '{}' ({:?})",
             rebuild,
             asset.name,
-            handle
+            instance.handle,
         );
 
         // #289 - Panic in fn extract_effects
         // We now keep a strong handle. Since CompiledParticleEffect is kept in sync
         // with the source ParticleEffect, this shouldn't produce any strong cyclic
         // dependency.
-        debug_assert!(handle.is_strong());
+        debug_assert!(instance.handle.is_strong());
 
         // Note: if something marked the ParticleEffect as changed (via Mut for example)
         // but didn't actually change anything, or at least didn't change the asset,
         // then we may end up here with the same asset handle. Don't try to be
         // too smart, and rebuild everything anyway, it's easier than trying to
         // diff what may or may not have changed.
-        self.asset = handle;
+        self.asset = instance.handle.clone();
         self.simulation_condition = asset.simulation_condition;
 
         // Check if the instance changed. If so, rebuild some data from this compiled
@@ -1211,11 +1248,11 @@ impl CompiledParticleEffect {
             .collect();
 
         trace!(
-            "CompiledParticleEffect::update(): init_shader={:?} update_shaders={:?} render_shaders={:?} has_image={} layout_flags={:?}",
+            "CompiledParticleEffect::update(): init_shader={:?} update_shaders={:?} render_shaders={:?} texture_count={} layout_flags={:?}",
             init_shader,
             update_shaders,
             render_shaders,
-            shader_source.particle_texture.is_some(),
+            material.map(|mat| mat.images.len()).unwrap_or(0),
             self.layout_flags,
         );
 
@@ -1232,7 +1269,7 @@ impl CompiledParticleEffect {
             render: render_shaders,
         });
 
-        self.particle_texture = shader_source.particle_texture;
+        self.textures = material.map(|mat| &mat.images).cloned().unwrap_or_default();
     }
 
     /// Get the effect shader if configured, or `None` otherwise.
@@ -1350,26 +1387,32 @@ fn compile_effects(
     effects: Res<Assets<EffectAsset>>,
     mut shaders: ResMut<Assets<Shader>>,
     mut shader_cache: ResMut<ShaderCache>,
-    mut q_effects: Query<(Entity, Ref<ParticleEffect>, &mut CompiledParticleEffect)>,
+    mut q_effects: Query<(
+        Entity,
+        Ref<ParticleEffect>,
+        Option<Ref<EffectMaterial>>,
+        &mut CompiledParticleEffect,
+    )>,
 ) {
     trace!("compile_effects");
 
     // Loop over all existing effects to update them, including invisible ones
-    for (asset, entity, effect, mut compiled_effect) in
+    for (asset, entity, effect, material, mut compiled_effect) in
         q_effects
             .iter_mut()
-            .filter_map(|(entity, effect, compiled_effect)| {
+            .filter_map(|(entity, effect, material, compiled_effect)| {
                 // Check if asset is available, otherwise silently ignore as we can't check for
                 // changes, and conceptually it makes no sense to render a particle effect whose
                 // asset was unloaded.
                 let asset = effects.get(&effect.handle)?;
 
-                Some((asset, entity, effect, compiled_effect))
+                Some((asset, entity, effect, material, compiled_effect))
             })
     {
         // If the ParticleEffect didn't change, and the compiled one is for the correct
         // asset, then there's nothing to do.
-        let need_rebuild = effect.is_changed();
+        let need_rebuild =
+            effect.is_changed() || material.as_ref().map_or(false, |r| r.is_changed());
         if !need_rebuild && (compiled_effect.asset == effect.handle) {
             continue;
         }
@@ -1389,7 +1432,8 @@ fn compile_effects(
             need_rebuild,
             #[cfg(feature = "2d")]
             z_layer_2d,
-            effect.handle.clone(),
+            &effect,
+            material.map(|r| r.into_inner()),
             asset,
             &mut shaders,
             &mut shader_cache,
@@ -1397,7 +1441,7 @@ fn compile_effects(
     }
 
     // Clear removed effects, to allow them to be released by the asset server
-    for (_, effect, mut compiled_effect) in q_effects.iter_mut() {
+    for (_, effect, _, mut compiled_effect) in q_effects.iter_mut() {
         if effects.get(&effect.handle).is_none() {
             compiled_effect.clear();
         }
@@ -1679,7 +1723,8 @@ else { return c1; }
         {
             // In the render context, the particle position is always available (either
             // stored or not), so the simulation space can always be evaluated.
-            let ctx = RenderContext::new(&property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let ctx = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_ok());
         }
@@ -1787,7 +1832,6 @@ else { return c1; }
 
             let mut shader_defs = std::collections::HashMap::<String, ShaderDefValue>::new();
             shader_defs.insert("LOCAL_SPACE_SIMULATION".into(), ShaderDefValue::Bool(true));
-            shader_defs.insert("PARTICLE_TEXTURE".into(), ShaderDefValue::Bool(true));
             shader_defs.insert("NEEDS_UV".into(), ShaderDefValue::Bool(true));
             shader_defs.insert("RENDER_NEEDS_SPAWNER".into(), ShaderDefValue::Bool(true));
             shader_defs.insert(

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -62,26 +62,42 @@ impl ToWgslString for ImageSampleMapping {
 /// # Attributes
 ///
 /// This modifier does not require any specific particle attribute.
-#[derive(Default, Debug, Clone, PartialEq, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
 pub struct ParticleTextureModifier {
-    /// The texture image to modulate the particle color with.
-    #[serde(skip)]
-    // TODO - Clarify if Modifier needs to be serializable, or we need another on-disk
-    // representation... NOTE - Need to keep a strong handle here, nothing else will keep that
-    // texture loaded currently.
-    pub texture: Handle<Image>,
+    /// Index of the texture slot containing the texture to use. The slot is
+    /// defined in the [`Module`], and the actual texture is bound via the
+    /// [`EffectMaterial`] component.
+    ///
+    /// [`EffectMaterial`]: crate::EffectMaterial
+    pub texture_slot: ExprHandle,
 
     /// The mapping of the texture image samples to the base particle color.
     pub sample_mapping: ImageSampleMapping,
+}
+
+impl ParticleTextureModifier {
+    /// Create a new modifier with the default [`ImageSampleMapping`].
+    pub fn new(texture_slot: ExprHandle) -> Self {
+        Self {
+            texture_slot,
+            sample_mapping: default(),
+        }
+    }
 }
 
 impl_mod_render!(ParticleTextureModifier, &[]); // TODO - should require some UV maybe?
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for ParticleTextureModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
-        context.set_particle_texture(self.texture.clone());
-        context.image_sample_mapping_code = self.sample_mapping.to_wgsl_string();
+    fn apply_render(
+        &self,
+        module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
+        context.set_needs_uv();
+        let code = self.eval(module, context)?;
+        context.fragment_code += &code;
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -90,6 +106,44 @@ impl RenderModifier for ParticleTextureModifier {
 
     fn as_modifier(&self) -> &dyn Modifier {
         self
+    }
+}
+
+impl ParticleTextureModifier {
+    /// Evaluate the modifier to generate the shader code.
+    pub fn eval(
+        &self,
+        module: &Module,
+        context: &mut dyn EvalContext,
+    ) -> Result<String, ExprError> {
+        let texture_slot = module.try_get(self.texture_slot)?;
+        let texture_slot = texture_slot.eval(module, context)?;
+        let sample_mapping = self.sample_mapping.to_wgsl_string();
+
+        let sample_mapping_name = format!("{:?}", self.sample_mapping);
+
+        // Build a switch statement to select the texture/sampler.
+        // FIXME - Ideally with bindless (texture/sampler arrays with dynamic indices)
+        // we don't need this. But bindless is not available on Web anyway, so this is a
+        // safe fallback.
+        let mut code = String::with_capacity(1024);
+        code += &format!(
+            "    // ParticleTextureModifier
+    var texColor: vec4<f32>;
+    switch ({texture_slot}) {{\n"
+        );
+        let count = module.texture_layout().layout.len() as u32;
+        for index in 0..count {
+            let wgsl_index = index.to_wgsl_string();
+            code += &format!("      case {wgsl_index}: {{ texColor = textureSample(material_texture_{index}, material_sampler_{index}, uv); }}\n");
+        }
+        code += &format!("      default: {{ texColor = vec4<f32>(0.0); }}\n");
+        code += &format!(
+            "    }}
+    // Sample mapping: {sample_mapping_name}
+    {sample_mapping}"
+        );
+        Ok(code)
     }
 }
 
@@ -112,8 +166,13 @@ impl_mod_render!(SetColorModifier, &[]);
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for SetColorModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        _module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         context.vertex_code += &format!("color = {0};\n", self.color.to_wgsl_string());
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -146,7 +205,11 @@ impl_mod_render!(
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for ColorOverLifetimeModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        _module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         let func_name = context.add_color_gradient(self.gradient.clone());
         context.render_extra += &format!(
             r#"fn {0}(key: f32) -> vec4<f32> {{
@@ -164,6 +227,8 @@ impl RenderModifier for ColorOverLifetimeModifier {
             Attribute::AGE.name(),
             Attribute::LIFETIME.name()
         );
+
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -197,8 +262,13 @@ impl_mod_render!(SetSizeModifier, &[]);
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for SetSizeModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        _module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         context.vertex_code += &format!("size = {0};\n", self.size.to_wgsl_string());
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -235,7 +305,11 @@ impl_mod_render!(
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for SizeOverLifetimeModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        _module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         let func_name = context.add_size_gradient(self.gradient.clone());
         context.render_extra += &format!(
             r#"fn {0}(key: f32) -> vec2<f32> {{
@@ -253,6 +327,8 @@ impl RenderModifier for SizeOverLifetimeModifier {
             Attribute::AGE.name(),
             Attribute::LIFETIME.name()
         );
+
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -396,11 +472,15 @@ impl Modifier for OrientModifier {
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for OrientModifier {
-    fn apply_render(&self, module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         match self.mode {
             OrientMode::ParallelCameraDepthPlane => {
                 if let Some(rotation) = self.rotation {
-                    let rotation = context.eval(module, rotation).unwrap();
+                    let rotation = context.eval(module, rotation)?;
                     context.vertex_code += &format!(
                         r#"let cam_rot = get_camera_rotation_effect_space();
 let particle_rot_in_cam_space = {};
@@ -422,7 +502,7 @@ axis_z = cam_rot[2].xyz;
             }
             OrientMode::FaceCameraPosition => {
                 if let Some(rotation) = self.rotation {
-                    let rotation = context.eval(module, rotation).unwrap();
+                    let rotation = context.eval(module, rotation)?;
                     context.vertex_code += &format!(
                         r#"axis_z = normalize(get_camera_position_effect_space() - position);
 let particle_rot_in_cam_space = {};
@@ -450,6 +530,8 @@ axis_z = cross(axis_x, axis_y);
 "#;
             }
         }
+
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -507,6 +589,8 @@ axis_z = cross(axis_x, axis_y);
 ///     .expr();
 /// let update_sprite_index = SetAttributeModifier::new(Attribute::SPRITE_INDEX, sprite_index);
 ///
+/// let texture_slot = writer.lit(0u32).expr();
+///
 /// let asset = EffectAsset::new(
 ///     vec![32768],
 ///     Spawner::once(32.0.into(), true),
@@ -517,7 +601,7 @@ axis_z = cross(axis_x, axis_y);
 /// .init(init_lifetime)
 /// .update(update_sprite_index)
 /// .render(ParticleTextureModifier {
-///     texture,
+///     texture_slot,
 ///     sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
 /// })
 /// .render(FlipbookModifier {
@@ -561,8 +645,13 @@ impl_mod_render!(FlipbookModifier, &[Attribute::SPRITE_INDEX]);
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for FlipbookModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        _module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         context.sprite_grid_size = Some(self.sprite_grid_size);
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -604,7 +693,11 @@ impl_mod_render!(
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for ScreenSpaceSizeModifier {
-    fn apply_render(&self, _module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        _module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         // Get perspective divide factor from clip space position. This is the "average"
         // factor for the entire particle, taken at its position (mesh origin),
         // and applied uniformly for all vertices. Scale size by w_cs to negate
@@ -620,6 +713,7 @@ impl RenderModifier for ScreenSpaceSizeModifier {
             let projection_scale = vec2<f32>(view.clip_from_view[0][0], view.clip_from_view[1][1]);\n
             size = (size * w_cs * 2.0) / min(screen_size_pixels.x * projection_scale.x, screen_size_pixels.y * projection_scale.y);\n",
             Attribute::POSITION.name());
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -661,10 +755,14 @@ impl_mod_render!(RoundModifier, &[]);
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for RoundModifier {
-    fn apply_render(&self, module: &mut Module, context: &mut RenderContext) {
+    fn apply_render(
+        &self,
+        module: &mut Module,
+        context: &mut RenderContext,
+    ) -> Result<(), ExprError> {
         context.set_needs_uv();
 
-        let roundness = context.eval(module, self.roundness).unwrap();
+        let roundness = context.eval(module, self.roundness)?;
         context.fragment_code += &format!(
             "let roundness = {};
             if (roundness > 0.0f) {{
@@ -676,6 +774,8 @@ impl RenderModifier for RoundModifier {
             }}",
             roundness
         );
+
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
@@ -711,20 +811,20 @@ mod tests {
 
     #[test]
     fn mod_particle_texture() {
-        let texture = Handle::<Image>::default();
-        let modifier = ParticleTextureModifier {
-            texture: texture.clone(),
-            ..default()
-        };
-
         let mut module = Module::default();
+        let slot = module.lit(42u32);
+        // let texture = Handle::<Image>::default();
+        let modifier = ParticleTextureModifier::new(slot);
+
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
-        assert!(context.particle_texture.is_some());
-        assert_eq!(context.particle_texture.unwrap(), texture);
+        // TODO - no validation at the minute
+        assert_eq!(context.texture_layout.layout.len(), 0); // we "forgot" to add the slot to Module
+        assert_eq!(context.textures.len(), 0); // we "forgot" the EffectMaterial
     }
 
     #[test]
@@ -736,8 +836,9 @@ mod tests {
         let mut module = Module::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         assert!(context.sprite_grid_size.is_some());
         assert_eq!(context.sprite_grid_size.unwrap(), UVec2::new(3, 4));
@@ -757,8 +858,9 @@ mod tests {
         let mut module = Module::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         assert!(context
             .render_extra
@@ -780,8 +882,9 @@ mod tests {
         let mut module = Module::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         assert!(context
             .render_extra
@@ -799,8 +902,9 @@ mod tests {
         let mut module = Module::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         assert_eq!(modifier.color, CpuValue::from(Vec4::ZERO));
         assert_eq!(context.vertex_code, "color = vec4<f32>(0.,0.,0.,0.);\n");
@@ -817,8 +921,9 @@ mod tests {
         let mut module = Module::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         assert_eq!(modifier.size, CpuValue::from(Vec2::ZERO));
         assert_eq!(context.vertex_code, "size = vec2<f32>(0.,0.);\n");
@@ -839,8 +944,9 @@ mod tests {
         let modifier = OrientModifier::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         // TODO - less weak test...
         assert!(context
@@ -858,8 +964,9 @@ mod tests {
         let modifier = OrientModifier::default().with_rotation(module.lit(1.));
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         // TODO - less weak test...
         assert!(context
@@ -878,8 +985,9 @@ mod tests {
             OrientModifier::new(OrientMode::FaceCameraPosition).with_rotation(module.lit(1.));
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context = RenderContext::new(&property_layout, &particle_layout);
-        modifier.apply_render(&mut module, &mut context);
+        let texture_layout = module.texture_layout();
+        let mut context = RenderContext::new(&property_layout, &particle_layout, &texture_layout);
+        modifier.apply_render(&mut module, &mut context).unwrap();
 
         // TODO - less weak test...
         assert!(context

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -101,7 +101,7 @@ impl RenderModifier for ParticleTextureModifier {
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {
-        Box::new(self.clone())
+        Box::new(*self)
     }
 
     fn as_modifier(&self) -> &dyn Modifier {
@@ -137,7 +137,7 @@ impl ParticleTextureModifier {
             let wgsl_index = index.to_wgsl_string();
             code += &format!("      case {wgsl_index}: {{ texColor = textureSample(material_texture_{index}, material_sampler_{index}, uv); }}\n");
         }
-        code += &format!("      default: {{ texColor = vec4<f32>(0.0); }}\n");
+        code += "      default: {{ texColor = vec4<f32>(0.0); }}\n";
         code += &format!(
             "    }}
     // Sample mapping: {sample_mapping_name}

--- a/src/modifier/ribbon.rs
+++ b/src/modifier/ribbon.rs
@@ -20,7 +20,7 @@ impl_mod_render!(RibbonModifier, &[Attribute::PREV, Attribute::NEXT]);
 
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl RenderModifier for RibbonModifier {
-    fn apply_render(&self, _: &mut Module, context: &mut RenderContext) {
+    fn apply_render(&self, _: &mut Module, context: &mut RenderContext) -> Result<(), ExprError> {
         context.vertex_code += r##"
     let next_index = particle.next;
     if (next_index >= arrayLength(&particle_buffer.particles)) {
@@ -38,6 +38,8 @@ impl RenderModifier for RibbonModifier {
     position = mix(next_particle.position, particle.position, 0.5);
     size = vec2(length(delta), size.y);
 "##;
+
+        Ok(())
     }
 
     fn boxed_render_clone(&self) -> Box<dyn RenderModifier> {

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -11,7 +11,7 @@ use super::{
     effect_cache::{DispatchBufferIndices, EffectSlices},
     EffectCacheId, GpuCompressedTransform, LayoutFlags,
 };
-use crate::{AlphaMode, EffectAsset, EffectShader, ParticleLayout, PropertyLayout};
+use crate::{AlphaMode, EffectAsset, EffectShader, ParticleLayout, PropertyLayout, TextureLayout};
 
 /// Data needed to render all batches pertaining to a specific effect.
 #[derive(Debug, Component)]
@@ -39,6 +39,10 @@ pub(crate) struct EffectBatches {
     pub particle_layout: ParticleLayout,
     /// Flags describing the render layout.
     pub layout_flags: LayoutFlags,
+    /// Texture layout.
+    pub texture_layout: TextureLayout,
+    /// Textures.
+    pub textures: Vec<Handle<Image>>,
     /// Alpha mode.
     pub alpha_mode: AlphaMode,
     /// Entities holding the source [`ParticleEffect`] instances which were
@@ -46,10 +50,6 @@ pub(crate) struct EffectBatches {
     ///
     /// [`ParticleEffect`]: crate::ParticleEffect
     pub entities: Vec<u32>,
-    /// Texture to modulate the particle color.
-    ///
-    /// TODO: We should support more than one of these.
-    pub image_handle: Handle<Image>,
     /// Configured shaders used for the particle rendering of this batch.
     /// Note that we don't need to keep the init/update shaders alive because
     /// their pipeline specialization is doing it via the specialization key.
@@ -126,8 +126,9 @@ impl EffectBatches {
                 .collect(),
             handle: input.handle,
             layout_flags: input.layout_flags,
+            texture_layout: input.texture_layout,
+            textures: input.textures,
             alpha_mode: input.alpha_mode,
-            image_handle: input.image_handle,
             render_shaders: input.effect_shader.render,
             init_pipeline_id,
             update_pipeline_ids,
@@ -152,10 +153,12 @@ pub(crate) struct BatchesInput {
     pub effect_shader: EffectShader,
     /// Various flags related to the effect.
     pub layout_flags: LayoutFlags,
+    /// Texture layout.
+    pub texture_layout: TextureLayout,
+    /// Textures.
+    pub textures: Vec<Handle<Image>>,
     /// Alpha mode.
     pub alpha_mode: AlphaMode,
-    /// Texture to modulate the particle color.
-    pub image_handle: Handle<Image>,
     /// Number of particles to spawn for this effect.
     pub spawn_count: u32,
     /// Emitter transform.

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -58,7 +58,7 @@ use crate::{
     spawn::EffectSpawner,
     AlphaMode, CompiledParticleEffect, EffectProperties, EffectShader, EffectSimulation,
     HanabiPlugin, ParticleLayout, PropertyLayout, RemovedEffectsEvent, SimulationCondition,
-    ToWgslString,
+    TextureLayout, ToWgslString,
 };
 
 mod aligned_buffer_vec;
@@ -920,7 +920,63 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
 pub(crate) struct ParticlesRenderPipeline {
     render_device: RenderDevice,
     view_layout: BindGroupLayout,
-    material_layout: BindGroupLayout,
+    material_layouts: HashMap<TextureLayout, BindGroupLayout>,
+}
+
+impl ParticlesRenderPipeline {
+    /// Cache a material, creating its bind group layout based on the texture
+    /// layout.
+    pub fn cache_material(&mut self, layout: &TextureLayout) {
+        if layout.layout.is_empty() {
+            return;
+        }
+
+        // FIXME - no current stable API to insert an entry into a HashMap only if it
+        // doesn't exist, and without having to build a key (as opposed to a reference).
+        // So do 2 lookups instead, to avoid having to clone the layout if it's already
+        // cached (which should be the common case).
+        if self.material_layouts.contains_key(layout) {
+            return;
+        }
+
+        let mut entries = Vec::with_capacity(layout.layout.len() * 2);
+        let mut index = 0;
+        for _slot in &layout.layout {
+            entries.push(BindGroupLayoutEntry {
+                binding: index,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    multisampled: false,
+                    sample_type: TextureSampleType::Float { filterable: true },
+                    view_dimension: TextureViewDimension::D2,
+                },
+                count: None,
+            });
+            entries.push(BindGroupLayoutEntry {
+                binding: index + 1,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Sampler(SamplerBindingType::Filtering),
+                count: None,
+            });
+            index += 2;
+        }
+        let material_bind_group_layout = self
+            .render_device
+            .create_bind_group_layout("hanabi:material_layout_render", &entries[..]);
+
+        self.material_layouts
+            .insert(layout.clone(), material_bind_group_layout);
+    }
+
+    /// Retrieve a bind group layout for a cached material.
+    pub fn get_material(&self, layout: &TextureLayout) -> Option<&BindGroupLayout> {
+        // Prevent a hash and lookup for the trivial case of an empty layout
+        if layout.layout.is_empty() {
+            return None;
+        }
+
+        self.material_layouts.get(layout)
+    }
 }
 
 impl FromWorld for ParticlesRenderPipeline {
@@ -953,32 +1009,10 @@ impl FromWorld for ParticlesRenderPipeline {
             ],
         );
 
-        let material_layout = render_device.create_bind_group_layout(
-            "hanabi:material_layout_render",
-            &[
-                BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Texture {
-                        multisampled: false,
-                        sample_type: TextureSampleType::Float { filterable: true },
-                        view_dimension: TextureViewDimension::D2,
-                    },
-                    count: None,
-                },
-                BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Sampler(SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        );
-
         Self {
             render_device: render_device.clone(),
             view_layout,
-            material_layout,
+            material_layouts: default(),
         }
     }
 }
@@ -996,11 +1030,8 @@ pub(crate) struct ParticleRenderPipelineKey {
     shader: Handle<Shader>,
     /// Particle layout.
     particle_layout: ParticleLayout,
-    /// Key: PARTICLE_TEXTURE
-    /// Define a texture sampled to modulate the particle color.
-    /// This key requires the presence of UV coordinates on the particle
-    /// vertices.
-    has_image: bool,
+    /// Texture layout.
+    texture_layout: TextureLayout,
     /// Key: LOCAL_SPACE_SIMULATION
     /// The effect is simulated in local space, and during rendering all
     /// particles are transformed by the effect's [`GlobalTransform`].
@@ -1033,7 +1064,7 @@ impl Default for ParticleRenderPipelineKey {
         Self {
             shader: Handle::default(),
             particle_layout: ParticleLayout::empty(),
-            has_image: false,
+            texture_layout: default(),
             local_space_simulation: false,
             use_alpha_mask: false,
             alpha_mode: AlphaMode::Blend,
@@ -1156,10 +1187,8 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         let mut layout = vec![self.view_layout.clone(), particles_buffer_layout];
         let mut shader_defs = vec!["SPAWNER_READONLY".into()];
 
-        // Key: PARTICLE_TEXTURE
-        if key.has_image {
-            layout.push(self.material_layout.clone());
-            shader_defs.push("PARTICLE_TEXTURE".into());
+        if let Some(material_bind_group_layout) = self.get_material(&key.texture_layout) {
+            layout.push(material_bind_group_layout.clone());
             // //  @location(1) vertex_uv: vec2<f32>
             // vertex_buffer_layout.attributes.push(VertexAttribute {
             //     format: VertexFormat::Float32x2,
@@ -1327,10 +1356,12 @@ pub(crate) struct ExtractedEffect {
     pub inverse_transform: Mat4,
     /// Layout flags.
     pub layout_flags: LayoutFlags,
+    /// Texture layout.
+    pub texture_layout: TextureLayout,
+    /// Textures.
+    pub textures: Vec<Handle<Image>>,
     /// Alpha mode.
     pub alpha_mode: AlphaMode,
-    /// Texture to modulate the particle color.
-    pub image_handle: Handle<Image>,
     /// Effect shader.
     pub effect_shader: EffectShader,
     /// For 2D rendering, the Z coordinate used as the sort key. Ignored for 3D
@@ -1529,13 +1560,8 @@ pub(crate) fn extract_effects(
         #[cfg(feature = "2d")]
         let z_sort_key_2d = effect.z_layer_2d;
 
-        let image_handle = effect
-            .particle_texture
-            .as_ref()
-            .map(|handle| handle.clone_weak())
-            .unwrap_or_default();
-
         let property_layout = asset.property_layout();
+        let texture_layout = asset.module().texture_layout();
 
         let property_data = if let Some(properties) = maybe_properties {
             // Note: must check that property layout is not empty, because the
@@ -1552,19 +1578,15 @@ pub(crate) fn extract_effects(
             None
         };
 
-        let mut layout_flags = effect.layout_flags;
-        if effect.particle_texture.is_some() {
-            layout_flags |= LayoutFlags::PARTICLE_TEXTURE;
-        }
-
+        let layout_flags = effect.layout_flags;
         let alpha_mode = effect.alpha_mode;
 
         trace!(
-            "Extracted instance of effect '{}' on entity {:?}: image_handle={:?} has_image={} layout_flags={:?}",
+            "Extracted instance of effect '{}' on entity {:?}: texture_layout_count={} texture_count={} layout_flags={:?}",
             asset.name,
             entity,
-            image_handle,
-            effect.particle_texture.is_some(),
+            texture_layout.layout.len(),
+            effect.textures.len(),
             layout_flags,
         );
 
@@ -1580,8 +1602,9 @@ pub(crate) fn extract_effects(
                 // TODO - more efficient/correct way than inverse()?
                 inverse_transform: transform.compute_matrix().inverse(),
                 layout_flags,
+                texture_layout,
+                textures: effect.textures.clone(),
                 alpha_mode,
-                image_handle,
                 effect_shader,
                 #[cfg(feature = "2d")]
                 z_sort_key_2d,
@@ -2012,8 +2035,8 @@ bitflags! {
     pub struct LayoutFlags: u32 {
         /// No flags.
         const NONE = 0;
-        /// The effect uses an image texture.
-        const PARTICLE_TEXTURE = (1 << 0);
+        // DEPRECATED - The effect uses an image texture.
+        //const PARTICLE_TEXTURE = (1 << 0);
         /// The effect is simulated in local space.
         const LOCAL_SPACE_SIMULATION = (1 << 2);
         /// The effect uses alpha masking instead of alpha blending. Only used for 3D.
@@ -2115,8 +2138,9 @@ pub(crate) fn prepare_effects(
                 property_layout: extracted_effect.property_layout.clone(),
                 effect_shader: extracted_effect.effect_shader.clone(),
                 layout_flags: extracted_effect.layout_flags,
+                texture_layout: extracted_effect.texture_layout.clone(),
+                textures: extracted_effect.textures.clone(),
                 alpha_mode: extracted_effect.alpha_mode,
-                image_handle: extracted_effect.image_handle,
                 spawn_count: extracted_effect.spawn_count,
                 transform: extracted_effect.transform.into(),
                 inverse_transform: extracted_effect.inverse_transform.into(),
@@ -2204,8 +2228,6 @@ pub(crate) fn prepare_effects(
 
         let render_shader = input.effect_shader.render.clone();
         trace!("render_shader(s) = {:?}", render_shader);
-
-        trace!("image_handle = {:?}", input.image_handle);
 
         let layout_flags = input.layout_flags;
         trace!("layout_flags = {:?}", layout_flags);
@@ -2372,6 +2394,43 @@ pub(crate) struct BufferBindGroups {
     render: BindGroup,
 }
 
+/// Combination of a texture layout and the bound textures.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+struct Material {
+    layout: TextureLayout,
+    textures: Vec<AssetId<Image>>,
+}
+
+impl Material {
+    /// Get the bind group entries to create a bind group.
+    pub fn make_entries<'a>(
+        &self,
+        gpu_images: &'a RenderAssets<GpuImage>,
+    ) -> Vec<BindGroupEntry<'a>> {
+        self.textures
+            .iter()
+            .enumerate()
+            .map(|(index, id)| {
+                if let Some(gpu_image) = gpu_images.get(*id) {
+                    vec![
+                        BindGroupEntry {
+                            binding: index as u32 * 2,
+                            resource: BindingResource::TextureView(&gpu_image.texture_view),
+                        },
+                        BindGroupEntry {
+                            binding: index as u32 * 2 + 1,
+                            resource: BindingResource::Sampler(&gpu_image.sampler),
+                        },
+                    ]
+                } else {
+                    vec![]
+                }
+            })
+            .flatten()
+            .collect()
+    }
+}
+
 #[derive(Default, Resource)]
 pub struct EffectBindGroups {
     /// Map from buffer index to the bind groups shared among all effects that
@@ -2382,6 +2441,8 @@ pub struct EffectBindGroups {
     /// Map from effect index to its update render indirect bind group (group
     /// 3).
     update_render_indirect_bind_groups: HashMap<EffectCacheId, BindGroup>,
+    /// Map from an effect material to its bind group.
+    material_bind_groups: HashMap<Material, BindGroup>,
 }
 
 impl EffectBindGroups {
@@ -2400,7 +2461,6 @@ pub struct QueueEffectsReadOnlyParams<'w, 's> {
     draw_functions_3d: Res<'w, DrawFunctions<Transparent3d>>,
     #[cfg(feature = "3d")]
     draw_functions_alpha_mask: Res<'w, DrawFunctions<AlphaMask3d>>,
-    render_pipeline: Res<'w, ParticlesRenderPipeline>,
     #[system_param(ignore)]
     marker: PhantomData<&'s usize>,
 }
@@ -2411,7 +2471,7 @@ fn emit_sorted_draw<T, F>(
     view_entities: &mut FixedBitSet,
     effect_batches: &Query<(Entity, &mut EffectBatches)>,
     effect_draw_batches: &Query<(Entity, &mut EffectDrawBatch)>,
-    read_params: &QueueEffectsReadOnlyParams,
+    render_pipeline: &mut ParticlesRenderPipeline,
     mut specialized_render_pipelines: Mut<SpecializedRenderPipelines<ParticlesRenderPipeline>>,
     pipeline_cache: &PipelineCache,
     msaa_samples: u32,
@@ -2494,6 +2554,9 @@ fn emit_sorted_draw<T, F>(
             #[cfg(feature = "trace")]
             _span_check_vis.exit();
 
+            // Create and cache the bind group layout for this texture layout
+            render_pipeline.cache_material(&batches.texture_layout);
+
             // FIXME - We draw the entire batch, but part of it may not be visible in this
             // view! We should re-batch for the current view specifically!
 
@@ -2503,13 +2566,13 @@ fn emit_sorted_draw<T, F>(
             let use_alpha_mask = batches.layout_flags.contains(LayoutFlags::USE_ALPHA_MASK);
             let flipbook = batches.layout_flags.contains(LayoutFlags::FLIPBOOK);
             let needs_uv = batches.layout_flags.contains(LayoutFlags::NEEDS_UV);
-            let has_image = batches.layout_flags.contains(LayoutFlags::PARTICLE_TEXTURE);
+            let image_count = batches.texture_layout.layout.len() as u8;
 
             // Specialize the render pipeline based on the effect batch
             trace!(
-                "Specializing render pipeline: render_shaders={:?} has_image={:?} use_alpha_mask={:?} flipbook={:?} hdr={}",
+                "Specializing render pipeline: render_shaders={:?} image_count={} use_alpha_mask={:?} flipbook={:?} hdr={}",
                 batches.render_shaders,
-                has_image,
+                image_count,
                 use_alpha_mask,
                 flipbook,
                 view.hdr
@@ -2526,11 +2589,11 @@ fn emit_sorted_draw<T, F>(
             let _span_specialize = bevy::utils::tracing::info_span!("specialize").entered();
             let render_pipeline_id = specialized_render_pipelines.specialize(
                 pipeline_cache,
-                &read_params.render_pipeline,
+                &render_pipeline,
                 ParticleRenderPipelineKey {
                     shader: render_shader_source.clone(),
                     particle_layout: batches.particle_layout.clone(),
-                    has_image,
+                    texture_layout: batches.texture_layout.clone(),
                     local_space_simulation,
                     use_alpha_mask,
                     alpha_mode,
@@ -2577,7 +2640,7 @@ fn emit_binned_draw<T, F>(
     view_entities: &mut FixedBitSet,
     effect_batches: &Query<(Entity, &mut EffectBatches)>,
     effect_draw_batches: &Query<(Entity, &mut EffectDrawBatch)>,
-    read_params: &QueueEffectsReadOnlyParams,
+    render_pipeline: &mut ParticlesRenderPipeline,
     mut specialized_render_pipelines: Mut<SpecializedRenderPipelines<ParticlesRenderPipeline>>,
     pipeline_cache: &PipelineCache,
     msaa_samples: u32,
@@ -2665,6 +2728,9 @@ fn emit_binned_draw<T, F>(
             #[cfg(feature = "trace")]
             _span_check_vis.exit();
 
+            // Create and cache the bind group layout for this texture layout
+            render_pipeline.cache_material(&batches.texture_layout);
+
             // FIXME - We draw the entire batch, but part of it may not be visible in this
             // view! We should re-batch for the current view specifically!
 
@@ -2674,13 +2740,13 @@ fn emit_binned_draw<T, F>(
             let use_alpha_mask = batches.layout_flags.contains(LayoutFlags::USE_ALPHA_MASK);
             let flipbook = batches.layout_flags.contains(LayoutFlags::FLIPBOOK);
             let needs_uv = batches.layout_flags.contains(LayoutFlags::NEEDS_UV);
-            let has_image = batches.layout_flags.contains(LayoutFlags::PARTICLE_TEXTURE);
+            let image_count = batches.texture_layout.layout.len() as u8;
 
             // Specialize the render pipeline based on the effect batch
             trace!(
-                "Specializing render pipeline: render_shaders={:?} has_image={:?} use_alpha_mask={:?} flipbook={:?} hdr={}",
+                "Specializing render pipeline: render_shaders={:?} image_count={} use_alpha_mask={:?} flipbook={:?} hdr={}",
                 batches.render_shaders,
-                has_image,
+                image_count,
                 use_alpha_mask,
                 flipbook,
                 view.hdr
@@ -2697,11 +2763,11 @@ fn emit_binned_draw<T, F>(
             let _span_specialize = bevy::utils::tracing::info_span!("specialize").entered();
             let render_pipeline_id = specialized_render_pipelines.specialize(
                 pipeline_cache,
-                &read_params.render_pipeline,
+                &render_pipeline,
                 ParticleRenderPipelineKey {
                     shader: render_shader_source.clone(),
                     particle_layout: batches.particle_layout.clone(),
-                    has_image,
+                    texture_layout: batches.texture_layout.clone(),
                     local_space_simulation,
                     use_alpha_mask,
                     alpha_mode,
@@ -2743,6 +2809,7 @@ fn emit_binned_draw<T, F>(
 pub(crate) fn queue_effects(
     views: Query<(Entity, &VisibleEntities, &ExtractedView)>,
     effects_meta: Res<EffectsMeta>,
+    mut render_pipeline: ResMut<ParticlesRenderPipeline>,
     mut specialized_render_pipelines: ResMut<SpecializedRenderPipelines<ParticlesRenderPipeline>>,
     pipeline_cache: Res<PipelineCache>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
@@ -2810,7 +2877,7 @@ pub(crate) fn queue_effects(
                 &mut view_entities,
                 &effect_batches,
                 &effect_draw_batches,
-                &read_params,
+                &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
                 &pipeline_cache,
                 msaa.samples(),
@@ -2850,7 +2917,7 @@ pub(crate) fn queue_effects(
                 &mut view_entities,
                 &effect_batches,
                 &effect_draw_batches,
-                &read_params,
+                &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
                 &pipeline_cache,
                 msaa.samples(),
@@ -2888,7 +2955,7 @@ pub(crate) fn queue_effects(
                 &mut view_entities,
                 &effect_batches,
                 &effect_draw_batches,
-                &read_params,
+                &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
                 &pipeline_cache,
                 msaa.samples(),
@@ -2921,7 +2988,7 @@ pub(crate) fn prepare_resources(
     mut effects_meta: ResMut<EffectsMeta>,
     render_device: Res<RenderDevice>,
     view_uniforms: Res<ViewUniforms>,
-    read_params: QueueEffectsReadOnlyParams,
+    render_pipeline: Res<ParticlesRenderPipeline>,
 ) {
     // Get the binding for the ViewUniform, the uniform data structure containing
     // the Camera data for the current view.
@@ -2932,7 +2999,7 @@ pub(crate) fn prepare_resources(
     // Create the bind group for the camera/view parameters
     effects_meta.view_bind_group = Some(render_device.create_bind_group(
         "hanabi:bind_group_camera_view",
-        &read_params.render_pipeline.view_layout,
+        &render_pipeline.view_layout,
         &[
             BindGroupEntry {
                 binding: 0,
@@ -2955,7 +3022,7 @@ pub(crate) fn prepare_bind_groups(
     dispatch_indirect_pipeline: Res<DispatchIndirectPipeline>,
     init_pipeline: Res<ParticlesInitPipeline>,
     update_pipeline: Res<ParticlesUpdatePipeline>,
-    render_pipeline: Res<ParticlesRenderPipeline>,
+    render_pipeline: ResMut<ParticlesRenderPipeline>,
     gpu_images: Res<RenderAssets<GpuImage>>,
 ) {
     if effects_meta.spawner_buffer.is_empty() || effects_meta.spawner_buffer.buffer().is_none() {
@@ -3251,56 +3318,43 @@ pub(crate) fn prepare_bind_groups(
                 );
         }
 
-        // Ensure the particle texture is available as a GPU resource and create a bind
-        // group for it
-        if effect_batches
-            .layout_flags
-            .contains(LayoutFlags::PARTICLE_TEXTURE)
-        {
-            if effect_bind_groups
-                .images
-                .get(&effect_batches.image_handle.id())
-                .is_none()
-            {
-                trace!(
-                    "Batch buffer #{} has missing GPU image bind group, creating...",
-                    effect_batches.buffer_index,
+        // Ensure the particle texture(s) are available as GPU resources and that a bind
+        // group for them exists FIXME fix this insert+get below
+        if !effect_batches.texture_layout.layout.is_empty() {
+            // This should always be available, as this is cached into the render pipeline
+            // just before we start specializing it.
+            let Some(material_bind_group_layout) =
+                render_pipeline.get_material(&effect_batches.texture_layout)
+            else {
+                error!(
+                    "Failed to find material bind group layout for buffer #{}",
+                    effect_batches.buffer_index
                 );
-                // If texture doesn't have a bind group yet from another instance of the
-                // same effect, then try to create one now
-                if let Some(gpu_image) = gpu_images.get(&effect_batches.image_handle) {
-                    let bind_group = render_device.create_bind_group(
-                        "hanabi:material_bind_group",
-                        &render_pipeline.material_layout,
-                        &[
-                            BindGroupEntry {
-                                binding: 0,
-                                resource: BindingResource::TextureView(&gpu_image.texture_view),
-                            },
-                            BindGroupEntry {
-                                binding: 1,
-                                resource: BindingResource::Sampler(&gpu_image.sampler),
-                            },
-                        ],
-                    );
-                    effect_bind_groups
-                        .images
-                        .insert(effect_batches.image_handle.id(), bind_group);
-                } else {
-                    // Texture is not ready; skip for now...
-                    trace!("GPU image not yet available; skipping batch for now.");
-                    continue;
-                }
-            } else {
-                trace!(
-                    "Image {:?} already has bind group {:?}.",
-                    effect_batches.image_handle,
-                    effect_bind_groups
-                        .images
-                        .get(&effect_batches.image_handle.id())
-                        .unwrap()
-                );
-            }
+                continue;
+            };
+
+            // TODO = move
+            let material = Material {
+                layout: effect_batches.texture_layout.clone(),
+                textures: effect_batches.textures.iter().map(|h| h.id()).collect(),
+            };
+            assert_eq!(material.layout.layout.len(), material.textures.len());
+
+            let bind_group_entries = material.make_entries(&gpu_images);
+
+            effect_bind_groups
+                .material_bind_groups
+                .entry(material.clone())
+                .or_insert_with(|| {
+                    render_device.create_bind_group(
+                        &format!(
+                            "hanabi:material_bind_group_{}",
+                            material.layout.layout.len()
+                        )[..],
+                        material_bind_group_layout,
+                        &bind_group_entries[..],
+                    )
+                });
         }
     }
 }
@@ -3397,19 +3451,18 @@ fn draw<'w>(
     );
 
     // Particle texture
-    if effect_batches
-        .layout_flags
-        .contains(LayoutFlags::PARTICLE_TEXTURE)
-    {
-        if let Some(bind_group) = effect_bind_groups
-            .images
-            .get(&effect_batches.image_handle.id())
-        {
+    // TODO = move
+    let material = Material {
+        layout: effect_batches.texture_layout.clone(),
+        textures: effect_batches.textures.iter().map(|h| h.id()).collect(),
+    };
+    if effect_batches.texture_layout.layout.len() > 0 {
+        if let Some(bind_group) = effect_bind_groups.material_bind_groups.get(&material) {
             pass.set_bind_group(2, bind_group, &[]);
         } else {
-            // Texture not ready; skip this drawing for now
+            // Texture(s) not ready; skip this drawing for now
             trace!(
-                "Particle texture bind group not available for batch buf={}. Skipping draw call.",
+                "Particle material bind group not available for batch buf={}. Skipping draw call.",
                 effect_batches.buffer_index,
             );
             return; // continue;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2410,7 +2410,7 @@ impl Material {
         self.textures
             .iter()
             .enumerate()
-            .map(|(index, id)| {
+            .flat_map(|(index, id)| {
                 if let Some(gpu_image) = gpu_images.get(*id) {
                     vec![
                         BindGroupEntry {
@@ -2426,7 +2426,6 @@ impl Material {
                     vec![]
                 }
             })
-            .flatten()
             .collect()
     }
 }
@@ -2589,7 +2588,7 @@ fn emit_sorted_draw<T, F>(
             let _span_specialize = bevy::utils::tracing::info_span!("specialize").entered();
             let render_pipeline_id = specialized_render_pipelines.specialize(
                 pipeline_cache,
-                &render_pipeline,
+                render_pipeline,
                 ParticleRenderPipelineKey {
                     shader: render_shader_source.clone(),
                     particle_layout: batches.particle_layout.clone(),
@@ -2763,7 +2762,7 @@ fn emit_binned_draw<T, F>(
             let _span_specialize = bevy::utils::tracing::info_span!("specialize").entered();
             let render_pipeline_id = specialized_render_pipelines.specialize(
                 pipeline_cache,
-                &render_pipeline,
+                render_pipeline,
                 ParticleRenderPipelineKey {
                     shader: render_shader_source.clone(),
                     particle_layout: batches.particle_layout.clone(),
@@ -3456,7 +3455,7 @@ fn draw<'w>(
         layout: effect_batches.texture_layout.clone(),
         textures: effect_batches.textures.iter().map(|h| h.id()).collect(),
     };
-    if effect_batches.texture_layout.layout.len() > 0 {
+    if !effect_batches.texture_layout.layout.is_empty() {
         if let Some(bind_group) = effect_bind_groups.material_bind_groups.get(&material) {
             pass.set_bind_group(2, bind_group, &[]);
         } else {

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -29,14 +29,7 @@ struct VertexOutput {
 #ifdef RENDER_NEEDS_SPAWNER
 @group(1) @binding(3) var<storage, read> spawner : Spawner; // NOTE - same group as update
 #endif
-#ifdef PARTICLE_TEXTURE
-@group(2) @binding(0) var particle_texture: texture_2d<f32>;
-@group(2) @binding(1) var particle_sampler: sampler;
-#endif
-// #ifdef PARTICLE_GRADIENTS
-// @group(3) @binding(0) var gradient_texture: texture_2d<f32>;
-// @group(3) @binding(1) var gradient_sampler: sampler;
-// #endif
+{{MATERIAL_BINDINGS}}
 
 fn get_camera_position_effect_space() -> vec3<f32> {
     let view_pos = view.world_from_view[3].xyz;
@@ -152,15 +145,12 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 #ifdef USE_ALPHA_MASK
     var alpha_cutoff: f32 = {{ALPHA_CUTOFF}};
 #endif
+    var color = in.color;
+#ifdef NEEDS_UV
+    var uv = in.uv;
+#endif
 
 {{FRAGMENT_MODIFIERS}}
-
-    var color = in.color;
-
-#ifdef PARTICLE_TEXTURE
-    var texColor = textureSample(particle_texture, particle_sampler, in.uv);
-    {{PARTICLE_TEXTURE_SAMPLE_MAPPING}}
-#endif
 
 #ifdef USE_ALPHA_MASK
     if color.a >= alpha_cutoff {


### PR DESCRIPTION
Add a new `TextureSampleExpr` to allow sampling a texture from an expression. Make the `ParticleTextureModifier` use this. Change the texture image to be hosted on a new `EffectMaterial` component, and add `Module::add_texture()` to define a new texture slot (binding).

This is a primitive first version with several restrictions:
- Only color textures (those returning `vec4<f32>`), no depth.
- Only sampling via `textureSample()` in WGSL, no LOD or bias, no unsampled gather, _etc._
- No validation whatsoever about the coherence of the slots, the images on the material, and the expressions. If anything is inconsistent, this might produce runtime errors (fail to create shader) or simply render the wrong thing (no texture).

Fixes #355