### PR TITLE
change the ribbon example into a tracer example.

### DIFF
--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -112,7 +112,6 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
 }
 
 fn move_head(
-    mut gizmos: Gizmos,
     mut query: Query<&mut Transform, With<ParticleEffect>>,
     mut effect: Query<&mut EffectProperties>,
     timer: Res<Time>,
@@ -129,7 +128,6 @@ fn move_head(
         ) * SHAPE_SCALE;
 
         properties.set("head_pos", (pos).into());
-        gizmos.sphere(pos, Quat::IDENTITY, 1.0, YELLOW);
         transform.translation = pos;
     }
 }

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -1,12 +1,5 @@
-<<<<<<< HEAD
 //! Uses with_ribbons to draw a "tracer" or a "trail" following an Entity.
-=======
-//! Uses the [RibbonModifier] to draw a "tracer" or a "trail" following an Entity.
-//! The trail effect is achieved by using the [CloneModifier] on the "head" particle in combination
-//! with the [RibbonModifier].
->>>>>>> 8508ca1 (clean up and better description)
 //! The movement of the head particle is achieved by linking the particle position to a CPU position using a [Property] in [move_head].
-//!
 
 use bevy::color::palettes::css::YELLOW;
 use bevy::math::vec4;

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -1,7 +1,6 @@
 //! Uses with_ribbons to draw a "tracer" or a "trail" following an Entity.
 //! The movement of the head particle is achieved by linking the particle position to a CPU position using a [Property] in [move_head].
 
-use bevy::color::palettes::css::YELLOW;
 use bevy::math::vec4;
 use bevy::prelude::*;
 use bevy::{

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -1,4 +1,10 @@
+<<<<<<< HEAD
 //! Uses with_ribbons to draw a "tracer" or a "trail" following an Entity.
+=======
+//! Uses the [RibbonModifier] to draw a "tracer" or a "trail" following an Entity.
+//! The trail effect is achieved by using the [CloneModifier] on the "head" particle in combination
+//! with the [RibbonModifier].
+>>>>>>> 8508ca1 (clean up and better description)
 //! The movement of the head particle is achieved by linking the particle position to a CPU position using a [Property] in [move_head].
 //!
 
@@ -19,7 +25,7 @@ use utils::*;
 const K: f32 = 0.64;
 const L: f32 = 0.384;
 
-const TIME_SCALE: f32 = 10.0;
+const TIME_SCALE: f32 = 6.5;
 const SHAPE_SCALE: f32 = 25.0;
 const LIFETIME: f32 = 1.5;
 const TRAIL_SPAWN_RATE: f32 = 256.0;
@@ -27,7 +33,7 @@ const TRAIL_SPAWN_RATE: f32 = 256.0;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::make_test_app("ribbon")
         .add_systems(Startup, setup)
-        .add_systems(Update, move_particle_effect)
+        .add_systems(Update, move_head)
         .run();
     app_exit.into_result()
 }
@@ -112,7 +118,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         .insert(Name::new("ribbon"));
 }
 
-fn move_particle_effect(
+fn move_head(
     mut gizmos: Gizmos,
     mut query: Query<&mut Transform, With<ParticleEffect>>,
     mut effect: Query<&mut EffectProperties>,
@@ -129,7 +135,6 @@ fn move_particle_effect(
             0.0,
         ) * SHAPE_SCALE;
 
-        //let pos = vec3(f32::cos(theta), f32::sin(theta), 0.0) * 5.0;
         properties.set("head_pos", (pos).into());
         gizmos.sphere(pos, Quat::IDENTITY, 1.0, YELLOW);
         transform.translation = pos;


### PR DESCRIPTION
I think this could be more helpful for people wanting to use the ribbon example. In my mind "tracers" are the most used application for this sort of thing, If you feel it isn't just close it.

run with:
 `cargo run --example ribbon --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/bevy_gizmos"` 