### PR TITLE
Destroy buffers after use, fix bug in `BufferTable`

### DIFF
--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -181,6 +181,9 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
                 size
             );
             self.capacity = capacity;
+            if let Some(buffer) = self.buffer.take() {
+                buffer.destroy();
+            }
             self.buffer = Some(device.create_buffer(&BufferDescriptor {
                 label: self.label.as_ref().map(|s| &s[..]),
                 size: size as BufferAddress,
@@ -705,6 +708,9 @@ impl HybridAlignedBufferVec {
                 capacity,
             );
             self.capacity = capacity;
+            if let Some(buffer) = self.buffer.take() {
+                buffer.destroy();
+            }
             self.buffer = Some(device.create_buffer(&BufferDescriptor {
                 label: self.label.as_ref().map(|s| &s[..]),
                 size: capacity as BufferAddress,


### PR DESCRIPTION
Always call `Buffer::destroy()` on the old buffer resource when a GPU buffer is re-allocated. This ensures we get a runtime assertion if a bind group is not recreated and attempts to use a stale buffer.

Fix a bug in `BufferTable` where the free list was not updated correctly, which could in theory lead to issues once re-allocating new elements.