### PR TITLE
Retain mesh and property into separate components

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,13 +25,13 @@ use crate::{
     compile_effects, gather_removed_effects,
     properties::EffectProperties,
     render::{
-        add_remove_effects, extract_effect_events, extract_effects, prepare_bind_groups,
-        prepare_effects, prepare_gpu_resources, queue_effects, DispatchIndirectPipeline,
-        DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta,
-        ExtractedEffects, GpuDispatchIndirect, GpuParticleGroup, GpuRenderEffectMetadata,
-        GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline,
-        ParticlesUpdatePipeline, ShaderCache, SimParams, StorageType as _, VfxSimulateDriverNode,
-        VfxSimulateNode,
+        add_remove_effects, batch_effects, extract_effect_events, extract_effects,
+        prepare_bind_groups, prepare_effects, prepare_gpu_resources, queue_effects,
+        DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache,
+        EffectsMeta, ExtractedEffects, GpuDispatchIndirect, GpuParticleGroup,
+        GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline,
+        ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache, SimParams, StorageType as _,
+        VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_initializers,
@@ -312,14 +312,14 @@ impl Plugin for HanabiPlugin {
             .add_systems(
                 Render,
                 (
-                    (add_remove_effects, prepare_effects)
+                    (add_remove_effects, prepare_effects, batch_effects)
                         .chain()
                         .in_set(EffectSystems::PrepareEffectAssets)
                         // Ensure we run after Bevy prepared the render Mesh
                         .after(allocate_and_free_meshes),
                     queue_effects
                         .in_set(EffectSystems::QueueEffects)
-                        .after(prepare_effects),
+                        .after(batch_effects),
                     prepare_gpu_resources
                         .in_set(EffectSystems::PrepareEffectGpuResources)
                         .after(prepare_view_uniforms),

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -136,7 +136,7 @@ impl EffectBatches {
                 .collect(),
             handle: input.handle.clone(),
             layout_flags: input.layout_flags,
-            mesh: cached_mesh.mesh.clone(),
+            mesh: cached_mesh.mesh,
             mesh_buffer: cached_mesh.buffer.clone(),
             mesh_slice: cached_mesh.range.clone(),
             texture_layout: input.texture_layout.clone(),


### PR DESCRIPTION
Retain the mesh and the properties of an effect instance into separate components (namely, `CachedMesh` and `CachedProperties`).

Directly process effect instances from extracted data, instead of inserting a modified representation (batch input) and processing that. This simplify the code and removes some unnecessary copies.

Split the batching operation (which currently doesn't batch anything) into a separate `batch_effects()` system, which reads all the cached effects directly from the ECS world, after `prepare_effects()` updated them from the extracted ones.