### PR TITLE
Fix bindings with atomics for wasm

### DIFF
--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -191,12 +191,12 @@ impl SortBindGroups {
                     },
                     count: None,
                 },
-                // @group(0) @binding(2) var<storage, read> effect_metadata : EffectMetadata;
+                // @group(0) @binding(2) var<storage, read_write> effect_metadata : EffectMetadata;
                 BindGroupLayoutEntry {
                     binding: 2,
                     visibility: ShaderStages::COMPUTE,
                     ty: BindingType::Buffer {
-                        ty: BufferBindingType::Storage { read_only: true },
+                        ty: BufferBindingType::Storage { read_only: false },
                         has_dynamic_offset: true,
                         min_binding_size: Some(effect_metadata_min_binding_size),
                     },
@@ -339,12 +339,12 @@ impl SortBindGroups {
                             },
                             count: None,
                         },
-                        // @group(0) @binding(3) var<storage, read> effect_metadata : EffectMetadata;
+                        // @group(0) @binding(3) var<storage, read_write> effect_metadata : EffectMetadata;
                         BindGroupLayoutEntry {
                             binding: 3,
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
-                                ty: BufferBindingType::Storage { read_only: true },
+                                ty: BufferBindingType::Storage { read_only: false },
                                 has_dynamic_offset: true,
                                 min_binding_size: Some(GpuEffectMetadata::aligned_size(alignment)),
                             },

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -28,7 +28,7 @@ fn compare_greater(kv1: KeyValuePair, kv2: KeyValuePair) -> bool {
     return false;
 }
 
-@group(0) @binding(0) var<storage, read_write> sort_buffer: SortBuffer;
+@group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
 
 /// Naive insertion sort. TODO: replace with something faster.
 @compute @workgroup_size(64)

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -12,7 +12,7 @@ struct KeyValuePair {
 }
 
 struct SortBuffer {
-    count: atomic<i32>,
+    count: i32,
     pairs: array<KeyValuePair>,
 }
 
@@ -22,7 +22,8 @@ struct IndirectIndexBuffer {
 
 @group(0) @binding(0) var<storage, read_write> indirect_index_buffer : IndirectIndexBuffer;
 @group(0) @binding(1) var<storage, read> sort_buffer : SortBuffer;
-@group(0) @binding(2) var<storage, read> effect_metadata : EffectMetadata;
+// Technically read-only, but the type contains atomic<> fields and wasm is strict about it
+@group(0) @binding(2) var<storage, read_write> effect_metadata : EffectMetadata;
 
 /// Fill the sorting key-value pair buffer with data to prepare for actual sorting.
 @compute @workgroup_size(64)

--- a/src/render/vfx_sort_fill.wgsl
+++ b/src/render/vfx_sort_fill.wgsl
@@ -25,7 +25,8 @@ struct RawParticleBuffer {
 @group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
 @group(0) @binding(1) var<storage, read> particle_buffer : RawParticleBuffer;
 @group(0) @binding(2) var<storage, read> indirect_index_buffer : array<u32>;
-@group(0) @binding(3) var<storage, read> effect_metadata : EffectMetadata;
+// Technically read-only, but the type contains atomic<> fields and wasm is strict about it
+@group(0) @binding(3) var<storage, read_write> effect_metadata : EffectMetadata;
 
 /// Fill the sorting key-value pair buffer with data to prepare for actual sorting.
 @compute @workgroup_size(64)


### PR DESCRIPTION
The wasm target is more strict about shader bindings. Any struct with an atomic needs to be declared `read_write`, even if never written. Fix a few instances were this was not the case.