### PR TITLE
Fix typo in worms example

### DIFF
--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -1,8 +1,8 @@
 //! Worms
 //!
-//! Demonstrates simple use of particle trails.
+//! Demonstrates a simple use of particle trails.
 
-use std::f32::consts::{FRAC_PI_2, PI};
+use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
     core_pipeline::{bloom::BloomSettings, tonemapping::Tonemapping},
@@ -58,7 +58,7 @@ fn setup(
     // scratch attribute.`
     let set_initial_angle_modifier = SetAttributeModifier::new(
         Attribute::F32_0,
-        writer.lit(0.0).normal(writer.lit(0.0)).expr(),
+        writer.lit(0.0).normal(writer.lit(1.0)).expr(),
     );
 
     // Give each particle a random opaque color.

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -306,9 +306,8 @@ impl<'a> EvalContext for ShaderWriter<'a> {
         if let Some(s) = self.expr_cache.get(&handle) {
             Ok(s.clone())
         } else {
-            module.try_get(handle)?.eval(module, self).map(|s| {
+            module.try_get(handle)?.eval(module, self).inspect(|s| {
                 self.expr_cache.insert(handle, s.clone());
-                s
             })
         }
     }
@@ -477,9 +476,8 @@ impl<'a> EvalContext for RenderContext<'a> {
         if let Some(s) = self.expr_cache.get(&handle) {
             Ok(s.clone())
         } else {
-            module.try_get(handle)?.eval(module, self).map(|s| {
+            module.try_get(handle)?.eval(module, self).inspect(|s| {
                 self.expr_cache.insert(handle, s.clone());
-                s
             })
         }
     }


### PR DESCRIPTION
Fix a typo in the `worms.rs` example, making all worms move in the same direction instead of a random one.

Fixes #381