### PR TITLE
Fix panic in clone init pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] 2024-11-16
+
+### Fixed
+
+- Fixed a panic in the init compute shader when using trails and ribbons, affecting some combinations of graphics API (notably Vulkan) and GPU devices only. (#399)
+
 ## [0.13.0] 2024-11-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Hanabi GPU particle system for the Bevy game engine"


### PR DESCRIPTION
Fix a panic in the clone init pass due to some Vulkan validation error when using ribbons and trails. The indirect dispatch of the clone init pass used the wrong buffer offset, which in some cases was leading to an out of bound access, caught by the validation layer.

Fixes #399