### PR TITLE
Clean-up extraction a bit

### DIFF
--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -182,7 +182,7 @@ pub(crate) struct BatchesInput {
     pub initializers: Vec<EffectInitializer>,
     /// The order in which we evaluate groups.
     pub group_order: Vec<u32>,
-    /// Emitter position.
+    /// Emitter position, for 3D sorting.
     #[cfg(feature = "3d")]
     pub position: Vec3,
     /// Sort key, for 2D only.

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -972,9 +972,11 @@ pub fn tick_initializers(
     let dt = time.delta_secs();
 
     for (entity, effect, maybe_inherited_visibility, maybe_initializers) in query.iter_mut() {
-        // TODO - maybe cache simulation_condition so we don't need to unconditionally
-        // query the asset?
         let Some(asset) = effects.get(&effect.handle) else {
+            trace!(
+                "Effect asset with handle {:?} is not available; skipped initializers tick.",
+                effect.handle
+            );
             continue;
         };
 
@@ -983,6 +985,10 @@ pub fn tick_initializers(
                 .map(|iv| iv.get())
                 .unwrap_or(true)
         {
+            trace!(
+                "Effect asset with handle {:?} is not visible, and simulates only WhenVisible; skipped initializers tick.",
+                effect.handle
+            );
             continue;
         }
 


### PR DESCRIPTION
- Remove the unused `HashMap` for extracted effects, simply extract them into a `Vec`. We don't need the lookup anymore.
- Extract the `GlobalTransform` as is, and do any conversion to GPU transform later during processing when the main world is not locked.