### PR TITLE
Improve debugging

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -121,7 +121,7 @@
 //! [modifiers]: crate::modifier
 //! [`SetAttributeModifier`]: crate::modifier::SetAttributeModifier
 
-use std::{any::Any, borrow::Cow, num::NonZeroU64};
+use std::{any::Any, borrow::Cow, fmt::Display, num::NonZeroU64};
 
 use bevy::{
     math::{Vec2, Vec3, Vec4},
@@ -154,6 +154,17 @@ pub enum ScalarType {
     Int,
     /// Unsigned 32-bit integer value (`u32`).
     Uint,
+}
+
+impl Display for ScalarType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bool => write!(f, "bool"),
+            Self::Float => write!(f, "f32"),
+            Self::Int => write!(f, "i32"),
+            Self::Uint => write!(f, "u32"),
+        }
+    }
 }
 
 impl ScalarType {
@@ -207,6 +218,12 @@ pub struct VectorType {
     elem_type: ScalarType,
     /// Number of components. Always 2/3/4.
     count: u8,
+}
+
+impl Display for VectorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "vec{}<{}>", self.count, self.elem_type)
+    }
 }
 
 impl VectorType {
@@ -300,6 +317,12 @@ pub struct MatrixType {
     cols: u8,
 }
 
+impl Display for MatrixType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "mat{}x{}<f32>", self.cols, self.rows)
+    }
+}
+
 impl MatrixType {
     /// Floating-point matrix of size 2x2 (`mat2x2<f32>`).
     pub const MAT2X2F: MatrixType = MatrixType::new(2, 2);
@@ -387,6 +410,18 @@ pub enum ValueType {
     Vector(VectorType),
     /// A floating-point matrix type of size between 2x2 and 4x4.
     Matrix(MatrixType),
+}
+
+impl Display for ValueType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The enum variants are different enough we don't need to discriminate at this
+        // level
+        match self {
+            ValueType::Scalar(s) => s.fmt(f),
+            ValueType::Vector(v) => v.fmt(f),
+            ValueType::Matrix(m) => m.fmt(f),
+        }
+    }
 }
 
 impl ValueType {

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -648,15 +648,15 @@ pub enum ExprError {
     /// Expression type error.
     ///
     /// Generally used for invalid type conversion (casting).
-    #[error("Type error: {0:?}")]
+    #[error("Type error: {0}")]
     TypeError(String),
 
     /// Expression syntax error.
-    #[error("Syntax error: {0:?}")]
+    #[error("Syntax error: {0}")]
     SyntaxError(String),
 
     /// Generic graph evaluation error.
-    #[error("Graph evaluation error: {0:?}")]
+    #[error("Graph evaluation error: {0}")]
     GraphEvalError(String),
 
     /// Error resolving a property.
@@ -664,7 +664,7 @@ pub enum ExprError {
     /// An unknown property was not defined in the evaluation context, which
     /// usually means that the property was not defined with
     /// [`Module::add_property()`].
-    #[error("Property error: {0:?}")]
+    #[error("Property error: {0}")]
     PropertyError(String),
 
     /// Invalid expression handle not referencing any existing [`Expr`] in the
@@ -675,7 +675,7 @@ pub enum ExprError {
     /// are written to the [`EffectAsset`]. See [`ExprWriter`] for details.
     ///
     /// [`EffectAsset`]: crate::EffectAsset
-    #[error("Invalid expression handle: {0:?}")]
+    #[error("Invalid expression handle: {0}")]
     InvalidExprHandleError(String),
 
     /// Invalid modifier context.

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -142,8 +142,7 @@ pub trait Modifier: Reflect + Send + Sync + 'static {
         None
     }
 
-    /// Get the list of dependent attributes required for this modifier to be
-    /// used.
+    /// Get the list of attributes required for this modifier to be used.
     fn attributes(&self) -> &[Attribute];
 
     /// Clone self.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -135,9 +135,10 @@ pub struct HanabiPlugin;
 impl HanabiPlugin {
     /// Create the `vfx_common.wgsl` shader with proper alignment.
     ///
-    /// This creates a new [`Shader`] from the `vfx_common.wgsl` code, by
-    /// applying the given alignment for storage buffers. This produces a shader
-    /// ready for the specific GPU device associated with that alignment.
+    /// This creates a new [`Shader`] from the `vfx_common.wgsl` template file,
+    /// by applying the given alignment for storage buffers. This produces a
+    /// shader ready for the specific GPU device associated with that
+    /// alignment.
     pub(crate) fn make_common_shader(min_storage_buffer_offset_alignment: u32) -> Shader {
         let spawner_padding_code =
             GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -200,7 +200,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
     /// Get a safe buffer label for debug display.
     ///
     /// Falls back to an empty string if no label was specified.
-    pub fn safe_label<'a>(&'a self) -> Cow<'a, str> {
+    pub fn safe_label(&self) -> Cow<'_, str> {
         self.label
             .as_ref()
             .map(|s| Cow::Borrowed(&s[..]))

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -880,8 +880,7 @@ impl EffectCache {
             let buffer_index = cached_effect_indices.buffer_index as usize;
             self.buffers[buffer_index]
                 .as_ref()
-                .map(|eb| eb.properties_buffer())
-                .flatten()
+                .and_then(|eb| eb.properties_buffer())
         } else {
             None
         }

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -672,12 +672,12 @@ pub struct EffectCache {
     /// by index, we cannot move them once they're allocated.
     buffers: Vec<Option<EffectBuffer>>,
     /// Map from an effect cache ID to various buffer indices.
-    effects: HashMap<EffectCacheId, CachedEffectIndices>,
+    effects: HashMap<EffectCacheId, CachedEffect>,
 }
 
 /// Stores various data, including the buffer index and slice boundaries within
 /// the buffer for all groups in a single effect.
-pub(crate) struct CachedEffectIndices {
+pub(crate) struct CachedEffect {
     /// The index of the buffer.
     pub(crate) buffer_index: u32,
     /// The slices within that buffer.
@@ -831,7 +831,7 @@ impl EffectCache {
         );
         self.effects.insert(
             id,
-            CachedEffectIndices {
+            CachedEffect {
                 buffer_index: buffer_index as u32,
                 slices,
                 group_order,
@@ -877,11 +877,11 @@ impl EffectCache {
 
     pub fn get_property_buffer(&self, id: EffectCacheId) -> Option<&Buffer> {
         if let Some(cached_effect_indices) = self.effects.get(&id) {
-            if let Some(buffer) = &self.buffers[cached_effect_indices.buffer_index as usize] {
-                buffer.properties_buffer()
-            } else {
-                None
-            }
+            let buffer_index = cached_effect_indices.buffer_index as usize;
+            self.buffers[buffer_index]
+                .as_ref()
+                .map(|eb| eb.properties_buffer())
+                .flatten()
         } else {
             None
         }
@@ -889,7 +889,7 @@ impl EffectCache {
 
     /// Remove an effect from the cache. If this was the last effect, drop the
     /// underlying buffer and return the index of the dropped buffer.
-    pub fn remove(&mut self, id: EffectCacheId) -> Option<CachedEffectIndices> {
+    pub fn remove(&mut self, id: EffectCacheId) -> Option<CachedEffect> {
         let indices = self.effects.remove(&id)?;
         let &mut Some(ref mut buffer) = &mut self.buffers[indices.buffer_index as usize] else {
             return None;


### PR DESCRIPTION
- Several asset-related errors now emit the asset name.
- `BufferTable` now emits a table name in its logs.
- Improved `ExprError` error messages by implementing `Display` for `ValueType`.
- `SetAttributeModifer::eval()` now attempts to check that the type of the value emitted by the expression, if available, matches the type of the attribute being assigned. This prevents generating invalid shader code.