### PR TITLE
Split properties into new `PropertyCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed the `ParticleEffect` component to require the `CompiledParticleEffect` and `SyncToRenderWorld` components.
+- Renamed `PropertyLayout::size()` to `cpu_size()` to prevent confusion.
+  The GPU size is given by `min_binding_size()`, and can be greater.
+- `PropertyLayout::generate_code()` now returns an `Option<String>` for clarity,
+  which is `None` if the layout is empty (as opposed to an empty string previously).
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,15 @@ required-features = [
     "bevy/bevy_window",
 ]
 
+[[test]]
+name = "properties"
+path = "gpu_tests/properties.rs"
+harness = false
+required-features = [
+    "bevy/bevy_winit",
+    "bevy/bevy_window",
+]
+
 [workspace]
 resolver = "2"
 members = ["."]

--- a/gpu_tests/properties.rs
+++ b/gpu_tests/properties.rs
@@ -1,0 +1,81 @@
+//! Test for effect properties.
+//!
+//! - Add an effect with a property.
+//! - Start running.
+//! - Replace the effect with a new one having no property.
+//!
+//! The backend should automatically de-allocate the property storage, and
+//! gracefully re-create any GPU bind group layout and bind group without any
+//! property reference.
+
+use bevy::{app::AppExit, core_pipeline::tonemapping::Tonemapping, log::LogPlugin, prelude::*};
+use bevy_hanabi::prelude::*;
+
+#[derive(Default, Resource)]
+struct Frame(pub u32);
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::default();
+    app.insert_resource(ClearColor(Color::BLACK))
+        .add_plugins(DefaultPlugins.set(LogPlugin {
+            level: bevy::log::Level::INFO,
+            filter: "bevy_hanabi=trace,wgpu_hal=warn".to_string(),
+            ..default()
+        }))
+        .add_plugins(HanabiPlugin)
+        .init_resource::<Frame>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, timeout)
+        .run();
+
+    Ok(())
+}
+
+fn setup(mut commands: Commands, mut assets: ResMut<Assets<EffectAsset>>) {
+    let mut module = Module::default();
+    module.add_property("my_property", VectorValue::new_vec3(Vec3::ZERO).into());
+    let pos = module.lit(Vec3::ZERO);
+    let mut asset = EffectAsset::new(128, Spawner::rate(1.0.into()), module)
+        .init(SetAttributeModifier::new(Attribute::POSITION, pos));
+    asset.name = "test_asset".to_string();
+    let handle = assets.add(asset);
+
+    commands.spawn((Camera3d::default(), Tonemapping::None));
+    commands.spawn(ParticleEffectBundle {
+        effect: ParticleEffect::new(handle),
+        ..default()
+    });
+}
+
+fn timeout(
+    mut commands: Commands,
+    mut assets: ResMut<Assets<EffectAsset>>,
+    mut frame: ResMut<Frame>,
+    mut query: Query<(Entity, &mut ParticleEffect)>,
+    mut ev_app_exit: EventWriter<AppExit>,
+) {
+    frame.0 += 1;
+
+    if frame.0 == 10 {
+        let (_, mut effect) = query.single_mut();
+
+        // New effect without any property
+        let mut module = Module::default();
+        let pos = module.lit(Vec3::ZERO);
+        let asset = EffectAsset::new(128, Spawner::rate(1.0.into()), module)
+            .init(SetAttributeModifier::new(Attribute::POSITION, pos));
+        let handle = assets.add(asset);
+
+        effect.handle = handle;
+    }
+
+    if frame.0 == 15 {
+        let (entity, _) = query.single();
+        commands.entity(entity).despawn_recursive();
+    }
+
+    if frame.0 >= 20 {
+        info!("SUCCESS!");
+        ev_app_exit.send(AppExit::Success);
+    }
+}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -30,8 +30,8 @@ use crate::{
         DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache,
         EffectsMeta, ExtractedEffects, GpuDispatchIndirect, GpuParticleGroup,
         GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline,
-        ParticlesRenderPipeline, ParticlesUpdatePipeline, ShaderCache, SimParams, StorageType as _,
-        VfxSimulateDriverNode, VfxSimulateNode,
+        ParticlesRenderPipeline, ParticlesUpdatePipeline, PropertyCache, ShaderCache, SimParams,
+        StorageType as _, VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_initializers,
@@ -277,13 +277,15 @@ impl Plugin for HanabiPlugin {
             EffectsMeta::new(render_device.clone(), &mut assets)
         };
 
-        let effect_cache = EffectCache::new(render_device);
+        let effect_cache = EffectCache::new(render_device.clone());
+        let property_cache = PropertyCache::new(render_device);
 
         // Register the custom render pipeline
         let render_app = app.sub_app_mut(RenderApp);
         render_app
             .insert_resource(effects_meta)
             .insert_resource(effect_cache)
+            .insert_resource(property_cache)
             .init_resource::<EffectBindGroups>()
             .init_resource::<DispatchIndirectPipeline>()
             .init_resource::<ParticlesInitPipeline>()

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -252,7 +252,7 @@ struct FreeRow(pub Range<u32>);
 
 impl PartialOrd for FreeRow {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.start.partial_cmp(&other.0.start)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use std::{num::NonZeroU64, ops::Range};
 
 use bevy::{
     log::trace,
@@ -11,6 +11,7 @@ use bevy::{
 };
 use bytemuck::{cast_slice, Pod};
 use copyless::VecHelper;
+use wgpu::{BindingResource, BufferBinding};
 
 /// Like Bevy's [`BufferVec`], but with extra per-item alignment.
 ///
@@ -246,8 +247,511 @@ impl<T: Pod + ShaderSize> std::ops::IndexMut<usize> for AlignedBufferVec<T> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FreeRow(pub Range<u32>);
+
+impl PartialOrd for FreeRow {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.start.partial_cmp(&other.0.start)
+    }
+}
+
+impl Ord for FreeRow {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.start.cmp(&other.0.start)
+    }
+}
+
+/// Like [`AlignedBufferVec`], but for heterogenous data.
+#[derive(Debug)]
+pub struct HybridAlignedBufferVec {
+    /// Pending values accumulated on CPU and not yet written to GPU.
+    values: Vec<u8>,
+    /// GPU buffer if already allocated, or `None` otherwise.
+    buffer: Option<Buffer>,
+    /// Capacity of the buffer, in bytes.
+    capacity: usize,
+    /// Alignment of each element, in bytes.
+    item_align: usize,
+    /// GPU buffer usages.
+    buffer_usage: BufferUsages,
+    /// Optional GPU buffer name, for debugging.
+    label: Option<String>,
+    /// Free ranges available for re-allocation. Those are row ranges; byte
+    /// ranges are obtained by multiplying these by `item_align`.
+    free_rows: Vec<FreeRow>,
+    /// Is the GPU buffer stale and the CPU one need to be re-uploaded?
+    is_stale: bool,
+}
+
+impl HybridAlignedBufferVec {
+    /// Create a new collection.
+    ///
+    /// `item_align` is an optional additional alignment for items in the
+    /// collection. If greater than the natural alignment dictated by WGSL
+    /// rules, this extra alignment is enforced. Otherwise it's ignored (so you
+    /// can pass `None` to ignore, which defaults to no alignment).
+    pub fn new(
+        buffer_usage: BufferUsages,
+        item_align: Option<NonZeroU64>,
+        label: Option<String>,
+    ) -> Self {
+        let item_align = item_align.map(|nz| nz.get()).unwrap_or(1) as usize;
+        trace!(
+            "HybridAlignedBufferVec['{}']: item_align={} byte",
+            label.as_ref().map(|s| &s[..]).unwrap_or(""),
+            item_align,
+        );
+        Self {
+            values: vec![],
+            buffer: None,
+            capacity: 0,
+            item_align,
+            buffer_usage,
+            label,
+            free_rows: vec![],
+            is_stale: true,
+        }
+    }
+
+    #[inline]
+    pub fn buffer(&self) -> Option<&Buffer> {
+        self.buffer.as_ref()
+    }
+
+    /// Get a binding for the entire buffer.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn max_binding(&self) -> Option<BindingResource> {
+        // FIXME - Return a Buffer wrapper first, which can be unwrapped, then from that
+        // wrapper implement all the xxx_binding() helpers. That avoids a bunch of "if
+        // let Some()" everywhere when we know the buffer is valid. The only reason the
+        // buffer might not be valid is if it was not created, and in that case
+        // we wouldn't be calling the xxx_bindings() helpers, we'd have earlied out
+        // before.
+        let buffer = self.buffer()?;
+        Some(BindingResource::Buffer(BufferBinding {
+            buffer,
+            offset: 0,
+            size: None, // entire buffer
+        }))
+    }
+
+    /// Get a binding for the first `size` bytes of the buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` is zero.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn lead_binding(&self, size: u32) -> Option<BindingResource> {
+        let buffer = self.buffer()?;
+        let size = NonZeroU64::new(size as u64).unwrap();
+        Some(BindingResource::Buffer(BufferBinding {
+            buffer,
+            offset: 0,
+            size: Some(size),
+        }))
+    }
+
+    /// Get a binding for a subset of the elements of the buffer.
+    ///
+    /// Returns a binding for the elements in the range `offset..offset+count`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `offset` is not a multiple of the alignment specified on
+    /// construction.
+    ///
+    /// Panics if `size` is zero.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn range_binding(&self, offset: u32, size: u32) -> Option<BindingResource> {
+        assert!(offset as usize % self.item_align == 0);
+        let buffer = self.buffer()?;
+        let size = NonZeroU64::new(size as u64).unwrap();
+        Some(BindingResource::Buffer(BufferBinding {
+            buffer,
+            offset: offset as u64,
+            size: Some(size),
+        }))
+    }
+
+    /// Capacity of the allocated GPU buffer, in bytes.
+    ///
+    /// This may be zero if the buffer was not allocated yet. In general, this
+    /// can differ from the actual data size cached on CPU and waiting to be
+    /// uploaded to GPU.
+    #[inline]
+    #[allow(dead_code)]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    // #[inline]
+    // pub fn len(&self) -> usize {
+    //     self.values.len()
+    // }
+
+    /// Alignment, in bytes, of all the elements.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn item_align(&self) -> usize {
+        self.item_align
+    }
+
+    /// Calculate a dynamic byte offset for a bind group from an array element
+    /// index.
+    ///
+    /// This returns the product of `index` by the internal [`item_align()`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the `index` is too large, producing a byte offset larger than
+    /// `u32::MAX`.
+    ///
+    /// [`item_align()`]: crate::HybridAlignedBufferVec::item_align
+    #[allow(dead_code)]
+    #[inline]
+    pub fn dynamic_offset(&self, index: usize) -> u32 {
+        let offset = self.item_align * index;
+        assert!(offset <= u32::MAX as usize);
+        u32::try_from(offset).expect("HybridAlignedBufferVec index out of bounds")
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Append a value to the buffer.
+    ///
+    /// As with [`set_content()`], the content is stored on the CPU and uploaded
+    /// on the GPU once [`write_buffers()`] is called.
+    ///
+    /// # Returns
+    ///
+    /// Returns a range starting at the byte offset at which the new element was
+    /// inserted, which is guaranteed to be a multiple of [`item_align()`].
+    /// The range span is the item byte size.
+    ///
+    /// [`item_align()`]: self::HybridAlignedBufferVec::item_align
+    #[allow(dead_code)]
+    pub fn push<T: Pod + ShaderSize>(&mut self, value: &T) -> Range<u32> {
+        let src: &[u8] = cast_slice(std::slice::from_ref(value));
+        assert_eq!(value.size().get() as usize, src.len());
+        self.push_raw(src)
+    }
+
+    /// Append a slice of values to the buffer.
+    ///
+    /// The values are assumed to be tightly packed, and will be copied
+    /// back-to-back into the buffer, without any padding between them. This
+    /// means that the individul slice items must be properly aligned relative
+    /// to the beginning of the slice.
+    ///
+    /// As with [`set_content()`], the content is stored on the CPU and uploaded
+    /// on the GPU once [`write_buffers()`] is called.
+    ///
+    /// # Returns
+    ///
+    /// Returns a range starting at the byte offset at which the new element
+    /// (the slice) was inserted, which is guaranteed to be a multiple of
+    /// [`item_align()`]. The range span is the item byte size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the byte size of the element `T` is not at least a multiple of
+    /// the minimum GPU alignment, which is 4 bytes. Note that this doesn't
+    /// guarantee that the written data is well-formed for use on GPU, as array
+    /// elements on GPU have other alignment requirements according to WGSL, but
+    /// at least this catches obvious errors.
+    ///
+    /// [`item_align()`]: self::HybridAlignedBufferVec::item_align
+    #[allow(dead_code)]
+    pub fn push_many<T: Pod + ShaderSize>(&mut self, value: &[T]) -> Range<u32> {
+        assert_eq!(size_of::<T>() % 4, 0);
+        let src: &[u8] = cast_slice(value);
+        self.push_raw(src)
+    }
+
+    pub fn push_raw(&mut self, src: &[u8]) -> Range<u32> {
+        self.is_stale = true;
+
+        // Calculate the number of (aligned) rows to allocate
+        let num_rows = src.len().div_ceil(self.item_align) as u32;
+
+        // Try to find a block of free rows which can accomodate it, and pick the
+        // smallest one in order to limit wasted space.
+        let mut best_slot: Option<(u32, usize)> = None;
+        for (index, range) in self.free_rows.iter().enumerate() {
+            let free_rows = range.0.end - range.0.start;
+            if free_rows >= num_rows {
+                let wasted_rows = free_rows - num_rows;
+                // If we found a slot with the exact size, just use it already
+                if wasted_rows == 0 {
+                    best_slot = Some((0, index));
+                    break;
+                }
+                // Otherwise try to find the smallest oversized slot to reduce wasted space
+                if let Some(best_slot) = best_slot.as_mut() {
+                    if wasted_rows < best_slot.0 {
+                        *best_slot = (wasted_rows, index);
+                    }
+                } else {
+                    best_slot = Some((wasted_rows, index));
+                }
+            }
+        }
+
+        // Insert into existing space
+        if let Some((_, index)) = best_slot {
+            let row_range = self.free_rows.remove(index);
+            debug_assert_eq!(row_range.0.start as usize % self.item_align, 0);
+            let offset = row_range.0.start as usize * self.item_align;
+            let free_size = (row_range.0.end - row_range.0.start) as usize * self.item_align;
+            let size = src.len();
+            assert!(size <= free_size);
+
+            let dst = self.values.as_mut_ptr();
+            // SAFETY: dst is guaranteed to point to allocated bytes, which are already
+            // initialized from a previous call, and are initialized by overwriting the
+            // bytes with those of a POD type.
+            #[allow(unsafe_code)]
+            unsafe {
+                let dst = dst.add(offset);
+                dst.copy_from_nonoverlapping(src.as_ptr(), size);
+            }
+
+            let start = offset as u32;
+            let end = start + size as u32;
+            start..end
+        }
+        // Insert at end of vector, after resizing it
+        else {
+            // Calculate new aligned insertion offset and new capacity
+            let offset = self.values.len().next_multiple_of(self.item_align);
+            let size = src.len();
+            let new_capacity = offset + size;
+            if new_capacity > self.values.capacity() {
+                self.values.reserve(new_capacity - self.values.len())
+            }
+
+            // Insert padding if needed
+            if offset > self.values.len() {
+                self.values.resize(offset, 0);
+            }
+
+            // Insert serialized value
+            // Dealing with safe code via Vec::spare_capacity_mut() is quite difficult
+            // without the upcoming (unstable) additions to MaybeUninit to deal with arrays.
+            // To prevent having to loop over individual u8, we use direct pointers instead.
+            assert!(self.values.capacity() >= offset + size);
+            assert_eq!(self.values.len(), offset);
+            let dst = self.values.as_mut_ptr();
+            // SAFETY: dst is guaranteed to point to allocated (offset+size) bytes, which
+            // are written by copying a Pod type, so ensures those values are initialized,
+            // and the final size is set to exactly (offset+size).
+            #[allow(unsafe_code)]
+            unsafe {
+                let dst = dst.add(offset);
+                dst.copy_from_nonoverlapping(src.as_ptr(), size);
+                self.values.set_len(offset + size);
+            }
+
+            debug_assert_eq!(offset % self.item_align, 0);
+            let start = offset as u32;
+            let end = start + size as u32;
+            start..end
+        }
+    }
+
+    /// Remove a range of bytes previously added.
+    ///
+    /// Remove a range of bytes previously returned by adding one or more
+    /// elements with [`push()`] or [`push_many()`].
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the range was valid and the corresponding data was
+    /// removed, or `false` otherwise. In that case, the buffer is not modified.
+    ///
+    /// [`push()`]: Self::push
+    /// [`push_many()`]: Self::push_many
+    pub fn remove(&mut self, range: Range<u32>) -> bool {
+        // Can only remove entire blocks starting at an aligned size
+        let align = self.item_align as u32;
+        if range.start % align != 0 {
+            return false;
+        }
+
+        // Check for out of bounds argument
+        let end = self.values.len() as u32;
+        if range.start >= end || range.end > end {
+            return false;
+        }
+
+        // Note: See below, sometimes self.values() has some padding left we couldn't
+        // recover earlier beause we didn't know the size of this allocation, but we
+        // need to still deallocate the row here.
+        if range.end == end || range.end.next_multiple_of(align) == end {
+            // If the allocation is at the end of the buffer, shorten the CPU values. This
+            // ensures is_empty() eventually returns true.
+            let mut new_row_end = range.start.div_ceil(align);
+
+            // Walk the (sorted) free list to also dequeue any range which is now at the end
+            // of the buffer
+            while let Some(free_row) = self.free_rows.pop() {
+                if free_row.0.end == new_row_end {
+                    new_row_end = free_row.0.start;
+                } else {
+                    self.free_rows.push(free_row);
+                    break;
+                }
+            }
+
+            // Note: we can't really recover any padding here because we don't know the
+            // exact size of that allocation, only its row-aligned size.
+            self.values.truncate((new_row_end * align) as usize);
+        } else {
+            // Otherwise, save the row into the free list.
+            let start = range.start / align;
+            let end = range.end.div_ceil(align);
+            let free_row = FreeRow(start..end);
+
+            // Insert as sorted
+            if self.free_rows.is_empty() {
+                // Special case to simplify below, and to avoid binary_search()
+                self.free_rows.push(free_row);
+            } else if let Err(index) = self.free_rows.binary_search(&free_row) {
+                if index >= self.free_rows.len() {
+                    // insert at end
+                    let prev = self.free_rows.last_mut().unwrap(); // known
+                    if prev.0.end == free_row.0.start {
+                        // merge with last value
+                        prev.0.end = free_row.0.end;
+                    } else {
+                        // insert last, with gap
+                        self.free_rows.push(free_row);
+                    }
+                } else if index == 0 {
+                    // insert at start
+                    let next = &mut self.free_rows[0];
+                    if free_row.0.end == next.0.start {
+                        // merge with next
+                        next.0.start = free_row.0.start;
+                    } else {
+                        // insert first, with gap
+                        self.free_rows.insert(0, free_row);
+                    }
+                } else {
+                    // insert between 2 existing elements
+                    let prev = &mut self.free_rows[index - 1];
+                    if prev.0.end == free_row.0.start {
+                        // merge with previous value
+                        prev.0.end = free_row.0.end;
+
+                        let prev = self.free_rows[index - 1].clone();
+                        let next = &mut self.free_rows[index];
+                        if prev.0.end == next.0.start {
+                            // also merge prev with next, and remove prev
+                            next.0.start = prev.0.start;
+                            self.free_rows.remove(index - 1);
+                        }
+                    } else {
+                        let next = &mut self.free_rows[index];
+                        if free_row.0.end == next.0.start {
+                            // merge with next value
+                            next.0.start = free_row.0.start;
+                        } else {
+                            // insert between 2 values, with gaps on both sides
+                            self.free_rows.insert(0, free_row);
+                        }
+                    }
+                }
+            } else {
+                // The range exists in the free list, this means it's already removed. This is a
+                // duplicate; ignore it.
+                return false;
+            }
+        }
+        self.is_stale = true;
+        true
+    }
+
+    /// Reserve some capacity into the buffer.
+    ///
+    /// If the buffer is reallocated, the old content (on the GPU) is lost, and
+    /// needs to be re-uploaded to the newly-created buffer. This is done with
+    /// [`write_buffer()`].
+    ///
+    /// # Returns
+    ///
+    /// `true` if the buffer was (re)allocated, or `false` if an existing buffer
+    /// was reused which already had enough capacity.
+    ///
+    /// [`write_buffer()`]: crate::AlignedBufferVec::write_buffer
+    pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) -> bool {
+        if capacity > self.capacity {
+            trace!(
+                "reserve: increase capacity from {} to {} bytes",
+                self.capacity,
+                capacity,
+            );
+            self.capacity = capacity;
+            self.buffer = Some(device.create_buffer(&BufferDescriptor {
+                label: self.label.as_ref().map(|s| &s[..]),
+                size: capacity as BufferAddress,
+                usage: BufferUsages::COPY_DST | self.buffer_usage,
+                mapped_at_creation: false,
+            }));
+            self.is_stale = !self.values.is_empty();
+            // FIXME - this discards the old content if any!!!
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Schedule the buffer write to GPU.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the buffer was (re)allocated, `false` otherwise. If the buffer
+    /// was reallocated, all bind groups referencing the old buffer should be
+    /// destroyed.
+    pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) -> bool {
+        if self.values.is_empty() || !self.is_stale {
+            return false;
+        }
+        let size = self.values.len();
+        trace!(
+            "hybrid abv: write_buffer: size={}B item_align={}B",
+            size,
+            self.item_align,
+        );
+        let buffer_changed = self.reserve(size, device);
+        if let Some(buffer) = &self.buffer {
+            queue.write_buffer(buffer, 0, self.values.as_slice());
+            self.is_stale = false;
+        }
+        buffer_changed
+    }
+
+    #[allow(dead_code)]
+    pub fn clear(&mut self) {
+        if !self.values.is_empty() {
+            self.is_stale = true;
+        }
+        self.values.clear();
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use bevy::math::Vec3;
     use bytemuck::{Pod, Zeroable};
 
@@ -358,6 +862,166 @@ mod tests {
             });
             assert!(!abv.is_empty());
             assert_eq!(abv.len(), 1);
+        }
+    }
+
+    #[test]
+    fn habv_remove() {
+        let mut habv =
+            HybridAlignedBufferVec::new(BufferUsages::STORAGE, NonZeroU64::new(32), None);
+        assert!(habv.is_empty());
+        assert_eq!(habv.item_align, 32);
+
+        // +r -r
+        {
+            let r = habv.push(&42u32);
+            assert_eq!(r, 0..4);
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 4);
+            assert!(habv.free_rows.is_empty());
+
+            assert!(habv.remove(r));
+            assert!(habv.is_empty());
+            assert!(habv.values.is_empty());
+            assert!(habv.free_rows.is_empty());
+        }
+
+        // +r0 +r1 +r2 -r0 -r0 -r1 -r2
+        {
+            let r0 = habv.push(&42u32);
+            let r1 = habv.push(&84u32);
+            let r2 = habv.push(&84u32);
+            assert_eq!(r0, 0..4);
+            assert_eq!(r1, 32..36);
+            assert_eq!(r2, 64..68);
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert!(habv.free_rows.is_empty());
+
+            assert!(habv.remove(r0.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert_eq!(habv.free_rows.len(), 1);
+            assert_eq!(habv.free_rows[0], FreeRow(0..1));
+
+            // dupe; no-op
+            assert!(!habv.remove(r0));
+
+            assert!(habv.remove(r1.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert_eq!(habv.free_rows.len(), 1); // merged!
+            assert_eq!(habv.free_rows[0], FreeRow(0..2));
+
+            assert!(habv.remove(r2));
+            assert!(habv.is_empty());
+            assert_eq!(habv.values.len(), 0);
+            assert!(habv.free_rows.is_empty());
+        }
+
+        // +r0 +r1 +r2 -r1 -r0 -r2
+        {
+            let r0 = habv.push(&42u32);
+            let r1 = habv.push(&84u32);
+            let r2 = habv.push(&84u32);
+            assert_eq!(r0, 0..4);
+            assert_eq!(r1, 32..36);
+            assert_eq!(r2, 64..68);
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert!(habv.free_rows.is_empty());
+
+            assert!(habv.remove(r1.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert_eq!(habv.free_rows.len(), 1);
+            assert_eq!(habv.free_rows[0], FreeRow(1..2));
+
+            assert!(habv.remove(r0.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert_eq!(habv.free_rows.len(), 1); // merged!
+            assert_eq!(habv.free_rows[0], FreeRow(0..2));
+
+            assert!(habv.remove(r2));
+            assert!(habv.is_empty());
+            assert_eq!(habv.values.len(), 0);
+            assert!(habv.free_rows.is_empty());
+        }
+
+        // +r0 +r1 +r2 -r1 -r2 -r0
+        {
+            let r0 = habv.push(&42u32);
+            let r1 = habv.push(&84u32);
+            let r2 = habv.push(&84u32);
+            assert_eq!(r0, 0..4);
+            assert_eq!(r1, 32..36);
+            assert_eq!(r2, 64..68);
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert!(habv.free_rows.is_empty());
+
+            assert!(habv.remove(r1.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 68);
+            assert_eq!(habv.free_rows.len(), 1);
+            assert_eq!(habv.free_rows[0], FreeRow(1..2));
+
+            assert!(habv.remove(r2.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 32); // can't recover exact alloc (4), only row-aligned size (32)
+            assert!(habv.free_rows.is_empty()); // merged!
+
+            assert!(habv.remove(r0));
+            assert!(habv.is_empty());
+            assert_eq!(habv.values.len(), 0);
+            assert!(habv.free_rows.is_empty());
+        }
+
+        // +r0 +r1 +r2 +r3 +r4 -r3 -r1 -r2 -r4 r0
+        {
+            let r0 = habv.push(&42u32);
+            let r1 = habv.push(&84u32);
+            let r2 = habv.push(&84u32);
+            let r3 = habv.push(&84u32);
+            let r4 = habv.push(&84u32);
+            assert_eq!(r0, 0..4);
+            assert_eq!(r1, 32..36);
+            assert_eq!(r2, 64..68);
+            assert_eq!(r3, 96..100);
+            assert_eq!(r4, 128..132);
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 132);
+            assert!(habv.free_rows.is_empty());
+
+            assert!(habv.remove(r3.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 132);
+            assert_eq!(habv.free_rows.len(), 1);
+            assert_eq!(habv.free_rows[0], FreeRow(3..4));
+
+            assert!(habv.remove(r1.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 132);
+            assert_eq!(habv.free_rows.len(), 2);
+            assert_eq!(habv.free_rows[0], FreeRow(1..2)); // sorted!
+            assert_eq!(habv.free_rows[1], FreeRow(3..4));
+
+            assert!(habv.remove(r2.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 132);
+            assert_eq!(habv.free_rows.len(), 1); // merged!
+            assert_eq!(habv.free_rows[0], FreeRow(1..4)); // merged!
+
+            assert!(habv.remove(r4.clone()));
+            assert!(!habv.is_empty());
+            assert_eq!(habv.values.len(), 32); // can't recover exact alloc (4), only row-aligned size (32)
+            assert!(habv.free_rows.is_empty());
+
+            assert!(habv.remove(r0));
+            assert!(habv.is_empty());
+            assert_eq!(habv.values.len(), 0);
+            assert!(habv.free_rows.is_empty());
         }
     }
 }

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 use super::{
     effect_cache::{DispatchBufferIndices, EffectSlices},
-    CachedMesh, LayoutFlags,
+    CachedMesh, LayoutFlags, PropertyBindGroupKey,
 };
 use crate::{
     spawn::EffectInitializer, AlphaMode, EffectAsset, EffectShader, ParticleLayout, TextureLayout,
@@ -30,6 +30,12 @@ pub(crate) struct EffectBatches {
     pub group_batches: Vec<EffectBatch>,
     /// Index of the buffer.
     pub buffer_index: u32,
+    /// Index of the property buffer, if any.
+    pub property_key: Option<PropertyBindGroupKey>,
+    /// Offset in bytes into the property buffer where the Property struct is
+    /// located for this effect.
+    // FIXME: This is a per-instance value which prevents batching :(
+    pub property_offset: Option<u32>,
     /// Index of the first Spawner of the effects in the batch.
     pub spawner_base: u32,
     /// The initializer (spawner or cloner) for each particle group.
@@ -118,9 +124,14 @@ impl EffectBatches {
         init_and_update_pipeline_ids: Vec<InitAndUpdatePipelineIds>,
         dispatch_buffer_indices: DispatchBufferIndices,
         first_particle_group_buffer_index: u32,
+        property_key: Option<PropertyBindGroupKey>,
+        property_offset: Option<u32>,
     ) -> EffectBatches {
+        assert_eq!(property_key.is_some(), property_offset.is_some());
         EffectBatches {
             buffer_index: input.effect_slices.buffer_index,
+            property_key,
+            property_offset,
             spawner_base,
             initializers: input.initializers.clone(),
             particle_layout: input.effect_slices.particle_layout.clone(),

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -301,6 +301,7 @@ impl EffectBuffer {
             render_device.limits().min_storage_buffer_offset_alignment,
         );
         let mut entries = vec![
+            // @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
             BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::VERTEX,
@@ -311,6 +312,7 @@ impl EffectBuffer {
                 },
                 count: None,
             },
+            // @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
             BindGroupLayoutEntry {
                 binding: 1,
                 visibility: ShaderStages::VERTEX,
@@ -321,6 +323,7 @@ impl EffectBuffer {
                 },
                 count: None,
             },
+            // @group(1) @binding(2) var<storage, read> dispatch_indirect : DispatchIndirect;
             BindGroupLayoutEntry {
                 binding: 2,
                 visibility: ShaderStages::VERTEX,
@@ -333,6 +336,7 @@ impl EffectBuffer {
             },
         ];
         if layout_flags.contains(LayoutFlags::LOCAL_SPACE_SIMULATION) {
+            // @group(1) @binding(3) var<storage, read> spawner : Spawner;
             entries.push(BindGroupLayoutEntry {
                 binding: 3,
                 visibility: ShaderStages::VERTEX,

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -873,7 +873,7 @@ impl EffectCache {
         let effect_buffer: &mut Option<EffectBuffer> =
             self.buffers.get_mut(buffer_index as usize).ok_or(())?;
         let effect_buffer = effect_buffer.as_mut().ok_or(())?;
-        effect_buffer.create_sim_bind_group(buffer_index, &render_device, group_binding);
+        effect_buffer.create_sim_bind_group(buffer_index, render_device, group_binding);
         Ok(())
     }
 

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -15,7 +15,7 @@ use crate::{
     render::{
         GpuDispatchIndirect, GpuParticleGroup, GpuSpawnerParams, LayoutFlags, StorageType as _,
     },
-    ParticleLayout, PropertyLayout,
+    ParticleLayout,
 };
 
 /// Describes all particle groups' slices of particles in the particle buffer
@@ -133,13 +133,8 @@ pub struct EffectBuffer {
     ///   and 1
     /// - the dead particle indices at offset 2
     indirect_buffer: Buffer,
-    /// GPU buffer holding the properties of the effect(s), if any. This is
-    /// always `None` if the property layout is empty.
-    properties_buffer: Option<Buffer>,
     /// Layout of particles.
     particle_layout: ParticleLayout,
-    /// Layout of properties of the effect(s), if using properties.
-    property_layout: PropertyLayout,
     /// Flags
     layout_flags: LayoutFlags,
     /// -
@@ -191,19 +186,16 @@ impl EffectBuffer {
         asset: Handle<EffectAsset>,
         capacity: u32,
         particle_layout: ParticleLayout,
-        property_layout: PropertyLayout,
         layout_flags: LayoutFlags,
         render_device: &RenderDevice,
         label: Option<&str>,
     ) -> Self {
         trace!(
-            "EffectBuffer::new(capacity={}, particle_layout={:?}, property_layout={:?}, layout_flags={:?}, item_size={}B, properties_size={}B)",
+            "EffectBuffer::new(capacity={}, particle_layout={:?}, layout_flags={:?}, item_size={}B)",
             capacity,
             particle_layout,
-            property_layout,
             layout_flags,
             particle_layout.min_binding_size().get(),
-            if property_layout.is_empty() { 0 } else { property_layout.min_binding_size().get() },
         );
 
         let capacity = capacity.max(Self::MIN_CAPACITY);
@@ -214,8 +206,11 @@ impl EffectBuffer {
 
         let particle_capacity_bytes: BufferAddress =
             capacity as u64 * particle_layout.min_binding_size().get();
+        let particle_label = label
+            .map(|s| format!("hanabi:buffer:effect{s}_particle"))
+            .unwrap_or("hanabi:buffer:effect_particle".to_owned());
         let particle_buffer = render_device.create_buffer(&BufferDescriptor {
-            label,
+            label: Some(&particle_label),
             size: particle_capacity_bytes,
             usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
             mapped_at_creation: false,
@@ -223,11 +218,9 @@ impl EffectBuffer {
 
         let capacity_bytes: BufferAddress = capacity as u64 * 4;
 
-        let indirect_label = if let Some(label) = label {
-            format!("{label}_indirect")
-        } else {
-            "hanabi:buffer:effect_indirect".to_owned()
-        };
+        let indirect_label = label
+            .map(|s| format!("hanabi:buffer:effect{s}_indirect"))
+            .unwrap_or("hanabi:buffer:effect_indirect".to_owned());
         let indirect_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some(&indirect_label),
             size: capacity_bytes * 3, // ping-pong + deadlist
@@ -248,30 +241,14 @@ impl EffectBuffer {
             indirect_buffer.unmap();
         }
 
-        let properties_buffer = if property_layout.is_empty() {
-            None
-        } else {
-            let properties_label = if let Some(label) = label {
-                format!("{}_properties", label)
-            } else {
-                "hanabi:buffer:effect_properties".to_owned()
-            };
-            let size = property_layout.min_binding_size().get(); // TODO: * num_effects_in_buffer (once batching works again)
-            let properties_buffer = render_device.create_buffer(&BufferDescriptor {
-                label: Some(&properties_label),
-                size,
-                usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
-                mapped_at_creation: false,
-            });
-            Some(properties_buffer)
-        };
-
         // TODO - Cache particle_layout and associated bind group layout, instead of
         // creating one bind group layout per buffer using that layout...
+        // FIXME - the layout is duplicated in ParticlesInitPipeline and
+        // ParticlesUpdatePipeline.
         let particle_group_size = GpuParticleGroup::aligned_size(
             render_device.limits().min_storage_buffer_offset_alignment,
         );
-        let mut entries = vec![
+        let entries = [
             // @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer
             BindGroupLayoutEntry {
                 binding: 0,
@@ -290,7 +267,7 @@ impl EffectBuffer {
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: false },
                     has_dynamic_offset: false,
-                    min_binding_size: BufferSize::new(12),
+                    min_binding_size: Some(NonZeroU64::new(12).unwrap()),
                 },
                 count: None,
             },
@@ -308,25 +285,16 @@ impl EffectBuffer {
                 count: None,
             },
         ];
-        if !property_layout.is_empty() {
-            entries.push(BindGroupLayoutEntry {
-                binding: 3,
-                visibility: ShaderStages::COMPUTE,
-                ty: BindingType::Buffer {
-                    ty: BufferBindingType::Storage { read_only: true },
-                    has_dynamic_offset: false, // TODO
-                    min_binding_size: Some(property_layout.min_binding_size()),
-                },
-                count: None,
-            });
-        }
-        let label = "hanabi:sim_particles_buffer_layout";
+        let bgl_label = label
+            .map(|s| format!("hanabi:bind_group_layout:effect{s}"))
+            .unwrap_or("hanabi:bind_group_layout:effect".to_owned());
         trace!(
             "Creating particle bind group layout '{}' for simulation passes with {} entries.",
-            label,
+            bgl_label,
             entries.len(),
         );
-        let particles_buffer_layout_sim = render_device.create_bind_group_layout(label, &entries);
+        let particles_buffer_layout_sim =
+            render_device.create_bind_group_layout(Some(&bgl_label[..]), &entries);
 
         // Create the render layout.
         let dispatch_indirect_size = GpuDispatchIndirect::aligned_size(
@@ -387,9 +355,7 @@ impl EffectBuffer {
         Self {
             particle_buffer,
             indirect_buffer,
-            properties_buffer,
             particle_layout,
-            property_layout,
             layout_flags,
             particles_buffer_layout_sim,
             particles_buffer_layout_with_dispatch,
@@ -401,16 +367,8 @@ impl EffectBuffer {
         }
     }
 
-    pub fn properties_buffer(&self) -> Option<&Buffer> {
-        self.properties_buffer.as_ref()
-    }
-
     pub fn particle_layout(&self) -> &ParticleLayout {
         &self.particle_layout
-    }
-
-    pub fn property_layout(&self) -> &PropertyLayout {
-        &self.property_layout
     }
 
     pub fn layout_flags(&self) -> LayoutFlags {
@@ -457,19 +415,6 @@ impl EffectBuffer {
         })
     }
 
-    /// Return a binding for the entire properties buffer associated with the
-    /// current effect buffer, if any.
-    pub fn properties_max_binding(&self) -> Option<BindingResource> {
-        self.properties_buffer.as_ref().map(|buffer| {
-            let capacity_bytes = self.property_layout.min_binding_size().get();
-            BindingResource::Buffer(BufferBinding {
-                buffer,
-                offset: 0,
-                size: Some(NonZeroU64::new(capacity_bytes).unwrap()),
-            })
-        })
-    }
-
     /// Create the bind group for the init and update passes if needed.
     ///
     /// The `buffer_index` must be the index of the current [`EffectBuffer`]
@@ -487,7 +432,7 @@ impl EffectBuffer {
 
         let layout = self.particle_layout_bind_group_sim();
         let label = format!("hanabi:bind_group_sim_batch{}", buffer_index);
-        let mut bindings = vec![
+        let bindings = [
             BindGroupEntry {
                 binding: 0,
                 resource: self.max_binding(),
@@ -501,12 +446,6 @@ impl EffectBuffer {
                 resource: BindingResource::Buffer(group_binding),
             },
         ];
-        if let Some(property_binding) = self.properties_max_binding() {
-            bindings.push(BindGroupEntry {
-                binding: 3,
-                resource: property_binding,
-            });
-        }
         trace!(
             "Create simulate bind group '{}' with {} entries",
             label,
@@ -514,6 +453,12 @@ impl EffectBuffer {
         );
         let bind_group = render_device.create_bind_group(Some(&label[..]), layout, &bindings);
         self.simulate_bind_group = Some(bind_group);
+    }
+
+    /// Clear the bind group for the init and update passes.
+    #[allow(dead_code)]
+    pub fn clear_sim_bind_group(&mut self) {
+        self.simulate_bind_group = None;
     }
 
     /// Return the cached bind group for the init and update passes.
@@ -793,13 +738,27 @@ impl EffectCache {
     }
 
     #[allow(dead_code)]
+    #[inline]
     pub fn buffers(&self) -> &[Option<EffectBuffer>] {
         &self.buffers
     }
 
     #[allow(dead_code)]
+    #[inline]
     pub fn buffers_mut(&mut self) -> &mut [Option<EffectBuffer>] {
         &mut self.buffers
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn get_buffer(&self, buffer_index: u32) -> Option<&EffectBuffer> {
+        self.buffers.get(buffer_index as usize)?.as_ref()
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn get_buffer_mut(&mut self, buffer_index: u32) -> Option<&mut EffectBuffer> {
+        self.buffers.get_mut(buffer_index as usize)?.as_mut()
     }
 
     pub fn insert(
@@ -807,7 +766,6 @@ impl EffectCache {
         asset: Handle<EffectAsset>,
         capacities: Vec<u32>,
         particle_layout: &ParticleLayout,
-        property_layout: &PropertyLayout,
         layout_flags: LayoutFlags,
         group_order: Vec<u32>,
     ) -> CachedEffect {
@@ -832,7 +790,7 @@ impl EffectCache {
                     None
                 }
             })
-            .or_else(|| {
+            .unwrap_or_else(|| {
                 // Cannot find any suitable buffer; allocate a new one
                 let buffer_index = self.buffers.iter().position(|buf| buf.is_none()).unwrap_or(self.buffers.len());
                 let byte_size = total_capacity.checked_mul(particle_layout.min_binding_size().get() as u32).unwrap_or_else(|| panic!(
@@ -852,10 +810,9 @@ impl EffectCache {
                     asset,
                     total_capacity,
                     particle_layout.clone(),
-                    property_layout.clone(),
                     layout_flags,
                     &self.device,
-                    Some(&format!("hanabi:buffer:effect{buffer_index}_particles")),
+                    Some(&format!("{buffer_index}")),
                 );
                 let slice_ref = buffer.allocate_slice(total_capacity, particle_layout).unwrap();
                 if buffer_index >= self.buffers.len() {
@@ -864,9 +821,8 @@ impl EffectCache {
                     debug_assert!(self.buffers[buffer_index].is_none());
                     self.buffers[buffer_index] = Some(buffer);
                 }
-                Some((buffer_index, slice_ref))
-            })
-            .unwrap();
+                (buffer_index, slice_ref)
+            });
 
         let mut ranges = vec![slice.range.start];
         let group_count = capacities.len();
@@ -907,10 +863,18 @@ impl EffectCache {
         self.init_bind_group(buffer_index)
     }
 
-    pub fn get_property_buffer(&self, buffer_index: u32) -> Option<&Buffer> {
-        self.buffers[buffer_index as usize]
-            .as_ref()
-            .and_then(|eb| eb.properties_buffer())
+    pub fn create_sim_bind_group(
+        &mut self,
+        buffer_index: u32,
+        render_device: &RenderDevice,
+        group_binding: BufferBinding,
+    ) -> Result<(), ()> {
+        // Create the bind group
+        let effect_buffer: &mut Option<EffectBuffer> =
+            self.buffers.get_mut(buffer_index as usize).ok_or(())?;
+        let effect_buffer = effect_buffer.as_mut().ok_or(())?;
+        effect_buffer.create_sim_bind_group(buffer_index, &render_device, group_binding);
+        Ok(())
     }
 
     /// Remove an effect from the cache. If this was the last effect, drop the
@@ -1052,7 +1016,6 @@ mod gpu_tests {
             asset,
             capacity,
             l64.clone(),
-            PropertyLayout::empty(), // not using properties
             LayoutFlags::NONE,
             &render_device,
             Some("my_buffer"),
@@ -1127,7 +1090,6 @@ mod gpu_tests {
             asset,
             capacity,
             l64.clone(),
-            PropertyLayout::empty(), // not using properties
             LayoutFlags::NONE,
             &render_device,
             Some("my_buffer"),
@@ -1182,8 +1144,6 @@ mod gpu_tests {
         let renderer = MockRenderer::new();
         let render_device = renderer.device();
 
-        let empty_property_layout = PropertyLayout::empty(); // not using properties
-
         let l32 = ParticleLayout::new().append(F4A).append(F4B).build();
         assert_eq!(32, l32.size());
 
@@ -1201,7 +1161,6 @@ mod gpu_tests {
             asset.clone(),
             capacities.clone(),
             &l32,
-            &empty_property_layout,
             LayoutFlags::NONE,
             group_order.clone(),
         );
@@ -1222,7 +1181,6 @@ mod gpu_tests {
             asset.clone(),
             capacities.clone(),
             &l32,
-            &empty_property_layout,
             LayoutFlags::NONE,
             group_order.clone(),
         );
@@ -1251,14 +1209,7 @@ mod gpu_tests {
         }
 
         // Regression #60
-        let effect3 = effect_cache.insert(
-            asset,
-            capacities,
-            &l32,
-            &empty_property_layout,
-            LayoutFlags::NONE,
-            group_order,
-        );
+        let effect3 = effect_cache.insert(asset, capacities, &l32, LayoutFlags::NONE, group_order);
         //assert!(effect3.is_valid());
         let slice3 = &effect3.slices;
         assert_eq!(slice3.group_count(), 1);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -58,6 +58,7 @@ use rand::random;
 
 use crate::{
     asset::EffectAsset,
+    calc_func_id,
     plugin::WithCompiledParticleEffect,
     render::{
         batch::{BatchesInput, EffectDrawBatch},
@@ -73,11 +74,14 @@ mod aligned_buffer_vec;
 mod batch;
 mod buffer_table;
 mod effect_cache;
+mod property;
 mod shader_cache;
 
 use aligned_buffer_vec::AlignedBufferVec;
 use buffer_table::{BufferTable, BufferTableId};
 pub(crate) use effect_cache::EffectCache;
+pub(crate) use property::PropertyCache;
+use property::{CachedEffectProperties, CachedPropertiesError};
 pub use shader_cache::ShaderCache;
 
 use self::batch::EffectBatches;
@@ -574,16 +578,18 @@ impl FromWorld for DispatchIndirectPipeline {
 pub(crate) struct ParticlesInitPipeline {
     render_device: RenderDevice,
     sim_params_layout: BindGroupLayout,
-    spawner_buffer_layout: BindGroupLayout,
     render_indirect_spawn_layout: BindGroupLayout,
     render_indirect_clone_layout: BindGroupLayout,
+    // Workaround for specialize() not being able to access external data: we temporarily store the
+    // bind group layout just before calling specialize, and remove it after.
+    // https://github.com/bevyengine/bevy/issues/17132
+    temp_spawner_buffer_layout: Option<BindGroupLayout>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ParticleInitPipelineKey {
     shader: Handle<Shader>,
     particle_layout_min_binding_size: NonZero<u64>,
-    property_layout_min_binding_size: Option<NonZero<u64>>,
     flags: ParticleInitPipelineKeyFlags,
 }
 
@@ -614,20 +620,6 @@ impl FromWorld for ParticlesInitPipeline {
             }],
         );
 
-        let spawner_buffer_layout = render_device.create_bind_group_layout(
-            "hanabi:buffer_layout:init_spawner",
-            &[BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::COMPUTE,
-                ty: BindingType::Buffer {
-                    ty: BufferBindingType::Storage { read_only: false },
-                    has_dynamic_offset: true,
-                    min_binding_size: Some(GpuSpawnerParams::min_size()),
-                },
-                count: None,
-            }],
-        );
-
         let render_indirect_spawn_layout = create_init_render_indirect_bind_group_layout(
             render_device,
             "hanabi:bind_group_layout:init_render_indirect_spawn",
@@ -642,9 +634,9 @@ impl FromWorld for ParticlesInitPipeline {
         Self {
             render_device: render_device.clone(),
             sim_params_layout,
-            spawner_buffer_layout,
             render_indirect_spawn_layout,
             render_indirect_clone_layout,
+            temp_spawner_buffer_layout: None,
         }
     }
 }
@@ -653,14 +645,17 @@ impl SpecializedComputePipeline for ParticlesInitPipeline {
     type Key = ParticleInitPipelineKey;
 
     fn specialize(&self, key: Self::Key) -> ComputePipelineDescriptor {
-        let particles_buffer_layout = create_init_particles_bind_group_layout(
+        trace!("Specializing init pipeline for key: {key:?}");
+
+        // FIXME: Remove from here, and use instead the one created in
+        // EffectBuffer::new()!
+        let particles_buffer_layout = create_sim_bind_group_layout(
             &self.render_device,
             "hanabi:init_particles_buffer_layout",
             key.particle_layout_min_binding_size,
-            key.property_layout_min_binding_size,
         );
 
-        let mut shader_defs = vec![];
+        let mut shader_defs = Vec::with_capacity(3);
         if key.flags.contains(ParticleInitPipelineKeyFlags::CLONE) {
             shader_defs.push(ShaderDefVal::Bool("CLONE".to_string(), true));
         }
@@ -683,12 +678,28 @@ impl SpecializedComputePipeline for ParticlesInitPipeline {
             self.render_indirect_spawn_layout.clone()
         };
 
+        // This should always be valid when specialize() is called, by design. This is
+        // how we pass the value to specialize() to work around the lack of access to
+        // external data.
+        // https://github.com/bevyengine/bevy/issues/17132
+        let spawner_buffer_layout = self.temp_spawner_buffer_layout.as_ref().unwrap();
+
+        let hash = calc_func_id(&key);
+        let label = format!("hanabi:pipeline:init_{hash:016X}");
+        trace!(
+            "-> creating pipeline '{}' with shader defs:{}",
+            label,
+            shader_defs
+                .iter()
+                .fold(String::new(), |acc, x| acc + &format!(" {x:?}"))
+        );
+
         ComputePipelineDescriptor {
-            label: Some("hanabi:pipeline_init_compute".into()),
+            label: Some(label.into()),
             layout: vec![
                 self.sim_params_layout.clone(),
                 particles_buffer_layout,
-                self.spawner_buffer_layout.clone(),
+                spawner_buffer_layout.clone(),
                 render_indirect_layout,
             ],
             shader: key.shader,
@@ -704,8 +715,11 @@ impl SpecializedComputePipeline for ParticlesInitPipeline {
 pub(crate) struct ParticlesUpdatePipeline {
     render_device: RenderDevice,
     sim_params_layout: BindGroupLayout,
-    spawner_buffer_layout: BindGroupLayout,
     render_indirect_layout: BindGroupLayout,
+    // Workaround for specialize() not being able to access external data: we temporarily store the
+    // bind group layout just before calling specialize, and remove it after.
+    // https://github.com/bevyengine/bevy/issues/17132
+    temp_spawner_buffer_layout: Option<BindGroupLayout>,
 }
 
 impl FromWorld for ParticlesUpdatePipeline {
@@ -729,24 +743,6 @@ impl FromWorld for ParticlesUpdatePipeline {
                     ty: BufferBindingType::Uniform,
                     has_dynamic_offset: false,
                     min_binding_size: Some(GpuSimParams::min_size()),
-                },
-                count: None,
-            }],
-        );
-
-        trace!(
-            "GpuSpawnerParams: min_size={}",
-            GpuSpawnerParams::min_size()
-        );
-        let spawner_buffer_layout = render_device.create_bind_group_layout(
-            "hanabi:update_spawner_buffer_layout",
-            &[BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::COMPUTE,
-                ty: BindingType::Buffer {
-                    ty: BufferBindingType::Storage { read_only: false },
-                    has_dynamic_offset: true,
-                    min_binding_size: Some(GpuSpawnerParams::min_size()),
                 },
                 count: None,
             }],
@@ -790,8 +786,8 @@ impl FromWorld for ParticlesUpdatePipeline {
         Self {
             render_device: render_device.clone(),
             sim_params_layout,
-            spawner_buffer_layout,
             render_indirect_layout,
+            temp_spawner_buffer_layout: None,
         }
     }
 }
@@ -802,8 +798,6 @@ pub(crate) struct ParticleUpdatePipelineKey {
     shader: Handle<Shader>,
     /// Particle layout.
     particle_layout: ParticleLayout,
-    /// Property layout.
-    property_layout: PropertyLayout,
     is_trail: bool,
 }
 
@@ -811,28 +805,18 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
     type Key = ParticleUpdatePipelineKey;
 
     fn specialize(&self, key: Self::Key) -> ComputePipelineDescriptor {
-        trace!(
-            "GpuParticle: attributes.min_binding_size={} properties.min_binding_size={}",
-            key.particle_layout.min_binding_size().get(),
-            if key.property_layout.is_empty() {
-                0
-            } else {
-                key.property_layout.min_binding_size().get()
-            },
-        );
+        trace!("Specializing update pipeline for key: {key:?}");
 
-        let update_particles_buffer_layout = create_update_bind_group_layout(
+        // FIXME: Remove from here, and use instead the one created in
+        // EffectBuffer::new()!
+        let update_particles_buffer_layout = create_sim_bind_group_layout(
             &self.render_device,
             "hanabi:update_particles_buffer_layout",
             key.particle_layout.min_binding_size(),
-            if key.property_layout.is_empty() {
-                None
-            } else {
-                Some(key.property_layout.min_binding_size())
-            },
         );
 
-        let mut shader_defs = vec!["REM_MAX_SPAWN_ATOMIC".into()];
+        let mut shader_defs = Vec::with_capacity(4);
+        shader_defs.push("REM_MAX_SPAWN_ATOMIC".into());
         if key.particle_layout.contains(Attribute::PREV) {
             shader_defs.push("ATTRIBUTE_PREV".into());
         }
@@ -843,12 +827,28 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
             shader_defs.push("TRAIL".into());
         }
 
+        // This should always be valid when specialize() is called, by design. This is
+        // how we pass the value to specialize() to work around the lack of access to
+        // external data.
+        // https://github.com/bevyengine/bevy/issues/17132
+        let spawner_buffer_layout = self.temp_spawner_buffer_layout.as_ref().unwrap();
+
+        let hash = calc_func_id(&key);
+        let label = format!("hanabi:pipeline:update_{hash:016X}");
+        trace!(
+            "-> creating pipeline '{}' with shader defs:{}",
+            label,
+            shader_defs
+                .iter()
+                .fold(String::new(), |acc, x| acc + &format!(" {x:?}"))
+        );
+
         ComputePipelineDescriptor {
-            label: Some("hanabi:pipeline_update_compute".into()),
+            label: Some(label.into()),
             layout: vec![
                 self.sim_params_layout.clone(),
                 update_particles_buffer_layout,
-                self.spawner_buffer_layout.clone(),
+                spawner_buffer_layout.clone(),
                 self.render_indirect_layout.clone(),
             ],
             shader: key.shader,
@@ -1054,7 +1054,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
     type Key = ParticleRenderPipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        trace!("Specializing render pipeline for key: {:?}", key);
+        trace!("Specializing render pipeline for key: {key:?}");
 
         let dispatch_indirect_size = GpuDispatchIndirect::aligned_size(
             self.render_device
@@ -1121,7 +1121,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         let mut layout = vec![self.view_layout.clone(), particles_buffer_layout];
         let mut shader_defs = vec!["SPAWNER_READONLY".into()];
 
-        let vertex_buffer_layout = key.mesh_layout.and_then(|mesh_layout| {
+        let vertex_buffer_layout = key.mesh_layout.as_ref().and_then(|mesh_layout| {
             mesh_layout
                 .0
                 .get_layout(&[
@@ -1228,7 +1228,18 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
             TextureFormat::bevy_default()
         };
 
+        let hash = calc_func_id(&key);
+        let label = format!("hanabi:pipeline:render_{hash:016X}");
+        trace!(
+            "-> creating pipeline '{}' with shader defs:{}",
+            label,
+            shader_defs
+                .iter()
+                .fold(String::new(), |acc, x| acc + &format!(" {x:?}"))
+        );
+
         RenderPipelineDescriptor {
+            label: Some(label.into()),
             vertex: VertexState {
                 shader: key.shader.clone(),
                 entry_point: "vertex".into(),
@@ -1261,7 +1272,6 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },
-            label: Some("hanabi:pipeline_render".into()),
             push_constant_ranges: Vec::new(),
             zero_initialize_workgroup_memory: false,
         }
@@ -1734,9 +1744,6 @@ pub struct EffectsMeta {
     /// Bind group for the simulation parameters, like the current time and
     /// frame delta time.
     sim_params_bind_group: Option<BindGroup>,
-    /// Bind group for the spawning parameters (number of particles to spawn
-    /// this frame, ...).
-    spawner_bind_group: Option<BindGroup>,
     /// Bind group #0 of the vfx_indirect shader, containing both the indirect
     /// compute dispatch and render buffers.
     dr_indirect_bind_group: Option<BindGroup>,
@@ -1792,7 +1799,6 @@ impl EffectsMeta {
         Self {
             view_bind_group: None,
             sim_params_bind_group: None,
-            spawner_bind_group: None,
             dr_indirect_bind_group: None,
             init_render_indirect_spawn_bind_group: None,
             init_render_indirect_clone_bind_group: None,
@@ -1843,13 +1849,19 @@ impl EffectsMeta {
     pub fn add_remove_effects(
         &mut self,
         mut commands: Commands,
-        q_cached_effects: &Query<(MainEntity, &CachedEffect, &DispatchBufferIndices)>,
+        q_cached_effects: &Query<(
+            MainEntity,
+            &CachedEffect,
+            &DispatchBufferIndices,
+            Option<&CachedEffectProperties>,
+        )>,
         mut added_effects: Vec<AddedEffect>,
         removed_effect_entities: Vec<RenderEntity>,
         render_device: &RenderDevice,
         render_queue: &RenderQueue,
         effect_bind_groups: &mut ResMut<EffectBindGroups>,
         effect_cache: &mut ResMut<EffectCache>,
+        property_cache: &mut ResMut<PropertyCache>,
     ) {
         // Deallocate GPU data for destroyed effect instances. This will automatically
         // drop any group where there is no more effect slice.
@@ -1873,7 +1885,7 @@ impl EffectsMeta {
 
             // Fecth the components of the effect being destroyed. Note that the despawn
             // command above is not yet applied, so this query should always succeed.
-            let Ok((main_entity, cached_effect, dispatch_buffer_indices)) =
+            let Ok((main_entity, cached_effect, dispatch_buffer_indices, cached_effect_properties)) =
                 q_cached_effects.get(render_entity.id())
             else {
                 error!(
@@ -1882,6 +1894,24 @@ impl EffectsMeta {
                 );
                 continue;
             };
+
+            // Deallocate properties if any
+            if let Some(cached_effect_properties) = cached_effect_properties {
+                match property_cache.remove_properties(cached_effect_properties) {
+                    Err(err) => match err {
+                        CachedPropertiesError::InvalidBufferIndex(buffer_index)
+                            => error!("Failed to remove cached properties of render entity {render_entity:?} from buffer #{buffer_index}: the index is invalid."),
+                        CachedPropertiesError::BufferDeallocated(buffer_index)
+                            => error!("Failed to remove cached properties of render entity {render_entity:?} from buffer #{buffer_index}: the buffer is not allocated."),
+                    }
+                    Ok(buffer_state) => if buffer_state == BufferState::Free {
+                        // The entire buffer was deallocated; destroy all bind groups referencing it
+                        let key = cached_effect_properties.to_key();
+                        trace!("Destroying property bind group for key {key:?} due to property buffer deallocated.");
+                        effect_bind_groups.property_bind_groups.remove(&key);
+                    }
+                }
+            }
 
             // Deallocate the effect slice in the GPU effect buffer, and if this was the
             // last slice, also deallocate the GPU buffer itself.
@@ -1965,15 +1995,17 @@ impl EffectsMeta {
                     .map(|group| group.capacity)
                     .collect(),
                 &added_effect.particle_layout,
-                &added_effect.property_layout,
                 added_effect.layout_flags,
                 added_effect.group_order,
             );
-            commands.entity(added_effect.render_entity.id()).insert((
-                added_effect.entity,
-                cached_effect,
-                dispatch_buffer_indices,
-            ));
+            let mut cmd = commands.entity(added_effect.render_entity.id());
+            cmd.insert((added_effect.entity, cached_effect, dispatch_buffer_indices));
+
+            // Allocate storage for properties if needed
+            if !added_effect.property_layout.is_empty() {
+                let cached_effect_properties = property_cache.insert(&added_effect.property_layout);
+                cmd.insert(cached_effect_properties);
+            }
 
             trace!(
                 "+ added effect entity {:?}: main_entity={:?} \
@@ -2085,12 +2117,18 @@ impl Default for LayoutFlags {
 /// effects have a corresponding entity in the render world, with a
 /// [`CachedEffect`] component. From there, we operate on those exclusively.
 pub(crate) fn add_remove_effects(
-    q_cached_effects: Query<(MainEntity, &CachedEffect, &DispatchBufferIndices)>,
+    q_cached_effects: Query<(
+        MainEntity,
+        &CachedEffect,
+        &DispatchBufferIndices,
+        Option<&CachedEffectProperties>,
+    )>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     commands: Commands,
     mut effects_meta: ResMut<EffectsMeta>,
     mut effect_cache: ResMut<EffectCache>,
+    mut property_cache: ResMut<PropertyCache>,
     mut extracted_effects: ResMut<ExtractedEffects>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
 ) {
@@ -2120,7 +2158,21 @@ pub(crate) fn add_remove_effects(
         &render_queue,
         &mut effect_bind_groups,
         &mut effect_cache,
+        &mut property_cache,
     );
+
+    // Note: we don't need to explicitly allocate GPU buffers for effects, because
+    // EffectBuffer already contains a reference to the RenderDevice, so has done so
+    // internally. This is not ideal design-wise, but works.
+
+    // Allocate all the property buffer(s) as needed, before we move to the next
+    // step which will need those buffers to schedule data copies from CPU.
+    for buffer in property_cache.buffers_mut() {
+        if let Some(buffer) = buffer {
+            let _changed = buffer.write_buffer(&render_device, &render_queue);
+            // FIXME - invalidate bind groups!
+        }
+    }
 }
 
 /// Indexed mesh metadata for [`CachedMesh`].
@@ -2152,11 +2204,17 @@ pub(crate) struct CachedMesh {
 /// Render world cached properties info for a single effect instance.
 #[allow(unused)]
 #[derive(Debug, Component)]
-struct CachedProperties {
+pub(crate) struct CachedProperties {
     /// Layout of the effect properties.
     pub layout: PropertyLayout,
     /// GPU buffer containing the property data.
     pub buffer: Buffer,
+    /// Index of the buffer in the [`EffectCache`].
+    pub buffer_index: u32,
+    /// Offset in bytes inside the buffer.
+    pub offset: u32,
+    /// Binding size in bytes of the property struct.
+    pub binding_size: u32,
 }
 
 pub(crate) fn prepare_effects(
@@ -2165,17 +2223,22 @@ pub(crate) fn prepare_effects(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     pipeline_cache: Res<PipelineCache>,
-    init_pipeline: Res<ParticlesInitPipeline>,
-    update_pipeline: Res<ParticlesUpdatePipeline>,
+    mut init_pipeline: ResMut<ParticlesInitPipeline>,
+    mut update_pipeline: ResMut<ParticlesUpdatePipeline>,
     mesh_allocator: Res<MeshAllocator>,
     render_meshes: Res<RenderAssets<RenderMesh>>,
-    effect_cache: Res<EffectCache>,
+    mut property_cache: ResMut<PropertyCache>,
     mut specialized_init_pipelines: ResMut<SpecializedComputePipelines<ParticlesInitPipeline>>,
     mut specialized_update_pipelines: ResMut<SpecializedComputePipelines<ParticlesUpdatePipeline>>,
     mut effects_meta: ResMut<EffectsMeta>,
     mut extracted_effects: ResMut<ExtractedEffects>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
-    mut q_cached_effects: Query<(MainEntity, &CachedEffect, &mut DispatchBufferIndices)>,
+    mut q_cached_effects: Query<(
+        MainEntity,
+        &CachedEffect,
+        &mut DispatchBufferIndices,
+        Option<&CachedEffectProperties>,
+    )>,
 ) {
     trace!("prepare_effects");
 
@@ -2200,7 +2263,7 @@ pub(crate) fn prepare_effects(
         // Skip effects not cached. Since we're iterating over the extracted effects
         // instead of the cached ones, it might happen we didn't cache some effect on
         // purpose because they failed earlier validations.
-        let Ok((main_entity, cached_effect, mut dispatch_buffer_indices)) =
+        let Ok((main_entity, cached_effect, mut dispatch_buffer_indices, cached_effect_properties)) =
             q_cached_effects.get_mut(extracted_effect.render_entity.id())
         else {
             trace!(
@@ -2354,6 +2417,21 @@ pub(crate) fn prepare_effects(
             flags
         };
 
+        // This should always exist by the time we reach this point, because we should
+        // have inserted any property in the cache, which would have allocated the
+        // proper layout (or the default no-property one).
+        let spawner_buffer_layout = property_cache
+            .bind_group_layout(property_layout_min_binding_size)
+            .expect(&format!(
+                "Failed to find bind group layout for property binding size {:?}",
+                property_layout_min_binding_size,
+            ));
+        trace!(
+            "Retrieved property bind group layout {:?} for binding size {:?}...",
+            spawner_buffer_layout.id(),
+            property_layout_min_binding_size
+        );
+
         // Specialize the init pipeline based on the effect.
         let init_and_update_pipeline_ids: Vec<InitAndUpdatePipelineIds> = extracted_effect
             .effect_shaders
@@ -2370,6 +2448,8 @@ pub(crate) fn prepare_effects(
                     }
                 }
 
+                // https://github.com/bevyengine/bevy/issues/17132
+                init_pipeline.temp_spawner_buffer_layout = Some(spawner_buffer_layout.clone());
                 let init_pipeline_id: CachedComputePipelineId = specialized_init_pipelines
                     .specialize(
                         &pipeline_cache,
@@ -2377,25 +2457,27 @@ pub(crate) fn prepare_effects(
                         ParticleInitPipelineKey {
                             shader: shader.init.clone(),
                             particle_layout_min_binding_size,
-                            property_layout_min_binding_size,
                             flags,
                         },
                     );
+                init_pipeline.temp_spawner_buffer_layout = None; // keep things tidy; this is just a hack, should not persist
                 trace!("Init pipeline specialized: id={:?}", init_pipeline_id);
 
+                // https://github.com/bevyengine/bevy/issues/17132
+                update_pipeline.temp_spawner_buffer_layout = Some(spawner_buffer_layout.clone());
                 let update_pipeline_id = specialized_update_pipelines.specialize(
                     &pipeline_cache,
                     &update_pipeline,
                     ParticleUpdatePipelineKey {
                         shader: shader.update.clone(),
                         particle_layout: effect_slices.particle_layout.clone(),
-                        property_layout: extracted_effect.property_layout.clone(),
                         is_trail: matches!(
                             extracted_effect.initializers[group_index],
                             EffectInitializer::Cloner(_)
                         ),
                     },
                 );
+                update_pipeline.temp_spawner_buffer_layout = None; // keep things tidy; this is just a hack, should not persist
                 trace!("Update pipeline specialized: id={:?}", update_pipeline_id);
 
                 InitAndUpdatePipelineIds {
@@ -2555,29 +2637,102 @@ pub(crate) fn prepare_effects(
         ));
 
         // Update properties
-        if extracted_effect.property_layout.is_empty() {
-            // No property on the effect; remove the component
-            cmd.remove::<CachedProperties>();
-        } else {
-            // Effect has properties, needs a component. However it can only get one if
-            // there's a buffer allocated.
-            if let Some(buffer) = effect_cache.get_property_buffer(cached_effect.buffer_index) {
-                // Insert a new component or overwrite the existing one
-                cmd.insert(CachedProperties {
-                    layout: extracted_effect.property_layout.clone(),
-                    buffer: buffer.clone(),
-                });
+        if let Some(cached_effect_properties) = cached_effect_properties {
+            // Because the component is persisted, it may be there from a previous version
+            // of the asset. And add_remove_effects() only add new instances or remove old
+            // ones, but doesn't update existing ones. Check if it needs to be removed.
+            // FIXME - Dedupe with add_remove_effect(), we shouldn't have 2 codepaths doing
+            // the same thing at 2 different times.
+            if extracted_effect.property_layout.is_empty() {
+                trace!(
+                    "Render entity {:?} had CachedEffectProperties component, but newly extracted property layout is empty. Removing component...",
+                    extracted_effect.render_entity.id(),
+                );
+                cmd.remove::<CachedEffectProperties>();
+                // Also remove the other one. FIXME - dedupe those two...
+                cmd.remove::<CachedProperties>();
 
-                // Write properties for this effect if they were modified.
-                // FIXME - This doesn't work with batching! Also probably shouldn't have one GPU
-                // buffer per instance...
-                if let Some(property_data) = &extracted_effect.property_data {
-                    trace!("Properties changed; (re-)uploading to GPU");
-                    render_queue.write_buffer(buffer, 0, property_data);
+                match property_cache.remove_properties(cached_effect_properties) {
+                    Err(err) => {
+                        let render_entity = extracted_effect.render_entity.id();
+                        match err {
+                            CachedPropertiesError::InvalidBufferIndex(buffer_index)
+                                => error!("Failed to remove cached properties of render entity {render_entity:?} from buffer #{buffer_index}: the index is invalid."),
+                            CachedPropertiesError::BufferDeallocated(buffer_index)
+                                => error!("Failed to remove cached properties of render entity {render_entity:?} from buffer #{buffer_index}: the buffer is not allocated."),
+                        }
+                    }
+                    Ok(buffer_state) => {
+                        if buffer_state == BufferState::Free {
+                            // The entire buffer was deallocated; destroy all bind groups
+                            // referencing it
+                            let key = cached_effect_properties.to_key();
+                            trace!("Destroying property bind group for key {key:?} due to property buffer deallocated.");
+                            effect_bind_groups.property_bind_groups.remove(&key);
+                        }
+                    }
+                }
+
+                if extracted_effect.property_data.is_some() {
+                    warn!(
+                        "Effect on entity {:?} doesn't declare any property in its Module, but some property values were provided. Those values will be discarded.",
+                        extracted_effect.main_entity.id(),
+                    );
                 }
             } else {
-                cmd.remove::<CachedProperties>();
+                // Effect has properties, needs a component. However it can only get one if
+                // there's a buffer allocated.
+                if let Some(buffer) =
+                    property_cache.get_buffer(cached_effect_properties.buffer_index)
+                {
+                    // Insert a new component or overwrite the existing one
+                    cmd.insert(CachedProperties {
+                        layout: extracted_effect.property_layout.clone(),
+                        buffer: buffer.clone(),
+                        buffer_index: cached_effect_properties.buffer_index,
+                        offset: cached_effect_properties.range.start,
+                        binding_size: cached_effect_properties.range.len() as u32,
+                    });
+
+                    // Write properties for this effect if they were modified.
+                    // FIXME - This doesn't work with batching!
+                    if let Some(property_data) = &extracted_effect.property_data {
+                        trace!(
+                        "Properties changed; (re-)uploading to GPU... New data: {} bytes. Capacity: {} bytes.",
+                        property_data.len(),
+                        cached_effect_properties.range.len(),
+                    );
+                        if property_data.len() <= cached_effect_properties.range.len() {
+                            render_queue.write_buffer(
+                                buffer,
+                                cached_effect_properties.range.start as u64,
+                                property_data,
+                            );
+                        } else {
+                            error!(
+                            "Cannot upload properties: existing property slice in property buffer #{} is too small ({} bytes) for the new data ({} bytes).",
+                            cached_effect_properties.buffer_index,
+                            cached_effect_properties.range.len(),
+                            property_data.len()
+                        );
+                        }
+                    }
+                } else {
+                    error!(
+                    "Render entity {:?} has a CachedEffectProperties component referencing the property buffer #{}, but that buffer was not found.",
+                    extracted_effect.render_entity.id(),
+                    cached_effect_properties.buffer_index
+                );
+                    cmd.remove::<CachedProperties>();
+                }
             }
+        } else {
+            // No property on the effect; remove the component
+            trace!(
+                "No CachedEffectProperties on render entity {:?}, remove any CachedProperties component too.",
+                extracted_effect.render_entity.id()
+            );
+            cmd.remove::<CachedProperties>();
         }
 
         total_effect_count += 1;
@@ -2593,9 +2748,14 @@ pub(crate) fn prepare_effects(
     effects_meta.allocate_gpu(&render_device, &render_queue, &mut effect_bind_groups);
 
     // Write the entire spawner buffer for this frame, for all effects combined
-    effects_meta
+    if effects_meta
         .spawner_buffer
-        .write_buffer(&render_device, &render_queue);
+        .write_buffer(&render_device, &render_queue)
+    {
+        // All property bind groups use the spawner buffer, which was reallocate
+        effect_bind_groups.property_bind_groups.clear();
+        effect_bind_groups.no_property_bind_group = None;
+    }
 
     // Write the entire particle group buffer for this frame
     if effects_meta
@@ -2640,6 +2800,7 @@ pub(crate) fn batch_effects(
     mut q_cached_effects: Query<(
         Entity,
         &CachedMesh,
+        Option<&CachedProperties>,
         &mut CachedGroups,
         &mut DispatchBufferIndices,
         &mut BatchesInput,
@@ -2661,8 +2822,14 @@ pub(crate) fn batch_effects(
     // FIXME - This is in ECS order, if we re-add the sorting above we need a
     // different order here!
     trace!("Batching {} effects...", q_cached_effects.iter().len());
-    for (entity, cached_mesh, mut cached_groups, dispatch_buffer_indices, mut input) in
-        &mut q_cached_effects
+    for (
+        entity,
+        cached_mesh,
+        cached_properties,
+        mut cached_groups,
+        dispatch_buffer_indices,
+        mut input,
+    ) in &mut q_cached_effects
     {
         // Detect if this cached effect was not updated this frame by a new extracted
         // effect. This happens when e.g. the effect is invisible and not simulated, or
@@ -2698,6 +2865,11 @@ pub(crate) fn batch_effects(
             cached_groups
                 .first_particle_group_buffer_index
                 .unwrap_or_default(),
+            cached_properties.map(|cp| PropertyBindGroupKey {
+                buffer_index: cp.buffer_index,
+                binding_size: cp.binding_size,
+            }),
+            cached_properties.map(|cp| cp.offset),
         );
         let batches_entity = commands.spawn(batches).insert(TemporaryRenderEntity).id();
         trace!(
@@ -2790,6 +2962,12 @@ impl Material {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PropertyBindGroupKey {
+    pub buffer_index: u32,
+    pub binding_size: u32,
+}
+
 #[derive(Default, Resource)]
 pub struct EffectBindGroups {
     /// Map from buffer index to the bind groups shared among all effects that
@@ -2804,6 +2982,11 @@ pub struct EffectBindGroups {
     update_render_indirect_bind_groups: HashMap<u32, BindGroup>,
     /// Map from an effect material to its bind group.
     material_bind_groups: HashMap<Material, BindGroup>,
+    /// Map from a [`PropertyBuffer`] index and a binding size to the
+    /// corresponding bind group.
+    property_bind_groups: HashMap<PropertyBindGroupKey, BindGroup>,
+    /// Bind group for the variant without any property.
+    no_property_bind_group: Option<BindGroup>,
 }
 
 impl EffectBindGroups {
@@ -2811,6 +2994,14 @@ impl EffectBindGroups {
         self.particle_buffers
             .get(&buffer_index)
             .map(|bg| &bg.render)
+    }
+
+    pub fn property(&self, key: Option<&PropertyBindGroupKey>) -> Option<&BindGroup> {
+        if let Some(key) = key {
+            self.property_bind_groups.get(key)
+        } else {
+            self.no_property_bind_group.as_ref()
+        }
     }
 }
 
@@ -3455,6 +3646,7 @@ pub(crate) fn prepare_bind_groups(
     mut effects_meta: ResMut<EffectsMeta>,
     mut effect_cache: ResMut<EffectCache>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
+    property_cache: Res<PropertyCache>,
     effect_batches: Query<(Entity, &mut EffectBatches)>,
     render_device: Res<RenderDevice>,
     dispatch_indirect_pipeline: Res<DispatchIndirectPipeline>,
@@ -3463,9 +3655,13 @@ pub(crate) fn prepare_bind_groups(
     render_pipeline: ResMut<ParticlesRenderPipeline>,
     gpu_images: Res<RenderAssets<GpuImage>>,
 ) {
-    if effects_meta.spawner_buffer.is_empty() || effects_meta.spawner_buffer.buffer().is_none() {
+    // We can't simulate nor render anything without at least the spawner buffer
+    if effects_meta.spawner_buffer.is_empty() {
         return;
     }
+    let Some(spawner_buffer) = effects_meta.spawner_buffer.buffer().cloned() else {
+        return;
+    };
 
     {
         #[cfg(feature = "trace")]
@@ -3484,9 +3680,9 @@ pub(crate) fn prepare_bind_groups(
             ));
         }
 
-        // Create the bind group for the spawner parameters
-        // FIXME - This is shared by init and update; should move
-        // "update_pipeline.spawner_buffer_layout" out of "update_pipeline"
+        // Create the bind group for the spawner parameters in the no-property variant.
+        // For the other variants with properties, we need the binding size, so we'll
+        // lazily create them below when looping on effect instances.
         trace!(
             "Spawner buffer bind group: size={} aligned_size={}",
             GpuSpawnerParams::min_size().get(),
@@ -3496,26 +3692,32 @@ pub(crate) fn prepare_bind_groups(
             effects_meta.spawner_buffer.aligned_size()
                 >= GpuSpawnerParams::min_size().get() as usize
         );
-        // Note: we clear effects_meta.spawner_buffer each frame in prepare_effects(),
-        // so this bind group is always invalid at the minute and always needs
-        // re-creation.
-        effects_meta.spawner_bind_group = effects_meta.spawner_buffer.buffer().map(|buffer| {
-            render_device.create_bind_group(
-                "hanabi:bind_group_spawner_buffer",
-                &update_pipeline.spawner_buffer_layout, // FIXME - Shared with init,is that OK?
-                &[BindGroupEntry {
-                    binding: 0,
-                    resource: BindingResource::Buffer(BufferBinding {
-                        buffer,
-                        offset: 0,
-                        size: Some(
-                            NonZeroU64::new(effects_meta.spawner_buffer.aligned_size() as u64)
-                                .unwrap(),
-                        ),
-                    }),
-                }],
-            )
-        });
+        if effect_bind_groups.no_property_bind_group.is_none() {
+            // If all effects use properties, there won't be a layout for the no-property
+            // variant. This is fine, we don't need it.
+            if let Some(layout) = property_cache.bind_group_layout(None) {
+                trace!("Creating new bind group for no-property variant.");
+                effect_bind_groups.no_property_bind_group = Some(
+                    render_device.create_bind_group(
+                        "hanabi:bind_group:no_property{}",
+                        layout,
+                        &[BindGroupEntry {
+                            binding: 0,
+                            resource: BindingResource::Buffer(BufferBinding {
+                                buffer: &spawner_buffer,
+                                offset: 0,
+                                size: Some(
+                                    NonZeroU64::new(
+                                        effects_meta.spawner_buffer.aligned_size() as u64
+                                    )
+                                    .unwrap(),
+                                ),
+                            }),
+                        }],
+                    ),
+                );
+            }
+        }
 
         // Create the bind group for the indirect dispatch of all effects
         effects_meta.dr_indirect_bind_group = match (
@@ -3681,15 +3883,14 @@ pub(crate) fn prepare_bind_groups(
             .entry(buffer_index as u32)
             .or_insert_with(|| {
                 trace!(
-                    "Create new particle bind groups for buffer_index={} | particle_layout {:?} | property_layout {:?}",
+                    "Create new particle bind groups for buffer_index={} | particle_layout {:?}",
                     buffer_index,
                     buffer.particle_layout(),
-                    buffer.property_layout(),
                 );
 
-                let dispatch_indirect_size = GpuDispatchIndirect::aligned_size(render_device
-                    .limits()
-                    .min_storage_buffer_offset_alignment);
+                let dispatch_indirect_size = GpuDispatchIndirect::aligned_size(
+                    render_device.limits().min_storage_buffer_offset_alignment,
+                );
                 let mut entries = vec![
                     BindGroupEntry {
                         binding: 0,
@@ -3708,7 +3909,10 @@ pub(crate) fn prepare_bind_groups(
                         }),
                     },
                 ];
-                if buffer.layout_flags().contains(LayoutFlags::LOCAL_SPACE_SIMULATION) {
+                if buffer
+                    .layout_flags()
+                    .contains(LayoutFlags::LOCAL_SPACE_SIMULATION)
+                {
                     entries.push(BindGroupEntry {
                         binding: 3,
                         resource: BindingResource::Buffer(BufferBinding {
@@ -3718,16 +3922,18 @@ pub(crate) fn prepare_bind_groups(
                         }),
                     });
                 }
-                trace!("Creating render bind group with {} entries (layout flags: {:?})", entries.len(), buffer.layout_flags());
+                trace!(
+                    "Creating render bind group with {} entries (layout flags: {:?})",
+                    entries.len(),
+                    buffer.layout_flags()
+                );
                 let render = render_device.create_bind_group(
                     &format!("hanabi:bind_group:render_vfx{buffer_index}_particles")[..],
-                     buffer.particle_layout_bind_group_with_dispatch(),
-                     &entries,
+                    buffer.particle_layout_bind_group_with_dispatch(),
+                    &entries,
                 );
 
-                BufferBindGroups {
-                    render,
-                }
+                BufferBindGroups { render }
             });
     }
 
@@ -3735,6 +3941,70 @@ pub(crate) fn prepare_bind_groups(
     for (entity, effect_batches) in effect_batches.iter() {
         #[cfg(feature = "trace")]
         let _span_buffer = bevy::utils::tracing::info_span!("create_batch_bind_groups").entered();
+
+        // Create the property layout if needed
+        if let Some(property_key) = &effect_batches.property_key {
+            let Some(property_buffer) = property_cache.get_buffer(property_key.buffer_index) else {
+                error!(
+                    "Missing property buffer #{}, referenced by effect batch on render entity {:?}.",
+                    property_key.buffer_index, entity
+                );
+                continue;
+            };
+
+            // This should always be non-zero if the property key is Some().
+            let binding_size = NonZeroU64::new(property_key.binding_size as u64).unwrap();
+            let Some(layout) = property_cache.bind_group_layout(Some(binding_size)) else {
+                error!(
+                    "Missing property bind group layout for binding size {}, referenced by effect batch on render entity {:?}.",
+                    binding_size.get(), entity
+                );
+                continue;
+            };
+
+            effect_bind_groups
+                .property_bind_groups
+                .entry(*property_key)
+                .or_insert_with(|| {
+                    trace!(
+                        "Creating new bind group for property buffer #{} and binding size {}",
+                        property_key.buffer_index,
+                        property_key.binding_size
+                    );
+                    render_device.create_bind_group(
+                        Some(
+                            &format!(
+                                "hanabi:bind_group:property{}_size{}",
+                                property_key.buffer_index, property_key.binding_size
+                            )[..],
+                        ),
+                        layout,
+                        &[
+                            BindGroupEntry {
+                                binding: 0,
+                                resource: BindingResource::Buffer(BufferBinding {
+                                    buffer: &spawner_buffer,
+                                    offset: 0,
+                                    size: Some(
+                                        NonZeroU64::new(
+                                            effects_meta.spawner_buffer.aligned_size() as u64
+                                        )
+                                        .unwrap(),
+                                    ),
+                                }),
+                            },
+                            BindGroupEntry {
+                                binding: 1,
+                                resource: BindingResource::Buffer(BufferBinding {
+                                    buffer: property_buffer,
+                                    offset: 0,
+                                    size: None,
+                                }),
+                            },
+                        ],
+                    )
+                });
+        }
 
         // Convert indirect buffer offsets from indices to bytes.
         let first_effect_particle_group_buffer_offset = effects_meta
@@ -3752,21 +4022,16 @@ pub(crate) fn prepare_bind_groups(
             size: Some(effect_particle_groups_buffer_size),
         };
 
-        let Some(Some(effect_buffer)) = effect_cache
-            .buffers_mut()
-            .get_mut(effect_batches.buffer_index as usize)
-        else {
-            error!("No particle buffer allocated for entity {:?}", entity);
-            continue;
-        };
-
         // Bind group for the init compute shader to simulate particles.
         // TODO - move this creation in RenderSet::PrepareBindGroups
-        effect_buffer.create_sim_bind_group(
+        if let Err(_) = effect_cache.create_sim_bind_group(
             effect_batches.buffer_index,
             &render_device,
             group_binding,
-        );
+        ) {
+            error!("No particle buffer allocated for entity {:?}", entity);
+            continue;
+        }
 
         if effect_bind_groups
             .update_render_indirect_bind_groups
@@ -4168,70 +4433,6 @@ impl Draw<Opaque3d> for DrawEffects {
     }
 }
 
-fn create_init_particles_bind_group_layout(
-    render_device: &RenderDevice,
-    label: &str,
-    particle_layout_min_binding_size: NonZero<u64>,
-    property_layout_min_binding_size: Option<NonZero<u64>>,
-) -> BindGroupLayout {
-    let mut entries = Vec::with_capacity(3);
-    // (1,0) ParticleBuffer
-    entries.push(BindGroupLayoutEntry {
-        binding: 0,
-        visibility: ShaderStages::COMPUTE,
-        ty: BindingType::Buffer {
-            ty: BufferBindingType::Storage { read_only: false },
-            has_dynamic_offset: false,
-            min_binding_size: Some(particle_layout_min_binding_size),
-        },
-        count: None,
-    });
-    // (1,1) IndirectBuffer
-    entries.push(BindGroupLayoutEntry {
-        binding: 1,
-        visibility: ShaderStages::COMPUTE,
-        ty: BindingType::Buffer {
-            ty: BufferBindingType::Storage { read_only: false },
-            has_dynamic_offset: false,
-            min_binding_size: BufferSize::new(12),
-        },
-        count: None,
-    });
-    // (1,2) array<ParticleGroup>
-    let particle_group_size =
-        GpuParticleGroup::aligned_size(render_device.limits().min_storage_buffer_offset_alignment);
-    entries.push(BindGroupLayoutEntry {
-        binding: 2,
-        visibility: ShaderStages::COMPUTE,
-        ty: BindingType::Buffer {
-            ty: BufferBindingType::Storage { read_only: true },
-            has_dynamic_offset: false,
-            min_binding_size: Some(particle_group_size),
-        },
-        count: None,
-    });
-    if let Some(min_binding_size) = property_layout_min_binding_size {
-        // (1,3) Properties
-        entries.push(BindGroupLayoutEntry {
-            binding: 3,
-            visibility: ShaderStages::COMPUTE,
-            ty: BindingType::Buffer {
-                ty: BufferBindingType::Storage { read_only: true },
-                has_dynamic_offset: false, // TODO
-                min_binding_size: Some(min_binding_size),
-            },
-            count: None,
-        });
-    }
-
-    trace!(
-        "Creating particle bind group layout '{}' for init pass with {} entries.",
-        label,
-        entries.len()
-    );
-    render_device.create_bind_group_layout(label, &entries)
-}
-
 fn create_init_render_indirect_bind_group_layout(
     render_device: &RenderDevice,
     label: &str,
@@ -4285,15 +4486,14 @@ fn create_init_render_indirect_bind_group_layout(
     render_device.create_bind_group_layout(label, &entries)
 }
 
-fn create_update_bind_group_layout(
+fn create_sim_bind_group_layout(
     render_device: &RenderDevice,
     label: &str,
     particle_layout_min_binding_size: NonZero<u64>,
-    property_layout_min_binding_size: Option<NonZero<u64>>,
 ) -> BindGroupLayout {
     let particle_group_size =
         GpuParticleGroup::aligned_size(render_device.limits().min_storage_buffer_offset_alignment);
-    let mut entries = vec![
+    let entries = [
         // @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer
         BindGroupLayoutEntry {
             binding: 0,
@@ -4328,22 +4528,9 @@ fn create_update_bind_group_layout(
             count: None,
         },
     ];
-    if let Some(property_layout_min_binding_size) = property_layout_min_binding_size {
-        // @binding(3) var<storage, read> properties : Properties
-        entries.push(BindGroupLayoutEntry {
-            binding: 3,
-            visibility: ShaderStages::COMPUTE,
-            ty: BindingType::Buffer {
-                ty: BufferBindingType::Storage { read_only: true },
-                has_dynamic_offset: false, // TODO
-                min_binding_size: Some(property_layout_min_binding_size),
-            },
-            count: None,
-        });
-    }
 
     trace!(
-        "Creating particle bind group layout '{}' for update pass with {} entries.",
+        "Creating particle bind group layout '{}' for simulation passes with {} entries.",
         label,
         entries.len()
     );
@@ -4465,12 +4652,14 @@ impl Node for VfxSimulateNode {
                             first_render_group_dispatch_buffer_index.offset(dest_group_index);
 
                         // Destination group spawners are packed one after one another.
-                        let spawner_base = batches.spawner_base + dest_group_index;
-                        let spawner_buffer_aligned = effects_meta.spawner_buffer.aligned_size();
+                        let spawner_index = batches.spawner_base + dest_group_index;
+                        let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
                         assert!(
-                            spawner_buffer_aligned >= GpuSpawnerParams::min_size().get() as usize
+                            spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize
                         );
-                        let spawner_offset = spawner_base * spawner_buffer_aligned as u32;
+                        let spawner_offset = spawner_index * spawner_aligned_size as u32;
+
+                        let property_offset = batches.property_offset;
 
                         match initializer {
                             EffectInitializer::Spawner(effect_spawner) => {
@@ -4569,13 +4758,13 @@ impl Node for VfxSimulateNode {
                                     batches.handle,
                                     spawn_count,
                                     workgroup_count,
-                                    spawner_base,
+                                    spawner_index,
                                     spawner_offset,
                                     render_effect_indirect_offset,
                                     render_group_indirect_offset,
                                 );
 
-                                // Setup compute pass
+                                // Dispatch init pass
                                 compute_pass.set_pipeline(init_pipeline);
                                 compute_pass.set_bind_group(
                                     0,
@@ -4583,10 +4772,17 @@ impl Node for VfxSimulateNode {
                                     &[],
                                 );
                                 compute_pass.set_bind_group(1, particles_init_bind_group, &[]);
+                                let offsets = if let Some(property_offset) = property_offset {
+                                    vec![spawner_offset, property_offset]
+                                } else {
+                                    vec![spawner_offset]
+                                };
                                 compute_pass.set_bind_group(
                                     2,
-                                    effects_meta.spawner_bind_group.as_ref().unwrap(),
-                                    &[spawner_offset],
+                                    effect_bind_groups
+                                        .property(batches.property_key.as_ref())
+                                        .unwrap(),
+                                    &offsets[..],
                                 );
                                 compute_pass.set_bind_group(
                                     3,
@@ -4691,10 +4887,17 @@ impl Node for VfxSimulateNode {
                                     &[],
                                 );
                                 compute_pass.set_bind_group(1, particles_init_bind_group, &[]);
+                                let offsets = if let Some(property_offset) = property_offset {
+                                    vec![spawner_offset, property_offset]
+                                } else {
+                                    vec![spawner_offset]
+                                };
                                 compute_pass.set_bind_group(
                                     2,
-                                    effects_meta.spawner_bind_group.as_ref().unwrap(),
-                                    &[spawner_offset],
+                                    effect_bind_groups
+                                        .property(batches.property_key.as_ref())
+                                        .unwrap(),
+                                    &offsets[..],
                                 );
                                 compute_pass.set_bind_group(
                                     3,
@@ -4853,10 +5056,12 @@ impl Node for VfxSimulateNode {
                         );
 
                     // Destination group spawners are packed one after one another.
-                    let spawner_base = batches.spawner_base + group_index;
-                    let spawner_buffer_aligned = effects_meta.spawner_buffer.aligned_size();
-                    assert!(spawner_buffer_aligned >= GpuSpawnerParams::min_size().get() as usize);
-                    let spawner_offset = spawner_base * spawner_buffer_aligned as u32;
+                    let spawner_index = batches.spawner_base + group_index;
+                    let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
+                    assert!(spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize);
+                    let spawner_offset = spawner_index * spawner_aligned_size as u32;
+
+                    let property_offset = batches.property_offset;
 
                     // for (effect_entity, effect_slice) in effects_meta.entity_map.iter()
                     // Retrieve the ExtractedEffect from the entity
@@ -4873,7 +5078,7 @@ impl Node for VfxSimulateNode {
                         "record commands for update pipeline of effect {:?} \
                         spawner_base={} update_group_dispatch_buffer_offset={}…",
                         batches.handle,
-                        spawner_base,
+                        spawner_index,
                         update_group_dispatch_buffer_offset,
                     );
 
@@ -4886,10 +5091,17 @@ impl Node for VfxSimulateNode {
                         &[],
                     );
                     compute_pass.set_bind_group(1, particles_update_bind_group, &[]);
+                    let offsets = if let Some(property_offset) = property_offset {
+                        vec![spawner_offset, property_offset]
+                    } else {
+                        vec![spawner_offset]
+                    };
                     compute_pass.set_bind_group(
                         2,
-                        effects_meta.spawner_bind_group.as_ref().unwrap(),
-                        &[spawner_offset],
+                        effect_bind_groups
+                            .property(batches.property_key.as_ref())
+                            .unwrap(),
+                        &offsets[..],
                     );
                     compute_pass.set_bind_group(3, update_render_indirect_bind_group, &[]);
 

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -1,0 +1,281 @@
+use std::{num::NonZeroU64, ops::Range};
+
+use bevy::{
+    log::trace,
+    prelude::{Component, Resource},
+    render::{
+        render_resource::{BindGroupLayout, Buffer, ShaderType as _},
+        renderer::{RenderDevice, RenderQueue},
+    },
+    utils::HashMap,
+};
+use wgpu::{BindGroupLayoutEntry, BindingType, BufferBindingType, BufferUsages, ShaderStages};
+
+use super::{
+    aligned_buffer_vec::HybridAlignedBufferVec, effect_cache::BufferState, PropertyBindGroupKey,
+};
+use crate::{render::GpuSpawnerParams, PropertyLayout};
+
+#[derive(Debug, Clone, PartialEq, Eq, Component)]
+pub struct CachedEffectProperties {
+    pub buffer_index: u32,
+    pub range: Range<u32>,
+}
+
+impl CachedEffectProperties {
+    pub fn to_key(&self) -> PropertyBindGroupKey {
+        PropertyBindGroupKey {
+            buffer_index: self.buffer_index,
+            binding_size: self.range.len() as u32,
+        }
+    }
+}
+
+/// Error code for [`PropertyCache::remove_properties()`].
+#[derive(Debug)]
+pub enum CachedPropertiesError {
+    /// The given buffer index is invalid. The [`PropertyCache`] doesn't contain
+    /// any buffer with such index.
+    InvalidBufferIndex(u32),
+    /// The given buffer index corresponds to a [`PropertyCache`] buffer which
+    /// was already deallocated.
+    BufferDeallocated(u32),
+}
+
+#[derive(Debug)]
+pub(crate) struct PropertyBuffer {
+    /// GPU buffer holding the properties of some effect(s).
+    buffer: HybridAlignedBufferVec,
+    // Layout of properties of the effect(s), if using properties.
+    //property_layout: PropertyLayout,
+}
+
+impl PropertyBuffer {
+    pub fn new(align: u32, label: Option<String>) -> Self {
+        let align = NonZeroU64::new(align as u64).unwrap();
+        let label = label.unwrap_or("hanabi:buffer:properties".to_string());
+        Self {
+            buffer: HybridAlignedBufferVec::new(BufferUsages::STORAGE, Some(align), Some(label)),
+        }
+    }
+
+    #[inline]
+    pub fn buffer(&self) -> Option<&Buffer> {
+        self.buffer.buffer()
+    }
+
+    #[inline]
+    pub fn allocate(&mut self, layout: &PropertyLayout) -> Range<u32> {
+        // Note: allocate with min_binding_size() and not cpu_size(), because the buffer
+        // needs to be large enough to host at least one struct when bound to a shader,
+        // and in WGSL the struct is padded to its align size.
+        let size = layout.min_binding_size().get() as usize;
+        // FIXME - allocate(size) instead of push(data) so we don't need to allocate an
+        // empty vector just to read its size.
+        self.buffer.push_raw(&vec![0u8; size][..])
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn free(&mut self, range: Range<u32>) -> BufferState {
+        if self.buffer.remove(range) && self.buffer.is_empty() {
+            BufferState::Free
+        } else {
+            BufferState::Used
+        }
+    }
+
+    #[inline]
+    pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) -> bool {
+        self.buffer.write_buffer(device, queue)
+    }
+}
+
+/// Cache for effect properties.
+#[derive(Resource)]
+pub struct PropertyCache {
+    /// Render device to allocate GPU buffers and bind group layouts as needed.
+    device: RenderDevice,
+    /// Collection of property buffers managed by this cache. Some buffers might
+    /// be `None` if the entry is not used. Since the buffers are referenced
+    /// by index, we cannot move them once they're allocated.
+    buffers: Vec<Option<PropertyBuffer>>,
+    /// Map from a binding size in bytes to its bind group layout. The binding
+    /// size zero is valid, and corresponds to the variant without properties,
+    /// which by abuse is stored here even though it's not related to properties
+    /// (contains only the spawner binding).
+    bind_group_layouts: HashMap<u32, BindGroupLayout>,
+}
+
+impl PropertyCache {
+    pub fn new(device: RenderDevice) -> Self {
+        let bgl = device.create_bind_group_layout(
+            "hanabi:bind_group_layout:no_property",
+            &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: true,
+                    min_binding_size: Some(GpuSpawnerParams::min_size()),
+                },
+                count: None,
+            }],
+        );
+        trace!(
+            "-> created bind group layout #{:?} for no-property variant",
+            bgl.id()
+        );
+        let mut bind_group_layouts = HashMap::with_capacity(1);
+        bind_group_layouts.insert(0, bgl);
+
+        Self {
+            device,
+            buffers: vec![],
+            bind_group_layouts,
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn buffers(&self) -> &[Option<PropertyBuffer>] {
+        &self.buffers
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn buffers_mut(&mut self) -> &mut [Option<PropertyBuffer>] {
+        &mut self.buffers
+    }
+
+    pub fn bind_group_layout(
+        &self,
+        min_binding_size: Option<NonZeroU64>,
+    ) -> Option<&BindGroupLayout> {
+        let key = min_binding_size.map(NonZeroU64::get).unwrap_or(0) as u32;
+        self.bind_group_layouts.get(&key)
+    }
+
+    pub fn insert(&mut self, property_layout: &PropertyLayout) -> CachedEffectProperties {
+        assert!(!property_layout.is_empty());
+
+        // Ensure there's a bind group layout for the property variant with that binding
+        // size
+        let min_binding_size = property_layout.min_binding_size();
+        self.bind_group_layouts
+            .entry(min_binding_size.get() as u32)
+            .or_insert_with(|| {
+                let label = format!(
+                    "hanabi:bind_group_layout:property_size{}",
+                    min_binding_size.get()
+                );
+                trace!(
+                    "Create new property bind group layout '{}' for binding size {} bytes.",
+                    label,
+                    min_binding_size.get()
+                );
+                let bgl = self.device.create_bind_group_layout(
+                    Some(&label[..]),
+                    &[
+                        BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: ShaderStages::COMPUTE,
+                            ty: BindingType::Buffer {
+                                ty: BufferBindingType::Storage { read_only: false },
+                                has_dynamic_offset: true,
+                                min_binding_size: Some(GpuSpawnerParams::min_size()),
+                            },
+                            count: None,
+                        },
+                        BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: ShaderStages::COMPUTE,
+                            ty: BindingType::Buffer {
+                                ty: BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: true,
+                                min_binding_size: Some(min_binding_size),
+                            },
+                            count: None,
+                        },
+                    ],
+                );
+                trace!("-> created bind group layout #{:?}", bgl.id());
+                bgl
+            });
+
+        self.buffers
+            .iter_mut()
+            .enumerate()
+            .find_map(|(buffer_index, buffer)| {
+                if let Some(buffer) = buffer {
+                    // Try to allocate a slice into the buffer
+                    // FIXME - Currently PropertyBuffer::allocate() always succeeds and
+                    // grows indefinitely
+                    let range = buffer.allocate(property_layout);
+                    Some(CachedEffectProperties {
+                        buffer_index: buffer_index as u32,
+                        range,
+                    })
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| {
+                // Cannot find any suitable buffer; allocate a new one
+                let buffer_index = self
+                    .buffers
+                    .iter()
+                    .position(|buf| buf.is_none())
+                    .unwrap_or(self.buffers.len());
+                let label = format!("hanabi:buffer:properties{buffer_index}");
+                trace!("Creating new property buffer #{buffer_index} '{label}'");
+                let align = self.device.limits().min_storage_buffer_offset_alignment;
+                let mut buffer = PropertyBuffer::new(align, Some(label));
+                // FIXME - Currently PropertyBuffer::allocate() always succeeds and grows
+                // indefinitely
+                let range = buffer.allocate(property_layout);
+                if buffer_index >= self.buffers.len() {
+                    self.buffers.push(Some(buffer));
+                } else {
+                    debug_assert!(self.buffers[buffer_index].is_none());
+                    self.buffers[buffer_index] = Some(buffer);
+                }
+                CachedEffectProperties {
+                    buffer_index: buffer_index as u32,
+                    range,
+                }
+            })
+    }
+
+    pub fn get_buffer(&self, buffer_index: u32) -> Option<&Buffer> {
+        self.buffers[buffer_index as usize]
+            .as_ref()
+            .map(|pb| pb.buffer())
+            .flatten()
+    }
+
+    /// Deallocated and remove properties from the cache.
+    pub fn remove_properties(
+        &mut self,
+        cached_effect_properties: &CachedEffectProperties,
+    ) -> Result<BufferState, CachedPropertiesError> {
+        trace!(
+            "Removing cached properties {:?} from cache.",
+            cached_effect_properties
+        );
+        let Some(buffer) = self
+            .buffers
+            .get_mut(cached_effect_properties.buffer_index as usize)
+        else {
+            return Err(CachedPropertiesError::InvalidBufferIndex(
+                cached_effect_properties.buffer_index,
+            ));
+        };
+        let Some(buffer) = buffer.as_mut() else {
+            return Err(CachedPropertiesError::BufferDeallocated(
+                cached_effect_properties.buffer_index,
+            ));
+        };
+        Ok(buffer.free(cached_effect_properties.range.clone()))
+    }
+}

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -111,6 +111,7 @@ impl PropertyCache {
     pub fn new(device: RenderDevice) -> Self {
         let bgl = device.create_bind_group_layout(
             "hanabi:bind_group_layout:no_property",
+            // @group(2) @binding(0) var<storage, read> spawner: Spawner;
             &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::COMPUTE,
@@ -177,6 +178,7 @@ impl PropertyCache {
                 let bgl = self.device.create_bind_group_layout(
                     Some(&label[..]),
                     &[
+                        // @group(2) @binding(0) var<storage, read> spawner: Spawner;
                         BindGroupLayoutEntry {
                             binding: 0,
                             visibility: ShaderStages::COMPUTE,
@@ -187,6 +189,7 @@ impl PropertyCache {
                             },
                             count: None,
                         },
+                        // @group(2) @binding(1) var<storage, read> properties : Properties;
                         BindGroupLayoutEntry {
                             binding: 1,
                             visibility: ShaderStages::COMPUTE,

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -250,8 +250,7 @@ impl PropertyCache {
     pub fn get_buffer(&self, buffer_index: u32) -> Option<&Buffer> {
         self.buffers[buffer_index as usize]
             .as_ref()
-            .map(|pb| pb.buffer())
-            .flatten()
+            .and_then(|pb| pb.buffer())
     }
 
     /// Deallocated and remove properties from the cache.

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -115,7 +115,7 @@ impl PropertyCache {
                 binding: 0,
                 visibility: ShaderStages::COMPUTE,
                 ty: BindingType::Buffer {
-                    ty: BufferBindingType::Storage { read_only: false },
+                    ty: BufferBindingType::Storage { read_only: true },
                     has_dynamic_offset: true,
                     min_binding_size: Some(GpuSpawnerParams::min_size()),
                 },
@@ -181,7 +181,7 @@ impl PropertyCache {
                             binding: 0,
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
-                                ty: BufferBindingType::Storage { read_only: false },
+                                ty: BufferBindingType::Storage { read_only: true },
                                 has_dynamic_offset: true,
                                 min_binding_size: Some(GpuSpawnerParams::min_size()),
                             },

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -29,17 +29,6 @@ struct Spawner {
     /// PRNG seed for this effect instance. Currently this can change each time the
     /// effect is recompiled, and cannot be set deterministically (TODO).
     seed: u32,
-    // Can't use storage<read> with atomics
-#ifdef SPAWNER_READONLY
-    count: i32,
-#else
-    count: atomic<i32>,
-#endif
-    /// Global index of the effect in the various shared buffers.
-    ///
-    /// This is a globally unique index for all active effect instances, used to index
-    /// global buffers like the spawner buffer or the render indirect dispatch buffer.
-    effect_index: u32,
     // The lifetime to initialize particles with. This is only used for cloners
     // (i.e. trails or ribbons).
     lifetime: f32,

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -1,5 +1,5 @@
 #import bevy_hanabi::vfx_common::{
-    ParticleGroup, SimParams, Spawner,
+    ParticleGroup, SimParams,
     DI_OFFSET_X, DI_OFFSET_PONG,
     RGI_OFFSET_ALIVE_COUNT, RGI_OFFSET_MAX_UPDATE, RGI_OFFSET_DEAD_COUNT,
     RGI_OFFSET_MAX_SPAWN, RGI_OFFSET_INSTANCE_COUNT, REM_OFFSET_PING

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -19,9 +19,8 @@ struct ParticleBuffer {
 @group(1) @binding(0) var<storage, read_write> particle_buffer: ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer: IndirectBuffer;
 @group(1) @binding(2) var<storage, read> particle_groups: array<ParticleGroup>;
-{{PROPERTIES_BINDING}}
-
 @group(2) @binding(0) var<storage, read_write> spawner: Spawner; // NOTE - same group as update
+{{PROPERTIES_BINDING}}
 @group(3) @binding(0) var<storage, read_write> render_effect_indirect: RenderEffectMetadata;
 @group(3) @binding(1) var<storage, read_write> dest_render_group_indirect: RenderGroupIndirect;
 #ifdef CLONE

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -19,7 +19,7 @@ struct ParticleBuffer {
 @group(1) @binding(0) var<storage, read_write> particle_buffer: ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer: IndirectBuffer;
 @group(1) @binding(2) var<storage, read> particle_groups: array<ParticleGroup>;
-@group(2) @binding(0) var<storage, read_write> spawner: Spawner; // NOTE - same group as update
+@group(2) @binding(0) var<storage, read> spawner: Spawner;
 {{PROPERTIES_BINDING}}
 @group(3) @binding(0) var<storage, read_write> render_effect_indirect: RenderEffectMetadata;
 @group(3) @binding(1) var<storage, read_write> dest_render_group_indirect: RenderGroupIndirect;

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -31,7 +31,7 @@ struct VertexOutput {
 @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
 @group(1) @binding(2) var<storage, read> dispatch_indirect : DispatchIndirect;
 #ifdef RENDER_NEEDS_SPAWNER
-@group(1) @binding(3) var<storage, read> spawner : Spawner; // NOTE - same group as update
+@group(1) @binding(3) var<storage, read> spawner : Spawner;
 #endif
 {{MATERIAL_BINDINGS}}
 

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -19,8 +19,8 @@ struct ParticleBuffer {
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
 @group(1) @binding(2) var<storage, read> particle_groups : array<ParticleGroup>;
-{{PROPERTIES_BINDING}}
 @group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as init
+{{PROPERTIES_BINDING}}
 @group(3) @binding(0) var<storage, read_write> render_effect_indirect : RenderEffectMetadata;
 @group(3) @binding(1) var<storage, read_write> render_group_indirect : array<RenderGroupIndirect>;
 

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -19,7 +19,7 @@ struct ParticleBuffer {
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read_write> indirect_buffer : IndirectBuffer;
 @group(1) @binding(2) var<storage, read> particle_groups : array<ParticleGroup>;
-@group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as init
+@group(2) @binding(0) var<storage, read> spawner : Spawner;
 {{PROPERTIES_BINDING}}
 @group(3) @binding(0) var<storage, read_write> render_effect_indirect : RenderEffectMetadata;
 @group(3) @binding(1) var<storage, read_write> render_group_indirect : array<RenderGroupIndirect>;


### PR DESCRIPTION
Split the properties from the `EffectCache` and move their resource management into a new `PropertyCache`, which allocates GPU buffers to store them. This clarifies ownership, and allows better batching (in theory) as not all effects use properties.

In this change, unfortunately for simplicity we directly store the offset into the property buffer for each instance into the effect batch, meaning we again block batching multiple effects. This is hopefully temporary (and not the only blocker, so doesn't introduce any regression), but makes the change incremental and easier to handle for now, while other clean-ups are still pending.