### PR TITLE
Fix bug in indexing the spawner params

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -407,7 +407,7 @@ pub struct GpuEffectMetadata {
     /// passes always write into the ping buffer and read from the pong buffer.
     /// The buffers are swapped (ping = 1 - ping) during the indirect dispatch.
     pub ping: u32,
-    /// Index of the [`GpuSpawnerParams] struct.
+    /// Unused. TODO remove.
     pub spawner_index: u32,
     /// Index of the [`GpuDispatchIndirect`] struct inside the global
     /// [`EffectsMeta::dispatch_indirect_buffer`].
@@ -4054,7 +4054,7 @@ pub(crate) fn prepare_effects(
                 dead_count: capacity,
                 max_spawn: capacity,
                 ping: 0,
-                spawner_index,
+                spawner_index: 0xDEADBEEF, // unused
                 indirect_dispatch_index: dispatch_buffer_indices
                     .update_dispatch_indirect_buffer_table_id
                     .0,

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -109,7 +109,7 @@ const EM_OFFSET_MAX_UPDATE: u32 = 6u;
 const EM_OFFSET_DEAD_COUNT: u32 = 7u;
 const EM_OFFSET_MAX_SPAWN: u32 = 8u;
 const EM_OFFSET_PING: u32 = 9u;
-const EM_OFFSET_SPAWNER_INDEX: u32 = 10u;
+//const EM_OFFSET_SPAWNER_INDEX: u32 = 10u;
 const EM_OFFSET_INDIRECT_DISPATCH_INDEX: u32 = 11u;
 
 /// Draw indirect parameters for GPU-driven rendering, and additional effect data.
@@ -146,7 +146,7 @@ struct EffectMetadata {
     /// always write into the ping buffer and read from the pong buffer. The buffers
     /// are swapped (ping = 1 - ping) during the indirect dispatch.
     ping: u32,
-    /// Index of the [`GpuSpawnerParams] struct.
+    /// Unused. TODO remove.
     spawner_index: u32,
     /// Index of the [`GpuDispatchIndirect`] struct inside the global
     /// [`EffectsMeta::dispatch_indirect_buffer`].

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -2,7 +2,7 @@
     ChildInfo, ChildInfoBuffer, SimParams, Spawner,
     EM_OFFSET_ALIVE_COUNT, EM_OFFSET_MAX_UPDATE, EM_OFFSET_DEAD_COUNT,
     EM_OFFSET_MAX_SPAWN, EM_OFFSET_INSTANCE_COUNT, EM_OFFSET_INDIRECT_DISPATCH_INDEX,
-    EM_OFFSET_PING, DISPATCH_INDIRECT_STRIDE, EFFECT_METADATA_STRIDE, EM_OFFSET_SPAWNER_INDEX
+    EM_OFFSET_PING, DISPATCH_INDIRECT_STRIDE, EFFECT_METADATA_STRIDE
 }
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
@@ -73,6 +73,5 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Copy the new pong into the spawner buffer, which will be used during rendering
     // to determine where to read particle indices.
-    let spawner_index = effect_metadata_buffer[em_base + EM_OFFSET_SPAWNER_INDEX];
-    spawner_buffer[spawner_index].render_pong = pong;
+    spawner_buffer[effect_index].render_pong = pong;
 }


### PR DESCRIPTION
The effect metadata was maintaining a stale index to the spawner, which was incorrectly used in the indirect pass instead of using the same effect index as when read a few lines above. The effect metadata can't possibly maintain an index to the spawner because the former is lazily uploaded (and in fact this resets the effect, so should be almost never) while the latter is re-uploaded each frame and is always tightly packed (we reallocated the spawners each frame since anyway they change each frame).

Fixes #412