### PR TITLE
Start transitioning to retained render world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Changed the `ParticleEffect` component to require the `CompiledParticleEffect` and `SyncToRenderWorld` components.
+
+### Fixed
+
+- Fixed a bug with opaque effects not rendering.
+
 ## [0.14.0] 2024-12-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.14.0"
+version = "0.15.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Hanabi GPU particle system for the Bevy game engine"

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,12 +25,13 @@ use crate::{
     compile_effects, gather_removed_effects,
     properties::EffectProperties,
     render::{
-        extract_effect_events, extract_effects, prepare_bind_groups, prepare_effects,
-        prepare_gpu_resources, queue_effects, DispatchIndirectPipeline, DrawEffects,
-        EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects,
-        GpuDispatchIndirect, GpuParticleGroup, GpuRenderEffectMetadata, GpuRenderGroupIndirect,
-        GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
-        ShaderCache, SimParams, StorageType as _, VfxSimulateDriverNode, VfxSimulateNode,
+        add_remove_effects, extract_effect_events, extract_effects, prepare_bind_groups,
+        prepare_effects, prepare_gpu_resources, queue_effects, DispatchIndirectPipeline,
+        DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta,
+        ExtractedEffects, GpuDispatchIndirect, GpuParticleGroup, GpuRenderEffectMetadata,
+        GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline,
+        ParticlesUpdatePipeline, ShaderCache, SimParams, StorageType as _, VfxSimulateDriverNode,
+        VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_initializers,
@@ -311,7 +312,8 @@ impl Plugin for HanabiPlugin {
             .add_systems(
                 Render,
                 (
-                    prepare_effects
+                    (add_remove_effects, prepare_effects)
+                        .chain()
                         .in_set(EffectSystems::PrepareEffectAssets)
                         // Ensure we run after Bevy prepared the render Mesh
                         .after(allocate_and_free_meshes),


### PR DESCRIPTION
Start to transition the internal rendering implementation to leverage the retained render world introduced in Bevy 0.15.

This change moves the `CachedEffect` and `DispatchBufferIndices` out of the `EffectCache`, and convert them to components added to the render world entity spawned and synchronized via `SyncToRenderWorld` with the main world entity owning the effect instance.

As part of this change, split the addition and removal of new effect instances into a separate `add_remove_effects()` system which runs before the `prepare_effects()` system.

Also fix a small bug with opaque particles not rendered in some cases; this is hypothetical, but `EffectShaderSource::generate()` was not setting the `LayoutFlags::OPAQUE`.