### PR TITLE
Add an `OnSpawn` condition for particle emission.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1146,7 +1146,7 @@ fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
         if has_age {
             if has_lifetime {
                 age_code += &format!(
-                    "\n    let was_alive = particle.{0} < particle.{1};",
+                    "\n    let was_alive = particle.{0} < particle.{1};\n    let is_new = particle.{0} == 0.0;",
                     Attribute::AGE.name(),
                     Attribute::LIFETIME.name()
                 );
@@ -1168,7 +1168,9 @@ fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
             // Since we're using a dead index buffer, all particles that make it to the
             // update compute shader are guaranteed to be alive (we never
             // simulate dead particles).
-            age_code = "\n    let was_alive = true;\n    var is_alive = true;".to_string();
+            age_code =
+                "\n    let was_alive = true;\n    var is_alive = true;\n    let is_new = false;"
+                    .to_string();
         }
 
         // Configure reaping code

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -616,6 +616,8 @@ pub enum EventEmitCondition {
     Always,
     /// Only emit events if the particle died during this frame update.
     OnDie,
+    /// Only emit events if the particle spawned during this frame update.
+    OnSpawn,
 }
 
 /// Emit GPU spawn events to spawn new particle(s) in a child effect.
@@ -661,6 +663,10 @@ impl EmitSpawnEventModifier {
             ),
             EventEmitCondition::OnDie => format!(
                 "if (was_alive && !is_alive) {{ append_spawn_events_{channel_index}(particle_index, {}); }}",
+                self.count.to_wgsl_string()
+            ),
+            EventEmitCondition::OnSpawn => format!(
+                "if (is_alive && is_new) {{ append_spawn_events_{channel_index}(particle_index, {}); }}",
                 self.count.to_wgsl_string()
             ),
         };


### PR DESCRIPTION
[Unity has this.]

An example use case is spawning a bunch of particles as clumps around a circle. You make a hidden particle system A that uses the `SetPositionCircleModifier` to spawn invisible particles around a circle, then add an `EmitSpawnEventModifier` with an `OnSpawn` condition that triggers another particle system B to spawn, say, 5 particles for each particle in system A. Particle system B uses a `SetPositionSphereModifier` and inherits the position from particle system A. That way you get some nice clumps of particles all spaced randomly around a circle.

[Unity has this.]: https://docs.unity3d.com/6000.0/Documentation/ScriptReference/ParticleSystemSubEmitterType.Birth.html