### PR TITLE
Remove `z_layer_2d`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `EffectAsset::ribbon_group` as well as `with_trails()` and `with_ribbons()`.
   Use the `Attribute::RIBBON_ID` instead to assign a per-particle ribbon ID.
 - Removed `ParticleEffectBundle`. Use `ParticleEffect` directly instead.
+- Removed `ParticleEffect::z_layer_2d`. Use the Z coordinate of the effect's `Tranform` to order effects.
 
 ## [0.14.0] 2024-12-09
 

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -1,8 +1,4 @@
 //! A particle system with a 2D camera.
-//!
-//! The particle effect instance override its `z_layer_2d` field, which can be
-//! tweaked at runtime via the egui inspector to move the 2D rendering layer of
-//! particle above or below the reference square.
 
 use bevy::{prelude::*, render::camera::ScalingMode};
 use bevy_hanabi::prelude::*;
@@ -95,15 +91,11 @@ fn setup(
 
     // Spawn an instance of the particle effect, and override its Z layer to
     // be above the reference white square previously spawned.
-    commands.spawn((
-        // Assign the Z layer so it appears in the egui inspector and can be modified at runtime
-        ParticleEffect::new(effect).with_z_layer_2d(Some(0.1)),
-        Name::new("effect:2d"),
-    ));
+    commands.spawn((ParticleEffect::new(effect), Name::new("effect:2d")));
 }
 
 fn update_plane(time: Res<Time>, mut query: Query<&mut Transform, With<Mesh2d>>) {
     let mut transform = query.single_mut();
     // Move the plane back and forth to show particles ordering relative to it
-    transform.translation.z = (time.elapsed_secs() * 2.5).sin() * 0.045 + 0.1;
+    transform.translation.z = (time.elapsed_secs() * 2.5).sin() * 0.045;
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -297,7 +297,8 @@ pub struct EffectAsset {
     pub simulation_condition: SimulationCondition,
     /// Seed for the pseudo-random number generator.
     ///
-    /// This is uploaded to GPU and used for the various random expressions and quantities computed in shaders.
+    /// This is uploaded to GPU and used for the various random expressions and
+    /// quantities computed in shaders.
     pub prng_seed: u32,
     /// Init modifier defining the effect.
     #[reflect(ignore)]

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -1,7 +1,5 @@
 use std::{collections::VecDeque, fmt::Debug, num::NonZeroU32, ops::Range};
 
-#[cfg(feature = "2d")]
-use bevy::math::FloatOrd;
 use bevy::{
     prelude::*,
     render::{
@@ -322,14 +320,8 @@ pub(crate) struct EffectDrawBatch {
     /// Note: currently there's a 1:1 mapping between effect batch and draw
     /// batch.
     pub effect_batch_index: EffectBatchIndex,
-    /// For 2D rendering, the Z coordinate used as the sort key. Ignored for 3D
-    /// rendering.
-    #[cfg(feature = "2d")]
-    pub z_sort_key_2d: FloatOrd,
-    /// For 3d rendering, the position of the emitter so we can compute distance
-    /// to camera. Ignored for 2D rendering.
-    #[cfg(feature = "3d")]
-    pub translation_3d: Vec3,
+    /// Position of the emitter so we can compute distance to camera.
+    pub translation: Vec3,
 }
 
 impl EffectBatch {
@@ -429,15 +421,11 @@ pub(crate) struct BatchInput {
     pub spawner_base: u32,
     /// Number of particles to spawn for this effect.
     pub spawn_count: u32,
-    /// Emitter position, for 3D sorting.
-    #[cfg(feature = "3d")]
+    /// Emitter position.
     pub position: Vec3,
     /// Index of the init indirect dispatch struct, if any.
     // FIXME - Contains a single effect's data; should handle multiple ones.
     pub init_indirect_dispatch_index: Option<u32>,
-    /// Sort key, for 2D only.
-    #[cfg(feature = "2d")]
-    pub z_sort_key_2d: FloatOrd,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -971,8 +971,6 @@ mod test {
                             InheritedVisibility::default(),
                             ParticleEffect {
                                 handle: handle.clone(),
-                                #[cfg(feature = "2d")]
-                                z_layer_2d: None,
                             },
                         ))
                         .id()
@@ -980,8 +978,6 @@ mod test {
                     world
                         .spawn((ParticleEffect {
                             handle: handle.clone(),
-                            #[cfg(feature = "2d")]
-                            z_layer_2d: None,
                         },))
                         .id()
                 };


### PR DESCRIPTION
Remove `ParticleEffect::z_layer_2d` in favor of just using the effect `Transform`'s Z coordinate. This makes ordering particle effects in layers (along Z) more consistent and expected.

Fixes #423