### PR TITLE
Color changes to allow random firework colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SpawnerSettings::with_emit_on_start()` to enable or disable starting the particle emitting
   when the `EffectSpawner` component is spawned into the ECS world.
   This allows spawning the component but only emitting particles under control of the application.
+- Added `ColorBlendMode` and `ColorBlendMask` to customize how color-related modifiers blend their value.
+  This allows overlaying _e.g._ a `SetAttributeModifier(Attribute::COLOR)` and a `ColorOverLifetimeModifier`
+  without the latter overwriting the value of the former.
+  See the `firework.rs` example for an example of using color blending.
+- Added `WriterExpr::vec4_xyz_w()` to recombine a 3D vector and a scalar together into a 4D vector.
+  This is particularly useful to combine some RGB value and Alpha value together.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See the `firework.rs` example for an example of using color blending.
 - Added `WriterExpr::vec4_xyz_w()` to recombine a 3D vector and a scalar together into a 4D vector.
   This is particularly useful to combine some RGB value and Alpha value together.
+- Added new `SetColorModifier::new(Into<CpuValue<Vec4>>)` and `ColorOverLifetimeModifier::new(Gradient<Vec4>)` helpers
+  for the common case where color blend and mask are the defaults.
 
 ### Changed
 

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -85,7 +85,7 @@ fn setup(
                 gradient: Gradient::constant(Vec3::splat(0.02)),
                 screen_space_size: false,
             })
-            .render(ColorOverLifetimeModifier { gradient })
+            .render(ColorOverLifetimeModifier::new(gradient))
             .render(round),
     );
 

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -128,7 +128,7 @@ fn setup(
             .render(SetSizeModifier {
                 size: Vec3::splat(0.02).into(),
             })
-            .render(ColorOverLifetimeModifier { gradient })
+            .render(ColorOverLifetimeModifier::new(gradient))
             .render(round),
     );
 

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -136,7 +136,7 @@ fn setup(
             sample_mapping: ImageSampleMapping::ModulateRGB,
         })
         .render(FlipbookModifier { sprite_grid_size })
-        .render(ColorOverLifetimeModifier { gradient })
+        .render(ColorOverLifetimeModifier::new(gradient))
         .render(SizeOverLifetimeModifier {
             gradient: Gradient::constant([0.5; 3].into()),
             screen_space_size: false,

--- a/examples/expr.rs
+++ b/examples/expr.rs
@@ -86,9 +86,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
             .init(init_lifetime)
             .init(init_vel)
             .update(update_accel)
-            .render(ColorOverLifetimeModifier {
-                gradient: color_gradient,
-            })
+            .render(ColorOverLifetimeModifier::new(color_gradient))
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient,
                 screen_space_size: false,

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -310,7 +310,7 @@ fn setup(
                 gradient: Gradient::constant(Vec3::splat(0.05)),
                 screen_space_size: false,
             })
-            .render(ColorOverLifetimeModifier { gradient }),
+            .render(ColorOverLifetimeModifier::new(gradient)),
     );
 
     commands.spawn((ParticleEffect::new(effect), EffectProperties::default()));

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -81,7 +81,7 @@ fn setup(
                 texture_slot,
                 sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
-            .render(ColorOverLifetimeModifier { gradient }),
+            .render(ColorOverLifetimeModifier::new(gradient)),
     );
 
     commands

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -41,9 +41,7 @@ where
         .with_simulation_space(SimulationSpace::Local)
         .init(init)
         .render(OrientModifier::new(OrientMode::FaceCameraPosition))
-        .render(SetColorModifier {
-            color: COLOR.into(),
-        })
+        .render(SetColorModifier::new(COLOR))
         .render(SetSizeModifier { size: SIZE.into() })
 }
 

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -244,7 +244,7 @@ fn setup(
             .init(init_vel)
             .init(init_age)
             .init(init_lifetime)
-            .render(ColorOverLifetimeModifier { gradient }),
+            .render(ColorOverLifetimeModifier::new(gradient)),
     );
 
     let mut gradient = Gradient::new();
@@ -289,7 +289,7 @@ fn setup(
                 texture_slot,
                 sample_mapping: ImageSampleMapping::Modulate,
             })
-            .render(ColorOverLifetimeModifier { gradient }),
+            .render(ColorOverLifetimeModifier::new(gradient)),
     );
 
     // Store the effects for later reference

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -86,9 +86,7 @@ fn setup(
         .init(init_vel1)
         .init(init_age1)
         .init(init_lifetime1)
-        .render(ColorOverLifetimeModifier {
-            gradient: gradient1,
-        }),
+        .render(ColorOverLifetimeModifier::new(gradient1)),
     );
 
     commands
@@ -135,9 +133,7 @@ fn setup(
         .init(init_vel2)
         .init(init_age2)
         .init(init_lifetime2)
-        .render(ColorOverLifetimeModifier {
-            gradient: gradient2,
-        }),
+        .render(ColorOverLifetimeModifier::new(gradient2)),
     );
 
     commands
@@ -184,9 +180,7 @@ fn setup(
         .init(init_vel3)
         .init(init_age3)
         .init(init_lifetime3)
-        .render(ColorOverLifetimeModifier {
-            gradient: gradient3,
-        }),
+        .render(ColorOverLifetimeModifier::new(gradient3)),
     );
 
     commands

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -75,9 +75,7 @@ fn make_effect(color: Color) -> EffectAsset {
         .init(init_age)
         .init(init_lifetime)
         .update(update_accel)
-        .render(ColorOverLifetimeModifier {
-            gradient: color_gradient,
-        })
+        .render(ColorOverLifetimeModifier::new(color_gradient))
         .render(SizeOverLifetimeModifier {
             gradient: size_gradient.clone(),
             screen_space_size: false,

--- a/examples/ordering.rs
+++ b/examples/ordering.rs
@@ -82,9 +82,7 @@ fn make_firework() -> EffectAsset {
         .update(update_accel)
         // Note: we (ab)use the ColorOverLifetimeModifier to set a fixed color hard-coded in the
         // render shader, without having to store a per-particle color. This is an optimization.
-        .render(ColorOverLifetimeModifier {
-            gradient: color_gradient1,
-        })
+        .render(ColorOverLifetimeModifier::new(color_gradient1))
         .render(SizeOverLifetimeModifier {
             gradient: size_gradient1,
             screen_space_size: false,

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -82,9 +82,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
             .init(init_lifetime)
             .update(update_drag)
             .update(tangent_accel)
-            .render(ColorOverLifetimeModifier {
-                gradient: color_gradient1,
-            })
+            .render(ColorOverLifetimeModifier::new(color_gradient1))
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient1,
                 screen_space_size: false,

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -77,7 +77,7 @@ fn setup(
         .init(init_age)
         .init(init_lifetime)
         .update(update_accel)
-        .render(ColorOverLifetimeModifier { gradient }),
+        .render(ColorOverLifetimeModifier::new(gradient)),
     );
 
     commands

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -122,9 +122,10 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         value: writer.lit(0u32).expr(),
     };
 
-    let render_color = ColorOverLifetimeModifier {
-        gradient: Gradient::linear(vec4(3.0, 0.0, 0.0, 1.0), vec4(3.0, 0.0, 0.0, 0.0)),
-    };
+    let render_color = ColorOverLifetimeModifier::new(Gradient::linear(
+        vec4(3.0, 0.0, 0.0, 1.0),
+        vec4(3.0, 0.0, 0.0, 0.0),
+    ));
 
     let spawner = SpawnerSettings::rate(RIBBON_SPAWN_RATE.into());
 

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -109,9 +109,7 @@ fn setup(
             .init(init_age1)
             .init(init_lifetime1)
             .update(update_accel1)
-            .render(ColorOverLifetimeModifier {
-                gradient: color_gradient1,
-            })
+            .render(ColorOverLifetimeModifier::new(color_gradient1))
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient1,
                 screen_space_size: false,
@@ -163,9 +161,7 @@ fn setup(
         .init(init_vel2)
         .init(init_age2)
         .init(init_lifetime2)
-        .render(ColorOverLifetimeModifier {
-            gradient: gradient2,
-        }),
+        .render(ColorOverLifetimeModifier::new(gradient2)),
     );
 
     commands
@@ -231,9 +227,7 @@ fn setup(
         .init(init_lifetime3)
         .init(init_size3)
         .update(update_accel3)
-        .render(ColorOverLifetimeModifier {
-            gradient: gradient3,
-        }),
+        .render(ColorOverLifetimeModifier::new(gradient3)),
     );
 
     commands

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -89,7 +89,7 @@ fn setup(
     .init(init_age)
     .init(init_lifetime)
     //.update(AccelModifier::constant(Vec3::new(0., 2., 0.)))
-    .render(ColorOverLifetimeModifier { gradient });
+    .render(ColorOverLifetimeModifier::new(gradient));
     let effect1 = effects.add(asset.clone());
 
     // Reference cube to visualize the emit origin

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -148,6 +148,12 @@ fn create_body_effect() -> EffectAsset {
     let init_lifetime_modifier =
         SetAttributeModifier::new(Attribute::LIFETIME, writer.lit(1.5).expr());
 
+    // The trail inherits the color of its parent head
+    let init_color_modifier = SetAttributeModifier::new(
+        Attribute::COLOR,
+        writer.parent_attr(Attribute::COLOR).expr(),
+    );
+
     // Render modifiers
 
     // Set the particle size.
@@ -167,6 +173,7 @@ fn create_body_effect() -> EffectAsset {
         .init(init_ribbon_id_modifier)
         .init(init_age_modifier)
         .init(init_lifetime_modifier)
+        .init(init_color_modifier)
         .render(set_size_modifier)
 }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -740,6 +740,8 @@ mod tests {
         {
             let effect = EffectAsset::default().add_render_modifier(Box::new(SetColorModifier {
                 color: CpuValue::Single(Vec4::ONE),
+                blend: ColorBlendMode::Overwrite,
+                mask: ColorBlendMask::RGBA,
             }));
             assert_eq!(effect.modifiers().count(), 1);
             let m = effect.modifiers().next().unwrap();

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -2062,6 +2062,12 @@ pub enum BinaryOperator {
     /// Given two scalar elements `x` and `y`, returns the vector consisting of
     /// those two elements `(x, y)`.
     Vec2,
+
+    /// Constructor for a 4-element vector.
+    ///
+    /// Given a 3-element vector `xyz` and a scalar value `w`, returns the
+    /// vector `vec4(xyz, w)`.
+    Vec4XyzW,
 }
 
 impl BinaryOperator {
@@ -2091,7 +2097,8 @@ impl BinaryOperator {
             | BinaryOperator::Step
             | BinaryOperator::UniformRand
             | BinaryOperator::NormalRand
-            | BinaryOperator::Vec2 => true,
+            | BinaryOperator::Vec2
+            | BinaryOperator::Vec4XyzW => true,
         }
     }
 
@@ -2132,6 +2139,7 @@ impl ToWgslString for BinaryOperator {
             BinaryOperator::UniformRand => "rand_uniform".to_string(),
             BinaryOperator::NormalRand => "rand_normal".to_string(),
             BinaryOperator::Vec2 => "vec2".to_string(),
+            BinaryOperator::Vec4XyzW => "vec4".to_string(),
         }
     }
 }
@@ -3817,6 +3825,23 @@ impl WriterExpr {
     #[inline]
     pub fn vec3(self, y: Self, z: Self) -> Self {
         self.ternary_op(y, z, TernaryOperator::Vec3)
+    }
+
+    /// Construct a `Vec4` from a vector XYZ and a scalar W.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_hanabi::*;
+    /// # let mut w = ExprWriter::new();
+    /// let rgb = w.rand(VectorType::VEC3F);
+    /// let a = w.lit(1.);
+    /// // Build vec4<f32>(R, G, B, A) and convert to 0xAABBGGRR
+    /// let col = rgb.vec4_xyz_w(a).Pack4x8unorm();
+    /// ```
+    #[inline]
+    pub fn vec4_xyz_w(self, w: Self) -> Self {
+        self.binary_op(w, BinaryOperator::Vec4XyzW)
     }
 
     /// Cast an expression to a different type.

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -3837,7 +3837,7 @@ impl WriterExpr {
     /// let rgb = w.rand(VectorType::VEC3F);
     /// let a = w.lit(1.);
     /// // Build vec4<f32>(R, G, B, A) and convert to 0xAABBGGRR
-    /// let col = rgb.vec4_xyz_w(a).Pack4x8unorm();
+    /// let col = rgb.vec4_xyz_w(a).pack4x8unorm();
     /// ```
     #[inline]
     pub fn vec4_xyz_w(self, w: Self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,11 @@
 //!     // Render the particles with a color gradient over their
 //!     // lifetime. This maps the gradient key 0 to the particle spawn
 //!     // time, and the gradient key 1 to the particle death (10s).
-//!     .render(ColorOverLifetimeModifier { gradient });
+//!     .render(ColorOverLifetimeModifier {
+//!         gradient,
+//!         blend: ColorBlendMode::Overwrite,
+//!         mask: ColorBlendMask::RGBA,
+//!     });
 //!
 //!     // Insert into the asset system
 //!     let effect_asset = effects.add(effect);

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -236,6 +236,20 @@ pub struct SetColorModifier {
     pub mask: ColorBlendMask,
 }
 
+impl SetColorModifier {
+    /// Create a new modifier with the default color blend and mask.
+    pub fn new<C>(color: C) -> Self
+    where
+        C: Into<CpuValue<Vec4>>,
+    {
+        Self {
+            color: color.into(),
+            blend: default(),
+            mask: default(),
+        }
+    }
+}
+
 impl_mod_render!(SetColorModifier, &[]);
 
 #[cfg_attr(feature = "serde", typetag::serde)]
@@ -282,6 +296,17 @@ pub struct ColorOverLifetimeModifier {
     pub blend: ColorBlendMode,
     /// The blend mask.
     pub mask: ColorBlendMask,
+}
+
+impl ColorOverLifetimeModifier {
+    /// Create a new modifier from a given gradient.
+    pub fn new(gradient: Gradient<Vec4>) -> Self {
+        Self {
+            gradient,
+            blend: default(),
+            mask: default(),
+        }
+    }
 }
 
 impl_mod_render!(

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -3,6 +3,7 @@
 use std::hash::Hash;
 
 use bevy::prelude::*;
+use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -149,6 +150,73 @@ impl ParticleTextureModifier {
     }
 }
 
+/// Color blending modes.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+pub enum ColorBlendMode {
+    /// Overwrite the destination color with the source one.
+    #[default]
+    Overwrite,
+    /// Add the source color to the destination one.
+    Add,
+    /// Multiply the source color by the destination one.
+    Modulate,
+}
+
+impl ColorBlendMode {
+    /// Convert the blend mode to the string representation of its operator.
+    pub fn to_assign_operator(&self) -> String {
+        match *self {
+            ColorBlendMode::Overwrite => "=",
+            ColorBlendMode::Add => "+=",
+            ColorBlendMode::Modulate => "*=",
+        }
+        .to_string()
+    }
+}
+
+/// Color component write mask for blending colors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+pub struct ColorBlendMask(u8);
+
+bitflags! {
+    impl ColorBlendMask: u8 {
+        /// First component (red).
+        const R = 0b0001;
+        /// Second component (green).
+        const G = 0b0010;
+        /// Third component (blue).
+        const B = 0b0100;
+        /// Last component (alpha).
+        const A = 0b1000;
+
+        /// RGB mask (skip alpha).
+        const RGB = 0b0111;
+
+        /// RGBA mask (all components).
+        const RGBA = 0b1111;
+    }
+}
+
+impl Default for ColorBlendMask {
+    fn default() -> Self {
+        Self::RGBA
+    }
+}
+
+impl ColorBlendMask {
+    /// Convert the mask to a string of components, e.g. "rgb" or "ra".
+    pub fn to_components(&self) -> String {
+        let cmp = ['r', 'g', 'b', 'a'];
+        (0..3).fold(String::new(), |mut acc, i| {
+            let mask = ColorBlendMask::from_bits_truncate(1u8 << i);
+            if self.contains(mask) {
+                acc.push(cmp[i]);
+            }
+            acc
+        })
+    }
+}
+
 /// A modifier to set the rendering color of all particles.
 ///
 /// This modifier assigns a _single_ color to all particles. That color can be
@@ -162,6 +230,10 @@ impl ParticleTextureModifier {
 pub struct SetColorModifier {
     /// The particle color.
     pub color: CpuValue<Vec4>,
+    /// The color blend mode.
+    pub blend: ColorBlendMode,
+    /// The blend mask.
+    pub mask: ColorBlendMask,
 }
 
 impl_mod_render!(SetColorModifier, &[]);
@@ -173,7 +245,15 @@ impl RenderModifier for SetColorModifier {
         _module: &mut Module,
         context: &mut RenderContext,
     ) -> Result<(), ExprError> {
-        context.vertex_code += &format!("color = {0};\n", self.color.to_wgsl_string());
+        let op = self.blend.to_assign_operator();
+        let col = self.color.to_wgsl_string();
+        let s = if self.mask == ColorBlendMask::RGBA {
+            format!("color {op} {col};\n")
+        } else {
+            let mask = self.mask.to_components();
+            format!("color.{mask} {op} ({col}).{mask};\n")
+        };
+        context.vertex_code += &s;
         Ok(())
     }
 
@@ -198,6 +278,10 @@ impl RenderModifier for SetColorModifier {
 pub struct ColorOverLifetimeModifier {
     /// The color gradient defining the particle color based on its lifetime.
     pub gradient: Gradient<Vec4>,
+    /// The color blend mode.
+    pub blend: ColorBlendMode,
+    /// The blend mask.
+    pub mask: ColorBlendMask,
 }
 
 impl_mod_render!(
@@ -223,13 +307,21 @@ impl RenderModifier for ColorOverLifetimeModifier {
             self.gradient.to_shader_code("key")
         );
 
-        context.vertex_code += &format!(
-            "color = {0}(particle.{1} / particle.{2});\n",
+        let op = self.blend.to_assign_operator();
+        let col = format!(
+            "{0}(particle.{1} / particle.{2});\n",
             func_name,
             Attribute::AGE.name(),
             Attribute::LIFETIME.name()
         );
+        let s = if self.mask == ColorBlendMask::RGBA {
+            format!("color {op} {col};\n")
+        } else {
+            let mask = self.mask.to_components();
+            format!("color.{mask} {op} ({col}).{mask};\n")
+        };
 
+        context.vertex_code += &s;
         Ok(())
     }
 

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -943,6 +943,8 @@ mod tests {
         gradient.add_key(0.8, blue);
         let modifier = ColorOverLifetimeModifier {
             gradient: gradient.clone(),
+            blend: ColorBlendMode::Overwrite,
+            mask: ColorBlendMask::RGBA,
         };
 
         let mut module = Module::default();

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -125,6 +125,18 @@ impl<T: Copy + FromReflect> From<T> for CpuValue<T> {
     }
 }
 
+impl<T: Copy + FromReflect> From<[T; 2]> for CpuValue<T> {
+    fn from(t: [T; 2]) -> Self {
+        Self::Uniform((t[0], t[1]))
+    }
+}
+
+impl<T: Copy + FromReflect> From<(T, T)> for CpuValue<T> {
+    fn from(t: (T, T)) -> Self {
+        Self::Uniform(t)
+    }
+}
+
 impl<T: Copy + FromReflect + FloatHash> Eq for CpuValue<T> {}
 
 impl<T: Copy + FromReflect + FloatHash> Hash for CpuValue<T> {


### PR DESCRIPTION
Change a few things to allow the `firework.rs` example to get a random color per firework explosion:

- Add `ColorBlendMode` and `ColorBlendMask` to enable color blending, and allow overlaying _e.g._ a `SetAttributeModifier(Attribute::COLOR)` with a `ColorOverLifetimeModifier`, without the former overwriting the latter. The blend mode determines the blend operation, while the blend mask determines which components are affected in the 4D vector.
- Add a new expression to combine a 3D vector and a scalar into a 4D vector. This allows recombining an RGB color with an Alpha value.
- Upload a different PRNG seed each frame because the GPU doesn't retain the PRNG state, so using the same seed each frame breaks randomness.

The `firework.rs` example has been updated to make use of all of this.