### PR TITLE
Fix visibility computation, allowing particles to appear in Bevy 0.16.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,11 @@ all-features = true
 
 [dev-dependencies]
 # For world inspector; required if "examples_world_inspector" is used.
-bevy-inspector-egui = "0.28"
-bevy_egui = { version = "0.31", default-features = false, features = [
+bevy-inspector-egui = "0.29.1"
+bevy_egui = { version = "0.32", default-features = false, features = [
     "manage_clipboard", "open_url"
 ] }
-egui = "0.29"
+egui = "0.30"
 
 bevy_sprite = "0.16.0-rc.3"
 bevy_text = "0.16.0-rc.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,9 @@ use std::fmt::Write as _;
 use bevy::{
     platform_support::collections::{HashMap, HashSet},
     prelude::*,
-    render::{sync_world::SyncToRenderWorld, view::VisibilityClass},
+    render::{
+        extract_component::ExtractComponent, sync_world::SyncToRenderWorld, view::VisibilityClass,
+    },
 };
 use rand::{Rng, SeedableRng as _};
 use serde::{Deserialize, Serialize};
@@ -575,7 +577,7 @@ impl From<&PropertyInstance> for PropertyValue {
 }
 
 /// The [`VisibilityClass`] used for all particle effects.
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Component, ExtractComponent)]
 pub struct EffectVisibilityClass;
 
 /// Particle-based visual effect instance.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,6 +6,7 @@ use bevy::{
     asset::weak_handle,
     prelude::*,
     render::{
+        extract_component::ExtractComponentPlugin,
         mesh::allocator::allocate_and_free_meshes,
         render_asset::prepare_assets,
         render_graph::RenderGraph,
@@ -39,7 +40,8 @@ use crate::{
     spawn::{self, Random},
     tick_spawners,
     time::effect_simulation_time_system,
-    update_properties_from_asset, EffectSimulation, ParticleEffect, SpawnerSettings, ToWgslString,
+    update_properties_from_asset, EffectSimulation, EffectVisibilityClass, ParticleEffect,
+    SpawnerSettings, ToWgslString,
 };
 
 /// Labels for the Hanabi systems.
@@ -198,6 +200,7 @@ impl Plugin for HanabiPlugin {
         // Register asset
         app.init_asset::<EffectAsset>()
             .insert_resource(Random(spawn::new_rng()))
+            .add_plugins(ExtractComponentPlugin::<EffectVisibilityClass>::default())
             .init_resource::<DefaultMesh>()
             .init_resource::<ShaderCache>()
             .init_resource::<DebugSettings>()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -64,7 +64,8 @@ use crate::{
         effect_cache::DispatchBufferIndices,
     },
     AlphaMode, Attribute, CompiledParticleEffect, EffectProperties, EffectShader, EffectSimulation,
-    EffectSpawner, ParticleLayout, PropertyLayout, SimulationCondition, TextureLayout,
+    EffectSpawner, EffectVisibilityClass, ParticleLayout, PropertyLayout, SimulationCondition,
+    TextureLayout,
 };
 
 mod aligned_buffer_vec;
@@ -4854,7 +4855,7 @@ fn emit_sorted_draw<T, F>(
             view_entities.clear();
             view_entities.extend(
                 visible_entities
-                    .iter::<CompiledParticleEffect>()
+                    .iter::<EffectVisibilityClass>()
                     .map(|e| e.1.index() as usize),
             );
         }
@@ -5038,7 +5039,7 @@ fn emit_binned_draw<T, F, G>(
             view_entities.clear();
             view_entities.extend(
                 visible_entities
-                    .iter::<CompiledParticleEffect>()
+                    .iter::<EffectVisibilityClass>()
                     .map(|e| e.1.index() as usize),
             );
         }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3497,7 +3497,6 @@ pub struct PrepareEffectsReadOnlyParams<'w, 's> {
     sim_params: Res<'w, SimParams>,
     render_device: Res<'w, RenderDevice>,
     render_queue: Res<'w, RenderQueue>,
-    #[system_param(ignore)]
     marker: PhantomData<&'s usize>,
 }
 
@@ -3511,7 +3510,6 @@ pub struct PipelineSystemParams<'w, 's> {
     specialized_update_pipelines: ResMut<'w, SpecializedComputePipelines<ParticlesUpdatePipeline>>,
     specialized_indirect_pipelines:
         ResMut<'w, SpecializedComputePipelines<DispatchIndirectPipeline>>,
-    #[system_param(ignore)]
     marker: PhantomData<&'s usize>,
 }
 
@@ -4818,7 +4816,6 @@ pub struct QueueEffectsReadOnlyParams<'w, 's> {
     draw_functions_alpha_mask: Res<'w, DrawFunctions<AlphaMask3d>>,
     #[cfg(feature = "3d")]
     draw_functions_opaque: Res<'w, DrawFunctions<Opaque3d>>,
-    #[system_param(ignore)]
     marker: PhantomData<&'s usize>,
 }
 


### PR DESCRIPTION
There were two problems here:

1. The `ExtractComponentPlugin` for `EffectVisibilityClass` wasn't being
   added, so the render world never got a chance to see
   `EffectVisibilityClass`.

2. The Hanabi code was trying to query `RenderVisibleEntities` for
   `CompiledParticleEffect` components, but those APIs expect to take a
   visibility class instead.

I solved (1) by adding the plugin in the Hanabi plugin initialization,
and I solved (2) by switching `CompiledParticleEffect` calls to
`EffectVisibilityClass`. Making those changes causes particles to render
in Bevy 0.16.