### PR TITLE
Invalidate more bind group on changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the `ParticleEffect` component to require the `CompiledParticleEffect` and `SyncToRenderWorld` components.
 - Renamed `PropertyLayout::size()` to `cpu_size()` to prevent confusion.
-  The GPU size is given by `min_binding_size()`, and can be greater.
+  The GPU size is given by `min_binding_size()`, and can be greater due to WGSL padding rules being different from Rust ones.
 - `PropertyLayout::generate_code()` now returns an `Option<String>` for clarity,
   which is `None` if the layout is empty (as opposed to an empty string previously).
+- Removed effects are now deallocated from the render world before the extract schedule, instead of during it.
+  This should have no consequence, unless you were using a system inserted explicitly before Hanabi's extraction.
 
 ### Fixed
 
 - Fixed a bug with opaque effects not rendering.
+
+### Removed
+
+- Removed the `EffectSystems::GatherRemovedEffects` system set.
+  Removed effects are now processed via observers, which execute during the render world sync just before extraction.
+  Removed the `RemovedEffectsEvent` type too.
 
 ## [0.14.0] 2024-12-09
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,11 +172,7 @@ use std::fmt::Write as _;
 
 #[cfg(feature = "2d")]
 use bevy::math::FloatOrd;
-use bevy::{
-    prelude::*,
-    render::sync_world::{MainEntity, RenderEntity, SyncToRenderWorld},
-    utils::HashSet,
-};
+use bevy::{prelude::*, render::sync_world::SyncToRenderWorld, utils::HashSet};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -1630,47 +1626,6 @@ fn update_properties_from_asset(
         };
 
         EffectProperties::update(properties, asset.properties(), effect.is_added());
