### PR TITLE
Add `DebugSettings` for GPU capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new `DebugSettings` resource, allowing to instruct a GPU debugger to start capturing API commands,
+  either right away or each time a new effect is spawned.
+
 ### Changed
 
 - Changed the `ParticleEffect` component to require the `CompiledParticleEffect` and `SyncToRenderWorld` components.

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1470,7 +1470,7 @@ pub enum BuiltInOperator {
     /// - Otherwise, the initial value is `true`.
     ///
     /// At the end of the update pass, if the particle has both the
-    /// [`Attribute::AGE`] and   [`Attribute::LIFETIME`], then the flag is
+    /// [`Attribute::AGE`] and [`Attribute::LIFETIME`], then the flag is
     /// re-evaluated as:
     ///
     /// ```wgsl

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ pub use graph::*;
 pub use modifier::*;
 pub use plugin::{EffectSystems, HanabiPlugin};
 pub use properties::*;
-pub use render::{LayoutFlags, ShaderCache};
+pub use render::{DebugSettings, LayoutFlags, ShaderCache};
 pub use spawn::{
     tick_initializers, Cloner, CpuValue, EffectCloner, EffectInitializer, EffectInitializers,
     EffectSpawner, Initializer, Random, Spawner,
@@ -1347,16 +1347,19 @@ impl CompiledParticleEffect {
             .map(|effect_group_shader_source| {
                 let init = shader_cache.get_or_insert(
                     &asset.name,
+                    "init",
                     &effect_group_shader_source.init,
                     shaders,
                 );
                 let update = shader_cache.get_or_insert(
                     &asset.name,
+                    "update",
                     &effect_group_shader_source.update,
                     shaders,
                 );
                 let render = shader_cache.get_or_insert(
                     &asset.name,
+                    "render",
                     &effect_group_shader_source.render,
                     shaders,
                 );

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -27,12 +27,12 @@ use crate::{
     render::{
         add_effects, batch_effects, extract_effect_events, extract_effects,
         on_remove_cached_effect, on_remove_cached_properties, prepare_bind_groups, prepare_effects,
-        prepare_gpu_resources, queue_effects, DispatchIndirectPipeline, DrawEffects,
+        prepare_gpu_resources, queue_effects, DebugSettings, DispatchIndirectPipeline, DrawEffects,
         EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, ExtractedEffects,
         GpuDispatchIndirect, GpuParticleGroup, GpuRenderEffectMetadata, GpuRenderGroupIndirect,
         GpuSpawnerParams, ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
-        PropertyCache, ShaderCache, SimParams, StorageType as _, VfxSimulateDriverNode,
-        VfxSimulateNode,
+        PropertyCache, RenderDebugSettings, ShaderCache, SimParams, StorageType as _,
+        VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_initializers,
@@ -184,6 +184,7 @@ impl Plugin for HanabiPlugin {
         app.init_asset::<EffectAsset>()
             .insert_resource(Random(spawn::new_rng()))
             .init_resource::<ShaderCache>()
+            .init_resource::<DebugSettings>()
             .init_resource::<Time<EffectSimulation>>()
             .configure_sets(
                 PostUpdate,
@@ -274,6 +275,7 @@ impl Plugin for HanabiPlugin {
             .insert_resource(effects_meta)
             .insert_resource(effect_cache)
             .insert_resource(property_cache)
+            .init_resource::<RenderDebugSettings>()
             .init_resource::<EffectBindGroups>()
             .init_resource::<DispatchIndirectPipeline>()
             .init_resource::<ParticlesInitPipeline>()

--- a/src/render/shader_cache.rs
+++ b/src/render/shader_cache.rs
@@ -31,6 +31,7 @@ impl ShaderCache {
     pub fn get_or_insert(
         &mut self,
         filename: &str,
+        suffix: &str,
         source: &str,
         shaders: &mut ResMut<Assets<Shader>>,
     ) -> Handle<Shader> {
@@ -42,7 +43,7 @@ impl ShaderCache {
             let hash = hasher.finish();
             let shader = Shader::from_wgsl(
                 source.to_string(),
-                format!("hanabi/{}_{}.wgsl", filename, hash),
+                format!("hanabi/{}_{}_{}.wgsl", filename, suffix, hash),
             );
             trace!(
                 "Shader path={} import_path={:?} imports={:?}",
@@ -50,8 +51,12 @@ impl ShaderCache {
                 shader.import_path,
                 shader.imports
             );
+            let shader_path = shader.path.clone();
             let handle = shaders.add(shader);
-            debug!("Inserted new configured shader: {:?}\n{}", handle, source);
+            debug!(
+                "Inserted new configured shader {}: {:?}\n{}",
+                shader_path, handle, source
+            );
             self.cache.insert(source.to_string(), handle.clone());
             handle
         }

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -18,7 +18,7 @@ struct SimParams {
 }
 
 struct Spawner {
-    // Compressed transform of the emitter.
+    /// Compressed transform of the emitter.
     transform: mat3x4<f32>, // transposed (row-major)
     /// Inverse compressed transform of the emitter.
     inverse_transform: mat3x4<f32>, // transposed (row-major)


### PR DESCRIPTION
Add a new `DebugSettings` resource controlling some debugging settings.

Add the ability via debugging settings to instruct a GPU debugger attached to the application to capture one or more GPU frames, either right now or each time a new effect is spawned.