### PR TITLE
Switch `GpuDispatchIndirect` buffers to `GpuBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `EmitSpawnEventModifier::count` is now an expression,
+  which allows dynamically controlling the number of particles emitted.
+
+### Fixed
+
+- Fixed several bugs related to buffer reallocation and bind group invalidation.
+  Those bugs generally occur when new effects are spawned, triggering GPU buffer reallocations.
+  Using stale bind groups referencing the old buffer produces issues ranging from rendering artifacts,
+  to complete loss of all rendering, or even panics in `wgpu` (where validation catches the misuse).
+
 ## [0.15.0] 2025-04-01
 
 ### Added

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -124,6 +124,10 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
         }
     }
 
+    fn safe_label(&self) -> &str {
+        self.label.as_ref().map(|s| &s[..]).unwrap_or("")
+    }
+
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
@@ -238,21 +242,33 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
         if capacity > self.capacity {
             let size = self.aligned_size * capacity;
             trace!(
-                "reserve: increase capacity from {} to {} elements, new size {} bytes",
+                "reserve['{}']: increase capacity from {} to {} elements, new size {} bytes",
+                self.safe_label(),
                 self.capacity,
                 capacity,
                 size
             );
             self.capacity = capacity;
-            if let Some(buffer) = self.buffer.take() {
-                buffer.destroy();
+            if let Some(old_buffer) = self.buffer.take() {
+                trace!(
+                    "reserve['{}']: destroying old buffer #{:?}",
+                    self.safe_label(),
+                    old_buffer.id()
+                );
+                old_buffer.destroy();
             }
-            self.buffer = Some(device.create_buffer(&BufferDescriptor {
+            let new_buffer = device.create_buffer(&BufferDescriptor {
                 label: self.label.as_ref().map(|s| &s[..]),
                 size: size as BufferAddress,
                 usage: BufferUsages::COPY_DST | self.buffer_usage,
                 mapped_at_creation: false,
-            }));
+            });
+            trace!(
+                "reserve['{}']: created new buffer #{:?}",
+                self.safe_label(),
+                new_buffer.id(),
+            );
+            self.buffer = Some(new_buffer);
             // FIXME - this discards the old content if any!!!
             true
         } else {
@@ -270,7 +286,8 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
             return false;
         }
         trace!(
-            "write_buffer: values.len={} item_size={} aligned_size={}",
+            "write_buffer['{}']: values.len={} item_size={} aligned_size={}",
+            self.safe_label(),
             self.values.len(),
             self.item_size,
             self.aligned_size
@@ -278,7 +295,12 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
         let buffer_changed = self.reserve(self.values.len(), device);
         if let Some(buffer) = &self.buffer {
             let aligned_size = self.aligned_size * self.values.len();
-            trace!("aligned_buffer: size={}", aligned_size);
+            trace!(
+                "aligned_buffer['{}']: size={} buffer={:?}",
+                self.safe_label(),
+                aligned_size,
+                buffer.id(),
+            );
             let mut aligned_buffer: Vec<u8> = vec![0; aligned_size];
             for i in 0..self.values.len() {
                 let src: &[u8] = cast_slice(std::slice::from_ref(&self.values[i]));

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -611,11 +611,11 @@ pub(crate) struct CachedEffect {
 /// that of the metadata buffer.
 #[derive(Debug, Default, Clone, Copy, Component)]
 pub(crate) struct DispatchBufferIndices {
-    /// The index of the [`GpuDispatchIndirect`] in
+    /// The index of the [`GpuDispatchIndirect`] row in the GPU buffer
     /// [`EffectsMeta::update_dispatch_indirect_buffer`].
     ///
     /// [`EffectsMeta::update_dispatch_indirect_buffer`]: super::EffectsMeta::update_dispatch_indirect_buffer
-    pub(crate) update_dispatch_indirect_buffer_table_id: BufferTableId,
+    pub(crate) update_dispatch_indirect_buffer_row_index: u32,
 
     /// The index of the [`GpuEffectMetadata`] in
     /// [`EffectsMeta::effect_metadata_buffer`].

--- a/src/render/event.rs
+++ b/src/render/event.rs
@@ -1,12 +1,10 @@
 use std::{num::NonZeroU64, ops::Range};
 
 use bevy::{
-    log::{trace, warn},
+    log::trace,
     prelude::{Component, Entity, ResMut, Resource},
     render::{
-        render_resource::{
-            BindGroup, BindGroupLayout, Buffer, BufferVec, ShaderSize as _, ShaderType,
-        },
+        render_resource::{BindGroup, BindGroupLayout, Buffer, ShaderSize as _, ShaderType},
         renderer::{RenderDevice, RenderQueue},
         sync_world::MainEntity,
     },
@@ -19,12 +17,12 @@ use wgpu::util::BufferInitDescriptor;
 use wgpu::BufferDescriptor;
 use wgpu::{
     BindGroupEntry, BindGroupLayoutEntry, BindingResource, BindingType, BufferBinding,
-    BufferBindingType, BufferUsages, ShaderStages,
+    BufferBindingType, BufferUsages, CommandEncoder, ShaderStages,
 };
 
 use super::{
-    aligned_buffer_vec::HybridAlignedBufferVec, effect_cache::BufferState, BufferBindingSource,
-    EffectBindGroups, GpuDispatchIndirect,
+    aligned_buffer_vec::HybridAlignedBufferVec, effect_cache::BufferState, gpu_buffer::GpuBuffer,
+    BufferBindingSource, EffectBindGroups, GpuDispatchIndirect,
 };
 use crate::ParticleLayout;
 
@@ -152,28 +150,6 @@ pub(crate) struct CachedParentInfo {
     pub byte_range: Range<u32>,
 }
 
-impl CachedParentInfo {
-    /// Get a binding of the given underlying child info buffer spanning over
-    /// the range of this child effect entry.
-    #[allow(dead_code)]
-    pub fn binding<'a>(&self, buffer: &'a Buffer) -> BufferBinding<'a> {
-        BufferBinding {
-            buffer,
-            offset: self.byte_range.start as u64,
-            size: Some(
-                NonZeroU64::new((self.byte_range.end - self.byte_range.start) as u64).unwrap(),
-            ),
-        }
-    }
-
-    /// Base offset of the first child into the global
-    /// [`EventCache::child_infos_buffer`], in number of element.
-    #[allow(dead_code)]
-    pub fn first_child_index(&self) -> u32 {
-        self.byte_range.start / size_of::<GpuChildInfo>() as u32
-    }
-}
-
 /// Reference to the parent of an effect instance.
 ///
 /// This is a weak reference to the parent while pending resolving. This
@@ -210,13 +186,9 @@ pub(crate) struct CachedChildInfo {
     /// Global index of this child effect into the shared global
     /// [`EventCache::child_infos_buffer`] array. This is a unique index across
     /// all effects.
-    ///
-    /// [`EventCache::child_infos_buffer`]: super::EventCache::child_infos_buffer
     pub global_child_index: u32,
     /// Index of the [`GpuDispatchIndirect`] entry into the
-    /// [`init_indirect_dispatch_buffer`] array.
-    ///
-    /// [`init_indirect_dispatch_buffer`]: super::EventCache::init_indirect_dispatch_buffer
+    /// [`EventCache::init_indirect_dispatch_buffer`] array.
     pub init_indirect_dispatch_index: u32,
 }
 
@@ -289,9 +261,10 @@ pub struct EventCache {
     /// structs for all the indirect init passes. Any effect allocating storage
     /// for GPU events also get an entry into this buffer, to allow consuming
     /// the events from an init pass indirectly dispatched (GPU-driven).
-    // Note: we abuse BufferVec but never copy anything from CPU
-    // FIXME - merge with the update pass one, we don't need 2 buffers storing the same type
-    init_indirect_dispatch_buffer: BufferVec<GpuDispatchIndirect>,
+    // FIXME - merge with the update pass one, we don't need 2 buffers storing the same type; on
+    // the other hand if we sync the allocations with GpuChildInfo we can guarantee a perfect
+    // batching for the init fill dispatch pass (single dispatch for all instances at once).
+    init_indirect_dispatch_buffer: GpuBuffer<GpuDispatchIndirect>,
     /// Bind group layout for the indirect dispatch pass, which clears the GPU
     /// event counts ([`GpuChildInfo::event_count`]).
     indirect_child_info_buffer_bind_group_layout: BindGroupLayout,
@@ -303,9 +276,10 @@ pub struct EventCache {
 impl EventCache {
     /// Create a new event cache.
     pub fn new(device: RenderDevice) -> Self {
-        let mut init_indirect_dispatch_buffer =
-            BufferVec::new(BufferUsages::STORAGE | BufferUsages::INDIRECT);
-        init_indirect_dispatch_buffer.set_label(Some("hanabi:buffer:init_indirect_dispatch"));
+        let init_indirect_dispatch_buffer = GpuBuffer::new(
+            BufferUsages::STORAGE | BufferUsages::INDIRECT,
+            Some("hanabi:buffer:init_indirect_dispatch".to_string()),
+        );
 
         let child_infos_bind_group_layout = device.create_bind_group_layout(
             "hanabi:bind_group_layout:indirect:child_infos@3",
@@ -377,9 +351,7 @@ impl EventCache {
 
         // Allocate an entry into the indirect dispatch buffer
         // The value pushed is a dummy; see allocate_frame_buffers().
-        let init_indirect_dispatch_index = self
-            .init_indirect_dispatch_buffer
-            .push(GpuDispatchIndirect::default()) as u32;
+        let init_indirect_dispatch_index = self.init_indirect_dispatch_buffer.allocate();
 
         // Try to find an allocated GPU buffer with enough capacity
         let mut empty_index = None;
@@ -465,10 +437,8 @@ impl EventCache {
             cached_effect_events
         );
 
-        // FIXME - free() not implemented in BufferVec!
-        warn!("free() not implemented in BufferVec, cannot free GpuInitDispatchInfo entry");
-        // self.init_indirect_dispatch_buffer
-        //     .free(cached_effect_events.init_indirect_dispatch_index);
+        self.init_indirect_dispatch_buffer
+            .free(cached_effect_events.init_indirect_dispatch_index);
 
         let entry = self
             .buffers
@@ -556,14 +526,39 @@ impl EventCache {
         // FIXME
         _effect_bind_groups: &mut ResMut<EffectBindGroups>,
     ) {
-        // Note: we abuse BufferVec for its ability to manage the GPU buffer, but
-        // we don't use its CPU side capabilities. So we only need the GPU buffer to be
-        // correctly allocated, using reserve(). No data is copied from CPU.
+        // This buffer is only ever used in the bind groups of a `GpuBufferOperations`,
+        // which manages its bind groups automatically each frame. So there's no
+        // invalidation to do here on re-allocation.
         self.init_indirect_dispatch_buffer
-            .reserve(self.init_indirect_dispatch_buffer.len(), render_device);
+            .prepare_buffers(render_device);
 
         self.child_infos_buffer
             .write_buffer(render_device, render_queue);
+    }
+
+    /// Schedule any pending buffer copy.
+    ///
+    /// This is necessary when a buffer is reallocated, to copy the old content.
+    /// This must be called once per frame after the buffers have been
+    /// reallocated with `prepare_buffers()`.
+    #[inline]
+    pub fn write_buffers(&self, command_encoder: &mut CommandEncoder) {
+        self.init_indirect_dispatch_buffer
+            .write_buffers(command_encoder);
+    }
+
+    /// Destroy old copies of buffers reallocated last frame and copied to a new
+    /// buffer.
+    ///
+    /// This must be called once per frame after any content was effectively
+    /// copied from an old to a new buffer. This means that, due to Bevy's
+    /// limitations, this must be called on the next frame, as we don't have
+    /// write access to anything nor any hint as to when copies are done until
+    /// the next frame rendering actually starts.
+    #[inline]
+    pub fn clear_previous_frame_resizes(&mut self) {
+        self.init_indirect_dispatch_buffer
+            .clear_previous_frame_resizes();
     }
 
     #[inline]

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -64,6 +64,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let indirect_dispatch_index = effect_metadata_buffer[em_base + EM_OFFSET_INDIRECT_DISPATCH_INDEX];
     let di_base = DISPATCH_INDIRECT_STRIDE * indirect_dispatch_index;
     dispatch_indirect_buffer[di_base] = (alive_count + 63u) >> 6u;
+    dispatch_indirect_buffer[di_base + 1u] = 1u;
+    dispatch_indirect_buffer[di_base + 2u] = 1u;
 
     // Swap ping/pong buffers. The update pass always writes into ping, and both the update
     // pass and the render pass always read from pong.


### PR DESCRIPTION
Both the indirect init and indirect update buffers used complex data structures designed for CPU/GPU interaction. However those buffers are only ever used on GPU. Switch both of them to use `GpuBuffer`, which doesn't handle any CPU access and is therefore more simple and optimized (doesn't make any CPU -> GPU upload copy for example).

Fix a bug where an old buffer for CPU spawners was used after being reallocated, which caused a panic when submitting the render queue.