-    }
-}
-
-/// Event sent by [`gather_removed_effects()`] with the list of effects removed
-/// during this frame.
-///
-/// The event is consumed during the extract phase by the [`extract_effects()`]
-/// system, to clean-up unused GPU resources.
-///
-/// [`extract_effects()`]: crate::render::extract_effects
-#[derive(Event)]
-struct RemovedEffectsEvent {
-    entities: Vec<(MainEntity, Option<RenderEntity>)>,
-}
-
-/// Gather all the removed [`ParticleEffect`] components to allow cleaning-up
-/// unused GPU resources.
-///
-/// This system executes inside the [`EffectSystems::GatherRemovedEffects`]
-/// set of the [`PostUpdate`] schedule.
-fn gather_removed_effects(
-    q_effects: Query<Option<RenderEntity>, With<ParticleEffect>>,
-    mut removed_effects: RemovedComponents<ParticleEffect>,
-    mut removed_effects_event_writer: EventWriter<RemovedEffectsEvent>,
-) {
-    let entities: Vec<Entity> = removed_effects.read().collect();
-    if !entities.is_empty() {
-        let entities = entities
-            .iter()
-            .map(|main_entity| {
-                (
-                    MainEntity::from(*main_entity),
-                    q_effects
-                        .get(*main_entity)
-                        .ok()
-                        .flatten()
-                        .map(RenderEntity::from),
-                )
-            })
-            .collect();
-        removed_effects_event_writer.send(RemovedEffectsEvent { entities });
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1560,8 +1560,7 @@ fn compile_effects(
     {
         // If the ParticleEffect didn't change, and the compiled one is for the correct
         // asset, then there's nothing to do.
-        let need_rebuild =
-            effect.is_changed() || material.as_ref().map_or(false, |r| r.is_changed());
+        let need_rebuild = effect.is_changed() || material.as_ref().is_some_and(|r| r.is_changed());
         if !need_rebuild && (compiled_effect.asset == effect.handle) {
             continue;
         }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,22 +22,23 @@ use bevy::{
 use crate::asset::EffectAssetLoader;
 use crate::{
     asset::EffectAsset,
-    compile_effects, gather_removed_effects,
+    compile_effects,
     properties::EffectProperties,
     render::{
-        add_remove_effects, batch_effects, extract_effect_events, extract_effects,
-        prepare_bind_groups, prepare_effects, prepare_gpu_resources, queue_effects,
-        DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache,
-        EffectsMeta, ExtractedEffects, GpuDispatchIndirect, GpuParticleGroup,
-        GpuRenderEffectMetadata, GpuRenderGroupIndirect, GpuSpawnerParams, ParticlesInitPipeline,
-        ParticlesRenderPipeline, ParticlesUpdatePipeline, PropertyCache, ShaderCache, SimParams,
-        StorageType as _, VfxSimulateDriverNode, VfxSimulateNode,
+        add_effects, batch_effects, extract_effect_events, extract_effects,
+        on_remove_cached_effect, on_remove_cached_properties, prepare_bind_groups, prepare_effects,
+        prepare_gpu_resources, queue_effects, DispatchIndirectPipeline, DrawEffects,
+        EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects,
+        GpuDispatchIndirect, GpuParticleGroup, GpuRenderEffectMetadata, GpuRenderGroupIndirect,
+        GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
+        PropertyCache, ShaderCache, SimParams, StorageType as _, VfxSimulateDriverNode,
+        VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_initializers,
     time::effect_simulation_time_system,
     update_properties_from_asset, CompiledParticleEffect, EffectSimulation, ParticleEffect,
-    RemovedEffectsEvent, Spawner,
+    Spawner,
 };
 
 /// Labels for the Hanabi systems.
@@ -68,16 +69,6 @@ pub enum EffectSystems {
     /// declared properties should run before this set in order for changes to
     /// be taken into account in the same frame.
     UpdatePropertiesFromAsset,
-
-    /// Gather all removed [`ParticleEffect`] components during the
-    /// [`PostUpdate`] set, to clean-up unused GPU resources.
-    ///
-    /// Systems deleting entities with a [`ParticleEffect`] component should run
-    /// before this set if they want the particle effect is cleaned-up during
-    /// the same frame.
-    ///
-    /// [`ParticleEffect`]: crate::ParticleEffect
-    GatherRemovedEffects,
 
     /// Prepare effect assets for the extracted effects.
     ///
@@ -191,7 +182,6 @@ impl Plugin for HanabiPlugin {
     fn build(&self, app: &mut App) {
         // Register asset
         app.init_asset::<EffectAsset>()
-            .add_event::<RemovedEffectsEvent>()
             .insert_resource(Random(spawn::new_rng()))
             .init_resource::<ShaderCache>()
             .init_resource::<Time<EffectSimulation>>()
@@ -203,7 +193,6 @@ impl Plugin for HanabiPlugin {
                         // ComputedVisibility was updated.
                         .after(VisibilitySystems::VisibilityPropagate),
                     EffectSystems::CompileEffects,
-                    EffectSystems::GatherRemovedEffects,
                 ),
             )
             .configure_sets(
@@ -222,7 +211,6 @@ impl Plugin for HanabiPlugin {
                     tick_initializers.in_set(EffectSystems::TickSpawners),
                     compile_effects.in_set(EffectSystems::CompileEffects),
                     update_properties_from_asset.in_set(EffectSystems::UpdatePropertiesFromAsset),
-                    gather_removed_effects.in_set(EffectSystems::GatherRemovedEffects),
                     check_visibility::<WithCompiledParticleEffect>
                         .in_set(VisibilitySystems::CheckVisibility),
                 ),
@@ -314,7 +302,7 @@ impl Plugin for HanabiPlugin {
             .add_systems(
                 Render,
                 (
-                    (add_remove_effects, prepare_effects, batch_effects)
+                    (add_effects, prepare_effects, batch_effects)
                         .chain()
                         .in_set(EffectSystems::PrepareEffectAssets)
                         // Ensure we run after Bevy prepared the render Mesh
@@ -331,6 +319,10 @@ impl Plugin for HanabiPlugin {
                         .after(prepare_assets::<GpuImage>),
                 ),
             );
+        render_app.world_mut().add_observer(on_remove_cached_effect);
+        render_app
+            .world_mut()
+            .add_observer(on_remove_cached_properties);
 
         // Register the draw function for drawing the particles. This will be called
         // during the main 2D/3D pass, at the Transparent2d/3d phase, after the

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -531,7 +531,10 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
             self.free_indices.splice(pos..pos, index..(index + count));
         }
 
-        debug_assert!((self.free_indices.len() as u32) < self.active_count);
+        debug_assert!(
+            (self.free_indices.is_empty() && self.active_count == 0)
+                || (self.free_indices.len() as u32) < self.active_count
+        );
     }
 
     /// Allocate any GPU buffer if needed, based on the most recent capacity

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -119,6 +119,10 @@ pub struct BufferTable<T: Pod + ShaderSize> {
     /// constraints.
     aligned_size: usize,
     /// Capacity of the buffer, in number of rows.
+    ///
+    /// This is the expected capacity, as requested by CPU side allocations and
+    /// deallocations. The GPU buffer might not have been resized yet to handle
+    /// it, so might be allocated with a different size.
     capacity: u32,
     /// Size of the "active" portion of the table, which includes allocated rows
     /// and any row in the free list. All other rows in the
@@ -344,9 +348,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
             self.active_count += 1;
             index
         } else {
-            // Note: this is inefficient O(n) but we need to apply the same logic as the
-            // EffectCache because we rely on indices being in sync.
-            self.free_indices.remove(0)
+            self.free_indices.pop().unwrap()
         };
         let allocated_count = self
             .buffer
@@ -373,6 +375,98 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
         BufferTableId(index)
     }
 
+    /// Insert several new contiguous rows into the table.
+    ///
+    /// For performance reasons, this buffers the row content on the CPU until
+    /// the next GPU update, to minimize the number of CPU to GPU transfers.
+    ///
+    /// # Returns
+    ///
+    /// Returns the index of the first entry. Other entries follow right after
+    /// it.
+    pub fn insert_contiguous(&mut self, values: impl ExactSizeIterator<Item = T>) -> BufferTableId {
+        let count = values.len() as u32;
+        trace!(
+            "Inserting {} contiguous values into table buffer '{}' with {} free indices, capacity: {}, active_size: {}",
+            count,
+            self.safe_name(),
+            self.free_indices.len(),
+            self.capacity,
+            self.active_count
+        );
+        let first_index = if self.free_indices.is_empty() {
+            let index = self.active_count;
+            if index == self.capacity {
+                self.capacity += count;
+            }
+            debug_assert!(index < self.capacity);
+            self.active_count += count;
+            index
+        } else {
+            let mut s = 0;
+            let mut n = 1;
+            let mut i = 1;
+            while i < self.free_indices.len() {
+                debug_assert!(self.free_indices[i] > self.free_indices[i - 1]); // always sorted
+                if self.free_indices[i] == self.free_indices[i - 1] + 1 {
+                    // contiguous
+                    n += 1;
+                    if n == count {
+                        break;
+                    }
+                } else {
+                    // non-contiguous; restart a new sequence
+                    debug_assert!(n < count);
+                    s = i;
+                }
+                i += 1;
+            }
+            if n == count {
+                // Found a range of 'count' consecutive entries. Consume it.
+                let index = self.free_indices[s];
+                self.free_indices.splice(s..=i, []);
+                index
+            } else {
+                // No free range for 'count' consecutive entries. Allocate at end instead.
+                let index = self.active_count;
+                if index == self.capacity {
+                    self.capacity += count;
+                }
+                debug_assert!(index < self.capacity);
+                self.active_count += count;
+                index
+            }
+        };
+        let allocated_count = self
+            .buffer
+            .as_ref()
+            .map(|ab| ab.allocated_count())
+            .unwrap_or(0);
+        trace!(
+            "Found {} free indices {}..{}, capacity: {}, active_count: {}, allocated_count: {}",
+            count,
+            first_index,
+            first_index + count,
+            self.capacity,
+            self.active_count,
+            allocated_count
+        );
+        for (i, value) in values.enumerate() {
+            let index = first_index + i as u32;
+            if index < allocated_count {
+                self.pending_values.alloc().init((index, value));
+            } else {
+                let extra_index = index - allocated_count;
+                if extra_index < self.extra_pending_values.len() as u32 {
+                    self.extra_pending_values[extra_index as usize] = value;
+                } else {
+                    self.extra_pending_values.alloc().init(value);
+                }
+            }
+        }
+        BufferTableId(first_index)
+    }
+
     /// Remove a row from the table.
     #[allow(dead_code)]
     pub fn remove(&mut self, id: BufferTableId) {
@@ -393,6 +487,51 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
                 .unwrap_or_else(|e| e); // will get position of insertion
             self.free_indices.insert(pos, index);
         }
+    }
+
+    /// Remove a range of rows from the table.
+    #[allow(dead_code)]
+    pub fn remove_range(&mut self, first: BufferTableId, count: u32) {
+        let index = first.0;
+        assert!(index + count <= self.active_count);
+
+        // If this is the last item in the active zone, just shrink the active zone
+        // (implicit free list).
+        if index == self.active_count - count {
+            self.active_count -= count;
+            self.capacity -= count;
+
+            // Also try to remove free indices
+            if self.free_indices.len() as u32 == self.active_count {
+                // Easy case: everything is free, clear everything
+                self.free_indices.clear();
+                self.active_count = 0;
+                self.capacity = 0;
+            } else {
+                // Some rows are still allocated. Dequeue from end while we have a contiguous
+                // tail of free indices.
+                let mut num_popped = 0;
+                while let Some(idx) = self.free_indices.pop() {
+                    if idx < self.active_count {
+                        self.free_indices.push(idx);
+                        break;
+                    }
+                    num_popped += 1;
+                }
+                self.active_count -= num_popped;
+                self.capacity -= num_popped;
+            }
+        } else {
+            // This is very inefficient but we need to apply the same logic as the
+            // EffectCache because we rely on indices being in sync.
+            let pos = self
+                .free_indices
+                .binary_search(&index) // will fail
+                .unwrap_or_else(|e| e); // will get position of insertion
+            self.free_indices.splice(pos..pos, index..(index + count));
+        }
+
+        debug_assert!((self.free_indices.len() as u32) < self.active_count);
     }
 
     /// Allocate any GPU buffer if needed, based on the most recent capacity
@@ -608,7 +747,7 @@ mod tests {
     }
 
     #[test]
-    fn table_sizes() {
+    fn buffer_table_sizes() {
         // Rust
         assert_eq!(std::mem::size_of::<GpuDummy>(), 12);
         assert_eq!(std::mem::align_of::<GpuDummy>(), 4);
@@ -691,6 +830,54 @@ mod tests {
             assert!(!table.is_empty());
             assert_eq!(table.len(), 1);
         }
+    }
+
+    #[test]
+    fn buffer_table_insert() {
+        let mut table =
+            BufferTable::<GpuDummy>::new(BufferUsages::STORAGE, NonZeroU64::new(32), None);
+
+        let id1 = table.insert(GpuDummy::default());
+        assert_eq!(id1.0, 0);
+        assert_eq!(table.active_count, 1);
+        assert!(table.free_indices.is_empty());
+
+        let id2 = table.insert(GpuDummy::default());
+        assert_eq!(id2.0, 1);
+        assert_eq!(table.active_count, 2);
+        assert!(table.free_indices.is_empty());
+
+        table.remove(id1);
+        assert_eq!(table.active_count, 2);
+        assert_eq!(table.free_indices.len(), 1);
+        assert_eq!(table.free_indices[0], 0);
+
+        let id3 = table.insert_contiguous([GpuDummy::default(); 2].into_iter());
+        assert_eq!(id3.0, 2); // at the end (doesn't fit in free slot #0)
+        assert_eq!(table.active_count, 4);
+        assert_eq!(table.free_indices.len(), 1);
+        assert_eq!(table.free_indices[0], 0);
+
+        table.remove(id2);
+        assert_eq!(table.active_count, 4);
+        assert_eq!(table.free_indices.len(), 2);
+        assert_eq!(table.free_indices[0], 0);
+        assert_eq!(table.free_indices[1], 1);
+
+        let id4 = table.insert_contiguous([GpuDummy::default(); 2].into_iter());
+        assert_eq!(id4.0, 0); // this times it fit into slot #0-#1
+        assert_eq!(table.active_count, 4);
+        assert!(table.free_indices.is_empty());
+
+        table.remove_range(id4, 2);
+        assert_eq!(table.active_count, 4);
+        assert_eq!(table.free_indices.len(), 2);
+        assert_eq!(table.free_indices[0], 0);
+        assert_eq!(table.free_indices[1], 1);
+
+        table.remove_range(id3, 2);
+        assert_eq!(table.active_count, 0);
+        assert!(table.free_indices.is_empty());
     }
 }
 

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -811,10 +811,8 @@ impl EffectCache {
     /// This iterates over all valid buffers and calls
     /// [`EffectBuffer::invalidate_sim_bind_group()`] on each one.
     pub fn invalidate_sim_bind_groups(&mut self) {
-        for buffer in &mut self.buffers {
-            if let Some(buffer) = buffer {
-                buffer.invalidate_sim_bind_group();
-            }
+        for buffer in self.buffers.iter_mut().flatten() {
+            buffer.invalidate_sim_bind_group();
         }
     }
 


### PR DESCRIPTION
Invalidate the bind groups for the simulation, containing the particle group buffer, when that buffer is reallocated or when the group changes position in the buffer. This was causing old buffers to be referenced when the group(s) changed, creating artifacts in ribbon rendering in particular.

Similarly, invalidate the bind groups referencing a property buffer when that buffer is reallocated, for the same reasons. This fixes a crash previously introduced by the new property buffer change.