### PR TITLE
Fix sort binding offset not aligned to device limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-msrv-stable-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.82
+          toolchain: 1.85
           components: rustfmt, clippy
       - name: Check
         run: cargo check --lib --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bevy_hanabi"
 version = "0.15.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
+rust-version = "1.85.0"
 description = "Hanabi GPU particle system for the Bevy game engine"
 repository = "https://github.com/djeedai/bevy_hanabi"
 homepage = "https://github.com/djeedai/bevy_hanabi"

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,9 @@ all-features = true
 version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = []
+ignore = [
+   "paste@1.0.15",
+]
 
 [licenses]
 allow = [

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,7 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-   "paste@1.0.15",
+   { id = "RUSTSEC-2024-0436", reason = "paste@1.0.15 - will soon upgrade with Bevy 0.16" },
 ]
 
 [licenses]

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -28,6 +28,33 @@ use utils::*;
 const K: f32 = 0.64;
 const L: f32 = 0.384;
 
+enum ShapeConfig {
+    Spirograph { k: f32, l: f32 },
+    Lissajou { a: f32, b: f32 },
+}
+
+#[derive(Component)]
+struct Shape {
+    pub config: ShapeConfig,
+    pub time_scale: f32,
+    pub shape_scale: Vec3,
+}
+
+impl Shape {
+    pub fn tick(&mut self, time: f32) -> Vec3 {
+        let time = time * self.time_scale;
+        let pos = match self.config {
+            ShapeConfig::Spirograph { k, l } => vec3(
+                (1.0 - k) * (time.cos()) + (l * k) * (((1.0 - k) / k) * time).cos(),
+                (1.0 - k) * (time.sin()) - (l * k) * (((1.0 - k) / k) * time).sin(),
+                0.0,
+            ),
+            ShapeConfig::Lissajou { a, b } => vec3((a * time).cos(), (b * time).sin(), 0.0),
+        };
+        pos * self.shape_scale
+    }
+}
+
 const TIME_SCALE: f32 = 6.5;
 const SHAPE_SCALE: f32 = 25.0;
 // Note: because Hanabi doesn't currently support position interpolation between
@@ -123,17 +150,34 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
 
     let effect = effects.add(effect);
 
-    commands.spawn((ParticleEffect::new(effect), Name::new("ribbon")));
+    commands.spawn((
+        ParticleEffect::new(effect.clone()),
+        Name::new("spirograph"),
+        Shape {
+            config: ShapeConfig::Spirograph { k: K, l: L },
+            time_scale: TIME_SCALE,
+            shape_scale: Vec3::ONE * SHAPE_SCALE,
+        },
+    ));
+
+    commands.spawn((
+        ParticleEffect::new(effect),
+        Name::new("lissajou"),
+        Shape {
+            config: ShapeConfig::Lissajou { a: 3., b: 4. },
+            time_scale: 2.,
+            shape_scale: Vec3::ONE * 18.,
+        },
+    ));
 }
 
-fn move_head(mut query: Query<&mut Transform, With<ParticleEffect>>, timer: Res<Time>) {
-    for mut transform in query.iter_mut() {
-        let time = timer.elapsed_secs() * TIME_SCALE;
-        let pos = vec3(
-            (1.0 - K) * (time.clone().cos()) + (L * K) * (((1.0 - K) / K) * time.clone()).cos(),
-            (1.0 - K) * (time.clone().sin()) - (L * K) * (((1.0 - K) / K) * time.clone()).sin(),
-            0.0,
-        ) * SHAPE_SCALE;
+fn move_head(
+    mut query: Query<(&mut Shape, &mut Transform), With<ParticleEffect>>,
+    timer: Res<Time>,
+) {
+    for (mut shape, mut transform) in query.iter_mut() {
+        let time = timer.elapsed_secs();
+        let pos = shape.tick(time);
         transform.translation = pos;
     }
 }

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -111,15 +111,11 @@ impl SortBindGroups {
                 | BufferUsages::INDIRECT,
             mapped_at_creation: false,
         });
-        let mut indirect_buffer = GpuBuffer::new_allocated(
+        let indirect_buffer = GpuBuffer::new_allocated(
             indirect_buffer,
             indirect_buffer_size as u32,
             Some("hanabi:buffer:sort:indirect".to_string()),
         );
-
-        // Always allocate entry #0 for the sort pass itself. We don't store the index,
-        // it's always zero.
-        indirect_buffer.allocate();
 
         let sort_bind_group_layout = render_device.create_bind_group_layout(
             "hanabi:bind_group_layout:sort",
@@ -244,13 +240,6 @@ impl SortBindGroups {
     #[inline]
     pub fn get_indirect_dispatch_byte_offset(&self, index: u32) -> u32 {
         self.indirect_buffer.item_size() as u32 * index
-    }
-
-    #[inline]
-    pub fn get_sort_indirect_dispatch_byte_offset(&self) -> u32 {
-        // See new(); we always allocate entry #0 in the indirect buffer for the sort
-        // pass itself
-        0
     }
 
     #[inline]

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -25,7 +25,7 @@ struct IndirectIndexBuffer {
 // Technically read-only, but the type contains atomic<> fields and wasm is strict about it
 @group(0) @binding(2) var<storage, read_write> effect_metadata : EffectMetadata;
 
-/// Fill the sorting key-value pair buffer with data to prepare for actual sorting.
+/// Copy the sorted particle indices back into the effect index buffer.
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let row_index = global_invocation_id.x;


### PR DESCRIPTION
Some sort compute pass were using a dynamic binding offset not a multiple of the device limit `min_storage_buffer_offset_alignment`. Instead of fixing the alignment, since the compute shader already adds a custom `u32` offset, use that offset to index precisely the dispatch indirect struct we want (12 bytes), and always bind the entire buffer with a zero binding offset.

Fixes #438