### PR TITLE
Revert "Make the number of particles to emit in a GPU event an expression instead of a constant. (#444)"

### DIFF
--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -79,7 +79,7 @@ fn create_rocket_effect() -> EffectAsset {
     // effect.
     let update_spawn_trail = EmitSpawnEventModifier {
         condition: EventEmitCondition::Always,
-        count: writer.lit(5u32).expr(),
+        count: 5,
         // We use channel #0 for those sparkle trail events; see EffectParent
         child_index: 0,
     };
@@ -89,7 +89,7 @@ fn create_rocket_effect() -> EffectAsset {
     // events for its child(ren) effects.
     let update_spawn_on_die = EmitSpawnEventModifier {
         condition: EventEmitCondition::OnDie,
-        count: writer.lit(1000u32).expr(),
+        count: 1000,
         // We use channel #1 for the explosion itself; see EffectParent
         child_index: 1,
     };

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -84,7 +84,7 @@ fn create_head_effect() -> EffectAsset {
     // Spawn a trail of child body particles into the other effect
     let update_spawn_trail = EmitSpawnEventModifier {
         condition: EventEmitCondition::Always,
-        count: writer.lit(5u32).expr(),
+        count: 5,
         // We use channel #0; see EffectParent
         child_index: 0,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,11 +919,6 @@ impl EffectShaderSource {
             emit_event_buffer_append_funcs_code.push_str(&format!(
                 r##"/// Append one or more spawn events to the event buffer.
 fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
-    // Optimize this case.
-    if (count == 0u) {{
-        return;
-    }}
-
     let base_child_index = effect_metadata.base_child_index;
     let capacity = arrayLength(&event_buffer_{0}.spawn_events);
     let base = min(u32(atomicAdd(&child_info_buffer.rows[base_child_index + {0}].event_count, i32(count))), capacity);

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -74,7 +74,7 @@ pub use velocity::*;
 
 use crate::{
     Attribute, EvalContext, ExprError, ExprHandle, Gradient, Module, ParticleLayout,
-    PropertyLayout, TextureLayout,
+    PropertyLayout, TextureLayout, ToWgslString,
 };
 
 /// The dimension of a shape to consider.
@@ -636,10 +636,8 @@ pub enum EventEmitCondition {
 pub struct EmitSpawnEventModifier {
     /// Emit condition for the GPU spawn events.
     pub condition: EventEmitCondition,
-    /// The number of particles to spawn if the emit condition is met.
-    ///
-    /// Expression type: `Uint`
-    pub count: ExprHandle,
+    /// Number of particles to spawn if the emit condition is met.
+    pub count: u32,
     /// Index of the event channel / child the events are emitted into.
     ///
     /// GPU spawn events emitted by this parent event are associated with a
@@ -652,25 +650,20 @@ pub struct EmitSpawnEventModifier {
 impl EmitSpawnEventModifier {
     fn eval(
         &self,
-        module: &mut Module,
-        context: &mut dyn EvalContext,
+        _module: &mut Module,
+        _context: &mut dyn EvalContext,
     ) -> Result<String, ExprError> {
         // FIXME - mixing (ex-)channel and event buffer index; this should be automated
         let channel_index = self.child_index;
         // TODO - validate GPU spawn events are in use in the eval context...
-
-        let count_val = context.eval(module, self.count)?;
-        let count_var = context.make_local_var();
-        context.push_stmt(&format!("let {} = {};", count_var, count_val));
-
         let cond = match self.condition {
             EventEmitCondition::Always => format!(
                 "if (is_alive) {{ append_spawn_events_{channel_index}(particle_index, {}); }}",
-                count_var
+                self.count.to_wgsl_string()
             ),
             EventEmitCondition::OnDie => format!(
                 "if (was_alive && !is_alive) {{ append_spawn_events_{channel_index}(particle_index, {}); }}",
-                count_var
+                self.count.to_wgsl_string()
             ),
         };
         Ok(cond)


### PR DESCRIPTION
This temporarily reverts commit 9f7c6de087c6ddd1df4c8076b15511be9892a652 to allow releasing a non-breaking hotfix. This will be re-applied after.