### PR TITLE
Re-apply "Make the number of particles to emit in a GPU event an expression instead of a constant. (#444)"

### DIFF
--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -79,7 +79,7 @@ fn create_rocket_effect() -> EffectAsset {
     // effect.
     let update_spawn_trail = EmitSpawnEventModifier {
         condition: EventEmitCondition::Always,
-        count: 5,
+        count: writer.lit(5u32).expr(),
         // We use channel #0 for those sparkle trail events; see EffectParent
         child_index: 0,
     };
@@ -89,7 +89,7 @@ fn create_rocket_effect() -> EffectAsset {
     // events for its child(ren) effects.
     let update_spawn_on_die = EmitSpawnEventModifier {
         condition: EventEmitCondition::OnDie,
-        count: 1000,
+        count: writer.lit(1000u32).expr(),
         // We use channel #1 for the explosion itself; see EffectParent
         child_index: 1,
     };

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -84,7 +84,7 @@ fn create_head_effect() -> EffectAsset {
     // Spawn a trail of child body particles into the other effect
     let update_spawn_trail = EmitSpawnEventModifier {
         condition: EventEmitCondition::Always,
-        count: 5,
+        count: writer.lit(5u32).expr(),
         // We use channel #0; see EffectParent
         child_index: 0,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,6 +919,11 @@ impl EffectShaderSource {
             emit_event_buffer_append_funcs_code.push_str(&format!(
                 r##"/// Append one or more spawn events to the event buffer.
 fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
+    // Optimize this case.
+    if (count == 0u) {{
+        return;
+    }}
+
     let base_child_index = effect_metadata.base_child_index;
     let capacity = arrayLength(&event_buffer_{0}.spawn_events);
     let base = min(u32(atomicAdd(&child_info_buffer.rows[base_child_index + {0}].event_count, i32(count))), capacity);


### PR DESCRIPTION
This reverts commit d65cd725f25b20122c926b585d374ad91a404319, thereby re-applying commit 9f7c6de087c6ddd1df4c8076b15511be9892a652.