### PR TITLE
Mark `CachedParentInfo` as changed if any of the `CachedChildInfo` of that entity's children were changed.

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -9,6 +9,7 @@ use std::{
 
 #[cfg(feature = "2d")]
 use bevy::core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT};
+use bevy::ecs::entity::EntityHashSet;
 #[cfg(feature = "2d")]
 use bevy::math::FloatOrd;
 #[cfg(feature = "3d")]
@@ -3238,6 +3239,11 @@ pub(crate) fn resolve_parents(
         .map(|(render_entity, main_entity, _)| (main_entity, render_entity))
         .collect::<HashMap<_, _>>();
 
+    // Record all parents with children that changed so that we can mark those
+    // parents' `CachedParentInfo` as changed. See the comment in the
+    // `q_parent_effects` loop for more information.
+    let mut parents_with_dirty_children = EntityHashSet::default();
+
     // Group child effects by parent, building a list of children for each parent,
     // solely based on the declaration each child makes of its parent. This doesn't
     // mean yet that the parent exists.
@@ -3343,6 +3349,10 @@ pub(crate) fn resolve_parents(
         };
         commands.entity(child_entity).insert(cached_child_info);
         trace!("Spawned CachedChildInfo on child entity {:?}", child_entity);
+
+        // Make a note of the parent entity so that we remember to mark its
+        // `CachedParentInfo` as changed below.
+        parents_with_dirty_children.insert(parent_entity);
     }
 
     // Once all parents are resolved, diff all children of already-cached parents,
@@ -3355,6 +3365,16 @@ pub(crate) fn resolve_parents(
             commands.entity(parent_entity).remove::<CachedParentInfo>();
             continue;
         };
+
+        // If we updated `CachedChildInfo` for any of this entity's children,
+        // then even if the check below passes, we must still set the change
+        // flag on this entity's `CachedParentInfo`. That's because the
+        // `fixup_parents` system looks at the change flag for the parent in
+        // order to determine which `CachedChildInfo` it needs to update, and
+        // that system must process all newly-added `CachedChildInfo`s.
+        if parents_with_dirty_children.contains(&parent_entity) {
+            cached_parent_info.set_changed();
+        }
 
         // Check if any child changed compared to the existing CachedChildren component
         if !is_child_list_changed(


### PR DESCRIPTION
Whenever a `CachedChildInfo` is created, then it must be "fixed up" via the `fixup_parents` system. That system uses a
`Changed<CachedParentInfo>` query filter to determine which parents it needs to process the children of. Usually, `resolve_parents` will regenerate the `CachedParentInfo` of every parent with a changed child, because the `is_child_list_changed` check will notice that the child entity IDs differ, and thus `fixup_parents` will pick up that newly-created `CachedParentInfo`. However, `resolve_parents` will skip regenerating the `CachedParentInfo` if the entity IDs of the children didn't change (as determined by `is_child_list_changed`). This means that, if the children changed but for whatever reason their *entity IDs* didn't, the change flag will never be set on the parent's `CachedParentInfo`. This means that `fixup_parents` will never process the `CachedChildInfo`, causing a crash later as the `global_child_index` will be wrong.

This PR fixes the problem by modifying `resolve_parents` so that, whenever a new `CachedChildInfo` is built, the parent of that child is added to a set. Then `resolve_parents` forcibly marks the `CachedParentInfo` of any parent in that set as changed, even if `is_child_list_changed` determined that the *contents* of the `CachedParentInfo` didn't need to change. This ensures that `fixup_parents` examines those parents and updates the `CachedChildInfo` of their children, preventing the crash.

For me, I ran into this crash when spawning two instances of my particle system containing 11 different effects one after another, and then despawning the earlier instance while the later one was still running. This patch fixes the bug for me.