### PR TITLE
Remove potentially stale fields from `CachedEffect` & `EffectBatch`

### DIFF
--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -2,10 +2,7 @@ use std::{collections::VecDeque, fmt::Debug, num::NonZeroU32, ops::Range};
 
 use bevy::{
     prelude::*,
-    render::{
-        render_resource::{BufferId, CachedComputePipelineId},
-        sync_world::MainEntity,
-    },
+    render::{render_resource::CachedComputePipelineId, sync_world::MainEntity},
     utils::HashMap,
 };
 
@@ -90,12 +87,6 @@ pub(crate) struct EffectBatch {
     pub layout_flags: LayoutFlags,
     /// Asset ID of the effect mesh to draw.
     pub mesh: AssetId<Mesh>,
-    /// GPU buffer storing the [`mesh`] of the effect.
-    ///
-    /// [`mesh`]: Self::mesh
-    pub mesh_buffer_id: BufferId,
-    /// Slice inside the GPU buffer for the effect mesh.
-    pub mesh_slice: Range<u32>,
     /// Texture layout.
     pub texture_layout: TextureLayout,
     /// Textures.
@@ -372,8 +363,6 @@ impl EffectBatch {
             dispatch_buffer_indices,
             layout_flags: input.layout_flags,
             mesh: cached_mesh.mesh,
-            mesh_buffer_id: cached_mesh.buffer.id(),
-            mesh_slice: cached_mesh.range.clone(),
             texture_layout: input.texture_layout.clone(),
             textures: input.textures.clone(),
             alpha_mode: input.alpha_mode,
@@ -462,8 +451,6 @@ mod tests {
             particle_layout: ParticleLayout::empty(),
             layout_flags: LayoutFlags::NONE,
             mesh: default(),
-            mesh_buffer_id: NonZeroU32::new(1).unwrap().into(),
-            mesh_slice: 0..0,
             texture_layout: default(),
             textures: default(),
             alpha_mode: default(),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4005,9 +4005,7 @@ pub(crate) fn prepare_effects(
         // some invalidation mechanism and ECS change detection.
         if cached_mesh.is_changed() {
             let mesh_id = cached_mesh.mesh;
-
             let current_vertex_slice_opt = mesh_allocator.mesh_vertex_slice(&mesh_id);
-            let current_index_slice_opt = mesh_allocator.mesh_index_slice(&mesh_id);
 
             if let Some(vertex_slice) = current_vertex_slice_opt {
                 let capacity = cached_effect.slice.len();
@@ -4068,17 +4066,14 @@ pub(crate) fn prepare_effects(
                     sort_key2_offset,
                     ..default()
                 };
+
+                let current_index_slice_opt = mesh_allocator.mesh_index_slice(&mesh_id);
                 if let Some(index_slice) = current_index_slice_opt {
-                    // --- Indexed Mesh ---
-                    // Use fresh index range for count and start offset
                     gpu_effect_metadata.vertex_or_index_count = index_slice.range.len() as u32;
                     gpu_effect_metadata.first_index_or_vertex_offset = index_slice.range.start;
-                    // Use fresh vertex range for base vertex offset
                     gpu_effect_metadata.vertex_offset_or_base_instance =
                         vertex_slice.range.start as i32;
                 } else {
-                    // --- Non-Indexed Mesh ---
-                    // Use fresh vertex range for count and start offset
                     gpu_effect_metadata.vertex_or_index_count = vertex_slice.range.len() as u32;
                     gpu_effect_metadata.first_index_or_vertex_offset = vertex_slice.range.start;
                     gpu_effect_metadata.vertex_offset_or_base_instance = 0;
@@ -4089,7 +4084,6 @@ pub(crate) fn prepare_effects(
                     dispatch_buffer_indices.effect_metadata_buffer_table_id, // Make sure this is accessible
                     gpu_effect_metadata,
                 );
-                // Consider if the WARN message is still needed here or should be moved/removed
 
                 assert!(dispatch_buffer_indices
                     .effect_metadata_buffer_table_id

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4067,8 +4067,7 @@ pub(crate) fn prepare_effects(
                     ..default()
                 };
 
-                let current_index_slice_opt = mesh_allocator.mesh_index_slice(&mesh_id);
-                if let Some(index_slice) = current_index_slice_opt {
+                if let Some(index_slice) = mesh_allocator.mesh_index_slice(&mesh_id) {
                     gpu_effect_metadata.vertex_or_index_count = index_slice.range.len() as u32;
                     gpu_effect_metadata.first_index_or_vertex_offset = index_slice.range.start;
                     gpu_effect_metadata.vertex_offset_or_base_instance =
@@ -4098,7 +4097,6 @@ pub(crate) fn prepare_effects(
                     dispatch_buffer_indices.effect_metadata_buffer_table_id.0, main_entity
                 );
             } else {
-                // Handle error: vertex slice not found for this mesh ID now
                 error!(
                     "Vertex slice not found for mesh {:?} in prepare_effects",
                     mesh_id

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4101,6 +4101,7 @@ pub(crate) fn prepare_effects(
 
         prepared_effect_count += 1;
     }
+
     trace!("Prepared {prepared_effect_count}/{extracted_effect_count} extracted effect(s)");
 
     // Once all EffectMetadata values are written, schedule a GPU upload

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5996,14 +5996,10 @@ fn draw<'w>(
     let Some(vertex_buffer_slice) = mesh_allocator.mesh_vertex_slice(&effect_batch.mesh) else {
         return;
     };
-    /*
 
     // Vertex buffer containing the particle model to draw. Generally a quad.
     // FIXME - need to upload "vertex_buffer_slice.range.start as i32" into
     // "base_vertex" in the indirect struct...
-    assert_eq!(effect_batch.mesh_buffer_id, vertex_buffer_slice.buffer.id());
-    assert_eq!(effect_batch.mesh_slice, vertex_buffer_slice.range);
-    */
     pass.set_vertex_buffer(0, vertex_buffer_slice.buffer.slice(..));
 
     // View properties (camera matrix, etc.)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4078,15 +4078,10 @@ pub(crate) fn prepare_effects(
                     gpu_effect_metadata.vertex_offset_or_base_instance = 0;
                 }
 
-                // Update the metadata buffer
-                effects_meta.effect_metadata_buffer.update(
-                    dispatch_buffer_indices.effect_metadata_buffer_table_id, // Make sure this is accessible
-                    gpu_effect_metadata,
-                );
-
                 assert!(dispatch_buffer_indices
                     .effect_metadata_buffer_table_id
                     .is_valid());
+
                 effects_meta.effect_metadata_buffer.update(
                     dispatch_buffer_indices.effect_metadata_buffer_table_id,
                     gpu_effect_metadata,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4025,28 +4025,6 @@ pub(crate) fn prepare_effects(
             ..default()
         };
 
-        if let Some(indexed) = &cached_mesh.indexed {
-            gpu_effect_metadata.vertex_or_index_count = indexed.range.len() as u32;
-            gpu_effect_metadata.first_index_or_vertex_offset = indexed.range.start;
-            gpu_effect_metadata.vertex_offset_or_base_instance = cached_mesh.range.start as i32;
-        } else {
-            gpu_effect_metadata.vertex_or_index_count = cached_mesh.range.len() as u32;
-            gpu_effect_metadata.first_index_or_vertex_offset = cached_mesh.range.start;
-            gpu_effect_metadata.vertex_offset_or_base_instance = 0;
-        };
-        assert!(dispatch_buffer_indices
-            .effect_metadata_buffer_table_id
-            .is_valid());
-        effects_meta.effect_metadata_buffer.update(
-            dispatch_buffer_indices.effect_metadata_buffer_table_id,
-            gpu_effect_metadata,
-        );
-
-        warn!(
-            "Updated metadata entry {} for effect {:?}, this will reset it.",
-            dispatch_buffer_indices.effect_metadata_buffer_table_id.0, main_entity
-        );
-
         if let Some(index_slice) = mesh_allocator.mesh_index_slice(&mesh_id) {
             gpu_effect_metadata.vertex_or_index_count = index_slice.range.len() as u32;
             gpu_effect_metadata.first_index_or_vertex_offset = index_slice.range.start;


### PR DESCRIPTION
Resolves https://github.com/djeedai/bevy_hanabi/issues/450

### Notes/Improvements.

- `EffectBatch` could still contain `pub mesh_slice: Range<u32>`, which would result in one query per batch to `MeshAllocator` but the `indexed` information would have to be passed somewhere else, either pass `mesh_slice` and `indexed` to `from_input` on `impl EffectBatch` or pass only `mesh_slice` and save `indexed` as `bool` on the `CachedMesh`. I assume this probably isn't worth it atm since `MeshAllocator` access is immutable but I don't know for certain without testing/benchmarking.