### PR TITLE
Add `wgpu` as core dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ bitflags = "2.3"
 typetag = { version = "0.2", optional = true }
 thiserror = "1.0"
 # Same versions as Bevy 0.14 (bevy_render)
+wgpu = "0.20"
 naga = "0.20"
 naga_oil = { version = "0.14", default-features = false, features = ["test_shader"] }
 
@@ -67,9 +68,6 @@ features = [ "bevy_core_pipeline", "bevy_render", "bevy_asset", "x11" ]
 all-features = true
 
 [dev-dependencies]
-# Same versions as Bevy 0.14 (bevy_render)
-wgpu = "0.20"
-
 # For world inspector; required if "examples_world_inspector" is used.
 bevy-inspector-egui = "0.25"
 bevy_egui = { version = "0.28", default-features = false, features = [

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -200,9 +200,9 @@ pub enum AlphaMode {
     Mask(ExprHandle),
 }
 
-impl Into<BlendState> for AlphaMode {
-    fn into(self) -> BlendState {
-        match self {
+impl From<AlphaMode> for BlendState {
+    fn from(value: AlphaMode) -> Self {
+        match value {
             AlphaMode::Blend => BlendState::ALPHA_BLENDING,
             AlphaMode::Premultiply => BlendState::PREMULTIPLIED_ALPHA_BLENDING,
             AlphaMode::Add => BlendState {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,11 +23,11 @@ use crate::{
     properties::EffectProperties,
     render::{
         extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects,
-        prepare_resources, queue_effects, DispatchIndirectPipeline, DrawEffects, EffectAssetEvents,
-        EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects, GpuDispatchIndirect,
-        GpuParticleGroup, GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams,
-        ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache,
-        SimParams, StorageType as _, VfxSimulateDriverNode, VfxSimulateNode,
+        prepare_gpu_resources, queue_effects, DispatchIndirectPipeline, DrawEffects,
+        EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects,
+        GpuDispatchIndirect, GpuParticleGroup, GpuRenderEffectMetadata, GpuRenderGroupIndirect,
+        GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
+        ShaderCache, SimParams, StorageType as _, VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_initializers,
@@ -76,16 +76,24 @@ pub enum EffectSystems {
     GatherRemovedEffects,
 
     /// Prepare effect assets for the extracted effects.
+    ///
+    /// Part of Bevy's own [`RenderSet::PrepareAssets`].
     PrepareEffectAssets,
 
     /// Queue the GPU commands for the extracted effects.
+    ///
+    /// Part of Bevy's own [`RenderSet::Queue`].
     QueueEffects,
 
     /// Prepare GPU data for the queued effects.
+    ///
+    /// Part of Bevy's own [`RenderSet::Prepare`].
     PrepareEffectGpuResources,
 
     /// Prepare the GPU bind groups once all buffers have been (re-)allocated
     /// and won't change this frame.
+    ///
+    /// Part of Bevy's own [`RenderSet::PrepareBindGroups`].
     PrepareBindGroups,
 }
 
@@ -299,7 +307,7 @@ impl Plugin for HanabiPlugin {
                     queue_effects
                         .in_set(EffectSystems::QueueEffects)
                         .after(prepare_effects),
-                    prepare_resources
+                    prepare_gpu_resources
                         .in_set(EffectSystems::PrepareEffectGpuResources)
                         .after(prepare_view_uniforms),
                     prepare_bind_groups

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1085,6 +1085,7 @@ mod test {
     fn test_once() {
         let rng = &mut new_rng();
         let spawner = Spawner::once(5.0.into(), true);
+        assert!(spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         let count = spawner.tick(0.001, rng);
         assert_eq!(count, 5);
@@ -1096,6 +1097,7 @@ mod test {
     fn test_once_reset() {
         let rng = &mut new_rng();
         let spawner = Spawner::once(5.0.into(), true);
+        assert!(spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         spawner.tick(1.0, rng);
         spawner.reset();
@@ -1107,6 +1109,7 @@ mod test {
     fn test_once_not_immediate() {
         let rng = &mut new_rng();
         let spawner = Spawner::once(5.0.into(), false);
+        assert!(spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         let count = spawner.tick(1.0, rng);
         assert_eq!(count, 0);
@@ -1119,6 +1122,7 @@ mod test {
     fn test_rate() {
         let rng = &mut new_rng();
         let spawner = Spawner::rate(5.0.into());
+        assert!(!spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         // Slightly over 1.0 to avoid edge case
         let count = spawner.tick(1.01, rng);
@@ -1131,6 +1135,7 @@ mod test {
     fn test_rate_active() {
         let rng = &mut new_rng();
         let spawner = Spawner::rate(5.0.into());
+        assert!(!spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         spawner.tick(1.01, rng);
         spawner.set_active(false);
@@ -1147,6 +1152,7 @@ mod test {
     fn test_rate_accumulate() {
         let rng = &mut new_rng();
         let spawner = Spawner::rate(5.0.into());
+        assert!(!spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         // 13 ticks instead of 12 to avoid edge case
         let count = (0..13).map(|_| spawner.tick(1.0 / 60.0, rng)).sum::<u32>();
@@ -1157,6 +1163,7 @@ mod test {
     fn test_burst() {
         let rng = &mut new_rng();
         let spawner = Spawner::burst(5.0.into(), 2.0.into());
+        assert!(!spawner.is_once());
         let mut spawner = make_effect_spawner(spawner);
         let count = spawner.tick(1.0, rng);
         assert_eq!(count, 5);


### PR DESCRIPTION
Move `wgpu` from a dev-dependency to a core crate dependency, to allow the direct use of its types.

Clean-up various documentations, and other minor code changes.