### PR TITLE
Add UI to all demos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 autoexamples = false
 
 [features]
-default = ["2d", "3d", "serde", "gpu_tests", "examples_world_inspector"]
+default = ["2d", "3d", "serde", "gpu_tests"]
 
 # Enable support for rendering through a 2D camera (Camera2d).
 # You need to activate either the 2d or 3d feature at least (or both).
@@ -50,14 +50,6 @@ trace = []
 # on a CI machine without a graphic adapter or without proper drivers.
 # This is a testing-only feature, which has no effect on the build.
 gpu_tests = []
-
-# Enable world inspector in examples, via bevy-inspector-egui.
-# This has no effect on the crate itself, only affects examples.
-# Unfortunately cargo doesn't allow example-only features.
-# We don't force a dependency on the bevy-inspector-egui crate because:
-# 1. dev-dependencies cannot be optional
-# 2. there's a bunch of duplicate deps and dodgy licenses pulled
-examples_world_inspector = []
 
 [dependencies]
 bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
@@ -97,21 +89,7 @@ features = [
 all-features = true
 
 [dev-dependencies]
-# For world inspector; required if "examples_world_inspector" is used.
-#bevy-inspector-egui = "0.29.1"
-#bevy_egui = { version = "0.32", default-features = false, features = [
-#    "manage_clipboard", "open_url"
-#] }
-#egui = "0.30"
-
-bevy_sprite = "0.16"
-bevy_text = "0.16"
-bevy_ui = "0.16"
-bevy_window = "0.16"
-bevy_picking = "0.16"
-
-# For glTF animations (Fox.glb)
-bevy_gltf = { version = "0.16", features = [ "bevy_animation" ] }
+bevy = { version = "0.16", default-features = true }
 
 # For procedural texture generation in examples
 noise = "0.9"
@@ -120,96 +98,66 @@ futures = "0.3"
 
 [[example]]
 name = "firework"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "portal"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "expr"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "spawn"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "multicam"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "visibility"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "random"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "spawn_on_command"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "activate"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "bevy/bevy_ui", "bevy/default_font", "3d" ]
 
 [[example]]
 name = "force_field"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "lifetime"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "init"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "instancing"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "gradient"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "circle"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "billboard"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "2d"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_sprite", "2d" ]
 
 [[example]]
 name = "worms"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "bevy/png", "3d" ]
 
 [[example]]
 name = "ribbon"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "ordering"
-required-features = [ "bevy/bevy_winit", "bevy/bevy_window", "bevy/bevy_pbr", "3d" ]
 
 [[example]]
 name = "puffs"
-required-features = [
-    "bevy/bevy_winit",
-    "bevy/bevy_window",
-    "bevy/bevy_pbr",
-    "bevy/bevy_scene",
-    "bevy/bevy_gltf",
-    "bevy/bevy_animation",
-    "bevy/png",
-    "3d",
-]
 
 [[test]]
 name = "empty_effect"

--- a/build_examples_wasm.bat
+++ b/build_examples_wasm.bat
@@ -7,29 +7,29 @@ set RUSTFLAGS=--cfg=web_sys_unstable_apis
 
 echo Build all examples for WASM...
 REM 3D
-cargo b --release --example firework --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example portal --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example expr --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example spawn --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example multicam --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example visibility --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example random --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example spawn_on_command --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example activate --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_ui bevy/default_font 3d bevy/webgpu"
-cargo b --release --example force_field --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example init --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example lifetime --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example ordering --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example ribbon --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
+cargo b --release --example firework --target wasm32-unknown-unknown
+cargo b --release --example portal --target wasm32-unknown-unknown
+cargo b --release --example expr --target wasm32-unknown-unknown
+cargo b --release --example spawn --target wasm32-unknown-unknown
+cargo b --release --example multicam --target wasm32-unknown-unknown
+cargo b --release --example visibility --target wasm32-unknown-unknown
+cargo b --release --example random --target wasm32-unknown-unknown
+cargo b --release --example spawn_on_command --target wasm32-unknown-unknown
+cargo b --release --example activate --target wasm32-unknown-unknown
+cargo b --release --example force_field --target wasm32-unknown-unknown
+cargo b --release --example init --target wasm32-unknown-unknown
+cargo b --release --example lifetime --target wasm32-unknown-unknown
+cargo b --release --example ordering --target wasm32-unknown-unknown
+cargo b --release --example ribbon --target wasm32-unknown-unknown
 REM 3D + PNG
-cargo b --release --example gradient --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example circle --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example billboard --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example worms --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example instancing --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example puffs --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_scene bevy/bevy_gltf bevy/bevy_animation bevy/png 3d bevy/webgpu"
+cargo b --release --example gradient --target wasm32-unknown-unknown
+cargo b --release --example circle --target wasm32-unknown-unknown
+cargo b --release --example billboard --target wasm32-unknown-unknown
+cargo b --release --example worms --target wasm32-unknown-unknown
+cargo b --release --example instancing --target wasm32-unknown-unknown
+cargo b --release --example puffs --target wasm32-unknown-unknown
 REM 2D
-cargo b --release --example 2d --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d bevy/webgpu"
+cargo b --release --example 2d --target wasm32-unknown-unknown
 
 wasm-bindgen --out-name wasm_firework --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/firework.wasm
 wasm-bindgen --out-name wasm_portal --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/portal.wasm

--- a/build_examples_wasm.sh
+++ b/build_examples_wasm.sh
@@ -5,29 +5,29 @@ export RUSTFLAGS=--cfg=web_sys_unstable_apis
 
 echo Build all examples for WASM...
 # 3D
-cargo b --release --example firework --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example portal --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example expr --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example spawn --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example multicam --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example visibility --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example random --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example spawn_on_command --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example activate --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_ui bevy/default_font 3d bevy/webgpu"
-cargo b --release --example force_field --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example init --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example lifetime --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example ordering --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
-cargo b --release --example ribbon --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d bevy/webgpu"
+cargo b --release --example firework --target wasm32-unknown-unknown
+cargo b --release --example portal --target wasm32-unknown-unknown
+cargo b --release --example expr --target wasm32-unknown-unknown
+cargo b --release --example spawn --target wasm32-unknown-unknown
+cargo b --release --example multicam --target wasm32-unknown-unknown
+cargo b --release --example visibility --target wasm32-unknown-unknown
+cargo b --release --example random --target wasm32-unknown-unknown
+cargo b --release --example spawn_on_command --target wasm32-unknown-unknown
+cargo b --release --example activate --target wasm32-unknown-unknown
+cargo b --release --example force_field --target wasm32-unknown-unknown
+cargo b --release --example init --target wasm32-unknown-unknown
+cargo b --release --example lifetime --target wasm32-unknown-unknown
+cargo b --release --example ordering --target wasm32-unknown-unknown
+cargo b --release --example ribbon --target wasm32-unknown-unknown
 # 3D + PNG
-cargo b --release --example gradient --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example circle --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example billboard --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example worms --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example instancing --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d bevy/webgpu"
-cargo b --release --example puffs --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_scene bevy/bevy_gltf bevy/bevy_animation bevy/png 3d bevy/webgpu"
+cargo b --release --example
+cargo b --release --example circle --target wasm32-unknown-unknown
+cargo b --release --example billboard --target wasm32-unknown-unknown
+cargo b --release --example worms --target wasm32-unknown-unknown
+cargo b --release --example instancing --target wasm32-unknown-unknown
+cargo b --release --example puffs --target wasm32-unknown-unknown
 # 2D
-cargo b --release --example 2d --target wasm32-unknown-unknown --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d bevy/webgpu"
+cargo b --release --example 2d --target wasm32-unknown-unknown
 
 echo Bindgen all examples...
 wasm-bindgen --out-name wasm_firework --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/firework.wasm

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -6,8 +6,13 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("2d.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("2d")
+    let app_exit = utils::DemoApp::new("2d")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update_plane)
         .run();

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -31,7 +31,7 @@ fn setup(
     proj.scaling_mode = ScalingMode::FixedVertical {
         viewport_height: 1.,
     };
-    commands.spawn((Camera2d::default(), Projection::Orthographic(proj)));
+    commands.spawn((Camera2d, Projection::Orthographic(proj)));
 
     // Spawn a reference white square in the center of the screen at Z=0
     commands.spawn((

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -6,7 +6,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("2d.txt");
+const DEMO_DESC: &str = include_str!("2d.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("2d")

--- a/examples/2d.txt
+++ b/examples/2d.txt
@@ -1,0 +1,3 @@
+This example show the use of particles with a 2D camera, and how to order rendering relative to other 2D meshes.
+
+The square mesh moves back and forth perpendicular to the screen (Z axis), but doesn't appear to move because of the orthographic projection. The particle effect remains at Z=0. When the square moves in front, the particles render behind it, and vice-versa.

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -13,15 +13,21 @@
 //! [`KillAabbModifier`] to ensure the bubble particles never escape water, and
 //! are despawned when reaching the surface.
 
-use bevy::{core_pipeline::tonemapping::Tonemapping, prelude::*, render::camera::ScalingMode};
+use bevy::{
+    core_pipeline::tonemapping::Tonemapping, prelude::*, render::camera::ScalingMode,
+    text::TextFont,
+};
 use bevy_hanabi::prelude::*;
 
 mod utils;
-use bevy_text::TextFont;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("activate.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("activate")
+    let app_exit = utils::DemoApp::new("activate")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -22,7 +22,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("activate.txt");
+const DEMO_DESC: &str = include_str!("activate.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("activate")

--- a/examples/activate.rs
+++ b/examples/activate.rs
@@ -154,7 +154,7 @@ fn setup(
             font_size: 60.0,
             ..default()
         },
-        TextColor(Color::WHITE.into()),
+        TextColor(Color::WHITE),
         StatusText,
     ));
 }

--- a/examples/activate.txt
+++ b/examples/activate.txt
@@ -1,0 +1,5 @@
+This example demonstrates the activation and deactivation of the CPU spawner.
+
+The ball moves up and down, spawning bubble particles at a constant rate of 30 particles per second. When in the water, the spawner is set to active. When the ball gets out, the spawner is deactivated.
+
+Spawner activation and deactivation is best suited for long-lived effects toggling often. The effect instance retains all GPU resources while inactive, but skips most processing. Toggling is therefore very cheap, at the cost of consuming GPU resources even when inactive. For occasional effects, it may be better suited to despawn the effect instance entirely and re-spawn it later, in order to release GPU resources while the effect is not in use.

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -35,7 +35,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("billboard.txt");
+const DEMO_DESC: &str = include_str!("billboard.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("billboard")

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -35,8 +35,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("billboard.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("billboard")
+    let app_exit = utils::DemoApp::new("billboard")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_camera)
         .run();

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -129,7 +129,7 @@ fn setup(
             .init(init_rotation)
             .init(init_color)
             .render(ParticleTextureModifier {
-                texture_slot: texture_slot,
+                texture_slot,
                 sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(OrientModifier {

--- a/examples/billboard.txt
+++ b/examples/billboard.txt
@@ -1,0 +1,5 @@
+This example shows billboarding and alpha masking.
+
+The particle effect uses the OrientModifier to ensure the 2D quad particles are always facing the camera; this is called "billboarding".
+
+The particles themselves are rendered using alpha masking, which discards all fragments below a certain cutoff threshold, to give the appearance of non-rectangular shapes and holes without using partial transparency. The cutoff threshold is animated between 0 and 1 to show its effect, using an expression executing entirely on GPU.

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -132,7 +132,7 @@ fn setup(
         .init(init_lifetime)
         .update(update_sprite_index)
         .render(ParticleTextureModifier {
-            texture_slot: texture_slot,
+            texture_slot,
             sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
         })
         .render(ParticleTextureModifier {

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -14,8 +14,12 @@ mod utils;
 use texutils::make_anim_img;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("circle.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("circle")
+    let app_exit = utils::DemoApp::new("circle")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -14,7 +14,7 @@ mod utils;
 use texutils::make_anim_img;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("circle.txt");
+const DEMO_DESC: &str = include_str!("circle.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("circle")

--- a/examples/circle.txt
+++ b/examples/circle.txt
@@ -1,0 +1,3 @@
+This example shows how to blend and animate a particle texture.
+
+The texture used to render the particle is animated with the FlipbookModifier, which modifies the UV coordinates of the 2D particle quad to match a sprite index in a larger atlas texture containing a noise pattern. A second atlas texture gives the particle an animated color, using the same flipbook sprite index. Those two texture are blended together, and blended with a gradient which progressively lowers the alpha value to make the particles gradually disappear.

--- a/examples/expr.rs
+++ b/examples/expr.rs
@@ -16,8 +16,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("expr.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("expr")
+    let app_exit = utils::DemoApp::new("expr")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/expr.rs
+++ b/examples/expr.rs
@@ -16,7 +16,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("expr.txt");
+const DEMO_DESC: &str = include_str!("expr.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("expr")

--- a/examples/expr.txt
+++ b/examples/expr.txt
@@ -1,0 +1,3 @@
+This example demonstrates the use of expressions.
+
+Expressions are building blocks representing shader instructions, which combined together create complex shader programs used to control the particle effect. Those expressions run entirely on GPU, when the particle is update each frame, and are therefore very efficient. The downside is the limited control from CPU, since expressions can only use GPU data.

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -1,6 +1,6 @@
 //! Firework
 //!
-//! This example demonstrate the use of the [`LinearDragModifier`] to slow down
+//! This example demonstrates the use of the [`LinearDragModifier`] to slow down
 //! particles over time. Combined with an HDR camera with Bloom, the example
 //! renders a firework explosion.
 //!
@@ -26,8 +26,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("firework.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("firework")
+    let app_exit = utils::DemoApp::new("firework")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -26,7 +26,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("firework.txt");
+const DEMO_DESC: &str = include_str!("firework.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("firework")

--- a/examples/firework.txt
+++ b/examples/firework.txt
@@ -1,0 +1,8 @@
+This example demonstrates the use of various modifiers to create a firework visual effect.
+
+The overall effect is composed of 3 distinct effect instances:
+- A parent 'rocket' effect spawns a single particle raising vertically in the sky. Spawning is controlled by CPU at a rate of 1 to 3 particles per second. Those particles are mostly invisible.
+- A child 'sparkle' effect renders sparkle particles which appear to be ejected from the rocket as it rises. Those particles are spawned by GPU events from the parent effect, while the parent particle is alive.
+- A child 'trail' effect spawns trail particles when the rocket explodes. Those particles are also spawned by GPU events, this time when the parent particles die.
+
+The example uses an HDR camera and bloom to give a glow to particles.

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -20,17 +20,13 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut app = utils::make_test_app("force_field");
+const DEMO_DESC: &'static str = include_str!("force_field.txt");
 
-    #[cfg(feature = "examples_world_inspector")]
-    app.init_resource::<inspector::Configuration>()
-        .register_type::<inspector::Configuration>()
-        .add_systems(Update, inspector::inspector_ui)
-        .add_systems(
-            PostUpdate,
-            inspector::apply_tweaks.after(EffectSystems::UpdatePropertiesFromAsset),
-        );
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut app = utils::DemoApp::new("force_field")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build();
 
     app.add_systems(Startup, setup)
         .add_systems(Update, (spawn_on_click, move_repulsor))
@@ -43,107 +39,6 @@ const BALL_RADIUS: f32 = 0.05;
 
 #[derive(Component)]
 struct RepulsorMarker(pub bool);
-
-#[cfg(feature = "examples_world_inspector")]
-mod inspector {
-    use bevy::{ecs::resource::Resource, prelude::*, reflect::Reflect, window::PrimaryWindow};
-    use bevy_egui::EguiContext;
-    use bevy_hanabi::EffectProperties;
-    use bevy_inspector_egui::{inspector_options::std_options::NumberDisplay, prelude::*};
-
-    use crate::RepulsorMarker;
-
-    #[derive(Reflect, Resource, InspectorOptions)]
-    #[reflect(Resource, InspectorOptions)]
-    pub struct Configuration {
-        #[inspector(min = 1.0, max = 50.0, display = NumberDisplay::Slider)]
-        attraction_accel: f32,
-        #[inspector(min = 1.0, max = 20.0, display = NumberDisplay::Slider)]
-        max_attraction_speed: f32,
-        #[inspector(min = 1.0, max = 10.0, display = NumberDisplay::Slider)]
-        sticky_factor: f32,
-        #[inspector(min = 0.02, max = 2.0, display = NumberDisplay::Slider)]
-        shell_half_thickness: f32,
-        repulsor_enabled: bool,
-        #[inspector(min = -30.0, max = -0.1, display = NumberDisplay::Slider)]
-        repulsor_accel: f32,
-    }
-
-    impl Default for Configuration {
-        fn default() -> Self {
-            Self {
-                attraction_accel: 20.,
-                max_attraction_speed: 5.,
-                sticky_factor: 2.,
-                shell_half_thickness: 0.1,
-                repulsor_enabled: true,
-                repulsor_accel: -15.,
-            }
-        }
-    }
-
-    pub fn inspector_ui(world: &mut World, mut disabled: Local<bool>) {
-        let space_pressed = world
-            .resource::<ButtonInput<KeyCode>>()
-            .just_pressed(KeyCode::Space);
-        if space_pressed {
-            *disabled = !*disabled;
-        }
-        if *disabled {
-            return;
-        }
-
-        let mut egui_context = world
-            .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
-            .single(world)
-            .clone();
-
-        egui::Window::new("ConformToSphereModifier").show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector_egui::bevy_inspector::ui_for_resource::<Configuration>(world, ui);
-
-                ui.separator();
-                ui.label("Press space to toggle");
-            });
-        });
-    }
-
-    pub fn apply_tweaks(
-        config: Res<Configuration>,
-        mut q_properties: Query<&mut EffectProperties>,
-        mut q_marker: Query<&mut RepulsorMarker>,
-    ) {
-        let mut properties = q_properties.single_mut();
-        properties = EffectProperties::set_if_changed(
-            properties,
-            "attraction_accel",
-            config.attraction_accel.into(),
-        );
-        properties = EffectProperties::set_if_changed(
-            properties,
-            "max_attraction_speed",
-            config.max_attraction_speed.into(),
-        );
-        properties = EffectProperties::set_if_changed(
-            properties,
-            "sticky_factor",
-            config.sticky_factor.into(),
-        );
-        properties = EffectProperties::set_if_changed(
-            properties,
-            "shell_half_thickness",
-            config.shell_half_thickness.into(),
-        );
-        EffectProperties::set_if_changed(
-            properties,
-            "repulsor_accel",
-            config.repulsor_accel.into(),
-        );
-
-        let mut marker = q_marker.single_mut();
-        marker.0 = config.repulsor_enabled;
-    }
-}
 
 const ATTRACTOR_POS: Vec3 = Vec3::new(0.01, 0.0, 0.0);
 const REPULSOR_POS: Vec3 = Vec3::new(0.3, 0.5, 0.0);
@@ -208,7 +103,7 @@ fn setup(
 
     // "forbid" sphere
     commands.spawn((
-        Transform::from_translation(Vec3::new(-2., -1., 0.1)),
+        Transform::from_translation(Vec3::new(-2., 1., 0.1)),
         Mesh3d(meshes.add(Sphere { radius: 0.6 })),
         MeshMaterial3d(materials.add(StandardMaterial {
             base_color: Color::linear_rgba(0.7, 0., 0., 0.2),
@@ -244,7 +139,7 @@ fn setup(
 
     // Define the sphere into which particles cannot enter. Any particle attempting
     // to enter gets killed.
-    let center = writer.lit(Vec3::new(-2., -1., 0.)).expr();
+    let center = writer.lit(Vec3::new(-2., 1., 0.)).expr();
     let radius = writer.lit(0.6);
     let sqr_radius = (radius.clone() * radius).expr();
     let deny_zone = KillSphereModifier::new(center, sqr_radius).with_kill_inside(true);
@@ -319,7 +214,7 @@ fn setup(
 fn spawn_on_click(
     mut q_effect: Query<(&mut EffectSpawner, &mut Transform), Without<Projection>>,
     mouse_button_input: Res<ButtonInput<MouseButton>>,
-    camera_query: Query<(&Camera, &GlobalTransform), With<Projection>>,
+    camera_query: Query<(&Camera, &GlobalTransform), With<Camera3d>>,
     window: Query<&Window, With<bevy::window::PrimaryWindow>>,
 ) {
     // Note: On first frame where the effect spawns, EffectSpawner is spawned during

--- a/examples/force_field.rs
+++ b/examples/force_field.rs
@@ -20,7 +20,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("force_field.txt");
+const DEMO_DESC: &str = include_str!("force_field.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut app = utils::DemoApp::new("force_field")

--- a/examples/force_field.txt
+++ b/examples/force_field.txt
@@ -1,0 +1,5 @@
+This example shows the use of attractors/repulsors and kill shapes.
+
+The ConformToSphereModifier is used to create one attractor and one repulsor spheres. Particles are attracted to the former, and pushed away from the latter, based on several parameters like the distance to the sphere center, or the attraction/repulsion acceleration (strength) and maximum speed.
+
+The particles are confined to the green box with a KillAabbModifier, which automatically kills any particle moving outside of it. They're also prevented from penetrating inside the red sphere with an inverted KillSphereModifier.

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -6,8 +6,13 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("gradient.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("gradient")
+    let app_exit = utils::DemoApp::new("gradient")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -6,7 +6,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("gradient.txt");
+const DEMO_DESC: &str = include_str!("gradient.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("gradient")

--- a/examples/gradient.txt
+++ b/examples/gradient.txt
@@ -1,0 +1,3 @@
+This example shows a basic particle effect setup.
+
+The particles are emitted at constant rate every frame, as the emitter moves around the scene (changes its Transform). The particles are rendered with a texture modulating their opacity, to give them a noise/smoke shape, and a color gradient to change their color and opacity over their lifetime, and eventually make them fade out.

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -13,7 +13,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("init.txt");
+const DEMO_DESC: &str = include_str!("init.txt");
 
 #[derive(Component)]
 struct RotateSpeed(pub f32);

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -13,11 +13,16 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("init.txt");
+
 #[derive(Component)]
 struct RotateSpeed(pub f32);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("init")
+    let app_exit = utils::DemoApp::new("init")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_effect)
         .run();

--- a/examples/init.txt
+++ b/examples/init.txt
@@ -1,0 +1,5 @@
+This example shows some of the built-in shape modifiers to initialize a particle's position.
+
+For each shape, the particles are spawned once, with a constant color and size, and no velocity nor motion integration. That way, they stay in place where they spawned. The effect is simulated in local space, such that the particles appear attached to it. Then the effect's Transform is used to rotate the instance, to help visualize the distribution of particles spawned.
+
+Other shape distributions can be achieved by using a custom expression and the SetAttributeModifier to assign the Attribute::POSITION of the particle directly. The modifiers demonstrated here are purely for convenience.

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -16,6 +16,8 @@ use rand::Rng;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("instancing.txt");
+
 #[derive(Default, Resource)]
 struct InstanceManager {
     effect: Handle<EffectAsset>,
@@ -176,7 +178,10 @@ impl InstanceManager {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("instancing")
+    let app_exit = utils::DemoApp::new("instancing")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build()
         .insert_resource(InstanceManager::new(5, 4))
         .add_systems(Startup, setup)
         .add_systems(Update, keyboard_input_system)

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -73,11 +73,7 @@ impl InstanceManager {
             return;
         }
 
-        let pos = origin
-            + IVec2::new(
-                index as i32 % self.grid_size.x,
-                index as i32 / self.grid_size.x,
-            );
+        let pos = origin + IVec2::new(index % self.grid_size.x, index / self.grid_size.x);
 
         *entry = Some(
             commands

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -16,7 +16,7 @@ use rand::Rng;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("instancing.txt");
+const DEMO_DESC: &str = include_str!("instancing.txt");
 
 #[derive(Default, Resource)]
 struct InstanceManager {

--- a/examples/instancing.txt
+++ b/examples/instancing.txt
@@ -1,0 +1,3 @@
+This example is more of a debug and stress test.
+
+It shows a grid of effect instances from 2 different effect assets. You can spawn new effect instances with the SPACE key, and delete random existing ones with the DELETE or BACKSPACE key. This example was intended to test batching, but that feature is currently disabled. It's still useful to test the behavior on effect spawning and despawning.

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -17,8 +17,13 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("lifetime.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("lifetime")
+    let app_exit = utils::DemoApp::new("lifetime")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/lifetime.rs
+++ b/examples/lifetime.rs
@@ -17,7 +17,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("lifetime.txt");
+const DEMO_DESC: &str = include_str!("lifetime.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("lifetime")

--- a/examples/lifetime.txt
+++ b/examples/lifetime.txt
@@ -1,0 +1,6 @@
+This simple example shows the effect of various particle lifetimes.
+
+All effects emit a burst of particles every 3 seconds. The only difference is the particle's lifetime for each effect:
+- Particles in the left effect have a lifetime of 12 seconds, longer than the spawn cycle period. New particles spawn as old particles are still alive.
+- Particles in the center effect have a lifetime of 3 seconds, exactly matching the spawn cycle period. New particles spawning appear to "replace" old particles, which die exactly at the same time.
+- Particles in the right effect have a lifetime of 1 second, shorter than the spawn cycle period. They die before the new particles from the next burst spawn.

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -12,8 +12,13 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("multicam.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("multicam")
+    let app_exit = utils::DemoApp::new("multicam")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update_camera_viewports)
         .run();

--- a/examples/multicam.rs
+++ b/examples/multicam.rs
@@ -12,7 +12,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("multicam.txt");
+const DEMO_DESC: &str = include_str!("multicam.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("multicam")

--- a/examples/multicam.txt
+++ b/examples/multicam.txt
@@ -1,0 +1,6 @@
+This example shows how to use RenderLayers to select which camera renders which effect.
+
+- The top left camera renders the green and blue effects.
+- The top right camera renders all effects.
+- The bottom left camera renders the red effect alone.
+- The bottom right camera renders the red and blue effects.

--- a/examples/ordering.rs
+++ b/examples/ordering.rs
@@ -18,8 +18,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("ordering.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("ordering")
+    let app_exit = utils::DemoApp::new("ordering")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/ordering.rs
+++ b/examples/ordering.rs
@@ -18,7 +18,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("ordering.txt");
+const DEMO_DESC: &str = include_str!("ordering.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("ordering")

--- a/examples/ordering.txt
+++ b/examples/ordering.txt
@@ -1,0 +1,3 @@
+This example shows the interaction of depth ordering and alpha blending.
+
+The red background is located behind the particle effect, and is always rendered behind particles. The blue and green background are both located in front of the particle effect, however the green mesh has an opaque material, while the blue mesh has a semi-transparent material. The former renders without alpha blending, and obscures the particles, while the latter renders with alpha blending, with the particles behind it partially visible.

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -20,7 +20,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("portal.txt");
+const DEMO_DESC: &str = include_str!("portal.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("portal")

--- a/examples/portal.rs
+++ b/examples/portal.rs
@@ -20,8 +20,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("portal.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("portal")
+    let app_exit = utils::DemoApp::new("portal")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/portal.txt
+++ b/examples/portal.txt
@@ -1,0 +1,3 @@
+This simple example shows the use of TangentAccelModifier to make particles rotate.
+
+The portal effect is created by spawning particles along a circle shape, and giving them a velocity at spawn which is tangent to that circle. This gives the impression that the particles are ejected from the circle. Some linear drag adds some sense of physicality by slowing down particles after they spawn.

--- a/examples/puffs.rs
+++ b/examples/puffs.rs
@@ -18,7 +18,7 @@ use crate::utils::*;
 
 mod utils;
 
-const DEMO_DESC: &'static str = include_str!("puffs.txt");
+const DEMO_DESC: &str = include_str!("puffs.txt");
 
 // A simple custom modifier that lights the meshes with Lambertian lighting.
 // Other lighting models are possible, up to and including PBR.

--- a/examples/puffs.rs
+++ b/examples/puffs.rs
@@ -18,6 +18,8 @@ use crate::utils::*;
 
 mod utils;
 
+const DEMO_DESC: &'static str = include_str!("puffs.txt");
+
 // A simple custom modifier that lights the meshes with Lambertian lighting.
 // Other lighting models are possible, up to and including PBR.
 #[derive(Clone, Copy, Reflect, Serialize, Deserialize)]
@@ -33,7 +35,9 @@ struct LambertianLightingModifier {
 static LIGHT_POSITION: Vec3 = vec3(-20.0, 40.0, 5.0);
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let app_exit = make_test_app("puffs")
+    let app_exit = DemoApp::new("puffs")
+        .with_desc(DEMO_DESC)
+        .build()
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 500.0,

--- a/examples/puffs.txt
+++ b/examples/puffs.txt
@@ -1,0 +1,3 @@
+This example shows the use of mesh particles.
+
+The particle effect uses a 3D sphere mesh to render puffs of smoke. The particles are spawned at a random location within a small area behind the fox, and with varying sizes. The size is also animated with a modifier to make the particles fade out as they age. A custom modifier is added to light the particles.

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -7,8 +7,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("random.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("random")
+    let app_exit = utils::DemoApp::new("random")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/random.rs
+++ b/examples/random.rs
@@ -7,7 +7,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("random.txt");
+const DEMO_DESC: &str = include_str!("random.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("random")

--- a/examples/random.txt
+++ b/examples/random.txt
@@ -1,0 +1,1 @@
+This simple example shows how to add variations to effects by spawning a random number of particles at random times.

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -67,7 +67,7 @@ const RIBBON_LIFETIME: f32 = 1.5;
 // Allocate a tiny bit more just to have some wiggle room.
 const PARTICLE_CAPACITY: u32 = 100;
 
-const DEMO_DESC: &'static str = include_str!("ribbon.txt");
+const DEMO_DESC: &str = include_str!("ribbon.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("ribbon")

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -67,8 +67,12 @@ const RIBBON_LIFETIME: f32 = 1.5;
 // Allocate a tiny bit more just to have some wiggle room.
 const PARTICLE_CAPACITY: u32 = 100;
 
+const DEMO_DESC: &'static str = include_str!("ribbon.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("ribbon")
+    let app_exit = utils::DemoApp::new("ribbon")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, move_head)
         .run();

--- a/examples/ribbon.txt
+++ b/examples/ribbon.txt
@@ -1,0 +1,5 @@
+This example shows the use of ribbons.
+
+Two instances of the same particle effect are spawned, one where the emitter moves alongside a Lissajou curve, and the other alongside a Spirograph curve.
+
+The ribbon effect is created by spawning particles in-place in the world without moving them, and assigning all the particles the same Attribute::RIBBON_ID. By doing so, Hanabi will sort all particles in an instance by age, and will render a single linked mesh. The effect is completed by fadding out the particle size and opacity toward their life end.

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -8,7 +8,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("spawn.txt");
+const DEMO_DESC: &str = include_str!("spawn.txt");
 
 /// Set this to `true` to enable WGPU downlevel constraints. This is disabled by
 /// default to prevent the example from failing to start on devices with a

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -8,6 +8,8 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("spawn.txt");
+
 /// Set this to `true` to enable WGPU downlevel constraints. This is disabled by
 /// default to prevent the example from failing to start on devices with a
 /// monitor resolution larger than the maximum resolution imposed by the
@@ -26,7 +28,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wgpu_settings.constrained_limits = Some(limits);
     }
 
-    let app_exit = utils::make_test_app_with_settings("spawn", wgpu_settings)
+    let app_exit = utils::DemoApp::new("spawn")
+        .with_desc(DEMO_DESC)
+        .with_desc_position(DescPosition::BottomRow)
+        .with_wgpu_settings(wgpu_settings)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update_accel)
         .run();

--- a/examples/spawn.txt
+++ b/examples/spawn.txt
@@ -1,0 +1,5 @@
+This simple example shows the 3 types of CPU spawning.
+
+- The left effect uses SpawnerSettings::rate() to spawn a constant stream of particles.
+- The center effect uses SpawnerSettings::once() to spawn a single burst of particles once only. It then idles forever.
+- The right effect uses SpawnerSettings::burst() to spawn bursts of particles every so often. It also uses a property to control the direction of spawning from CPU.

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -14,8 +14,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("spawn_on_command.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("spawn_on_command")
+    let app_exit = utils::DemoApp::new("spawn_on_command")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();

--- a/examples/spawn_on_command.rs
+++ b/examples/spawn_on_command.rs
@@ -14,7 +14,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("spawn_on_command.txt");
+const DEMO_DESC: &str = include_str!("spawn_on_command.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("spawn_on_command")

--- a/examples/spawn_on_command.txt
+++ b/examples/spawn_on_command.txt
@@ -1,0 +1,3 @@
+This example shows CPU-side control over spawning.
+
+The ball bounces inside the cube, and a system calculates its collisions. Each time the ball collide, the particle effect is moved to the collision point, a random color is assigned by the CPU via a property, and the spawner is instructed to emit a single burst of particles.

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -138,12 +138,12 @@ impl std::error::Error for ExampleFailedError {}
 /// Convert an [`AppExit`] into a `Result`, for error code propagation to the
 /// OS.
 pub trait AppExitIntoResult {
-    fn into_result(&self) -> Result<(), Box<dyn std::error::Error>>;
+    fn into_result(self) -> Result<(), Box<dyn std::error::Error>>;
 }
 
 impl AppExitIntoResult for AppExit {
-    fn into_result(&self) -> Result<(), Box<dyn std::error::Error>> {
-        match *self {
+    fn into_result(self) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
             AppExit::Success => Ok(()),
             AppExit::Error(code) => Err(Box::new(ExampleFailedError(code))),
         }

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -1,14 +1,21 @@
 #![allow(unused)]
 
-use std::{fmt::Display, num::NonZeroU8};
+use std::num::NonZeroU8;
 
 use bevy::{
     log::LogPlugin,
     prelude::*,
-    render::{settings::WgpuSettings, RenderDebugFlags, RenderPlugin},
+    render::{
+        camera::CameraOutputMode, settings::WgpuSettings, view::RenderLayers, RenderDebugFlags,
+        RenderPlugin,
+    },
+    text::{TextColor, TextFont},
+    ui::{
+        widget::Text, BackgroundColor, BorderColor, BorderRadius, Display, Node, Overflow,
+        PositionType, UiRect, Val, ZIndex,
+    },
 };
-#[cfg(feature = "examples_world_inspector")]
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use wgpu::BlendState;
 
 use crate::prelude::*;
 
@@ -35,49 +42,92 @@ pub fn get_log_filters(example_name: &str) -> String {
     .join(",")
 }
 
-/// Create a test app for an example.
-pub fn make_test_app(example_name: &str) -> App {
-    make_test_app_with_settings(example_name, WgpuSettings::default())
+#[derive(Default, Clone, Copy)]
+pub enum DescPosition {
+    #[default]
+    LeftColumn,
+    BottomRow,
 }
 
-/// Create a test app for an example, with explicit WGPU settings.
-pub fn make_test_app_with_settings(example_name: &str, wgpu_settings: WgpuSettings) -> App {
-    let mut app = App::default();
-    app.insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(
-            DefaultPlugins
-                .set(LogPlugin {
-                    level: bevy::log::Level::INFO,
-                    filter: get_log_filters(example_name),
-                    ..default()
-                })
-                .set(RenderPlugin {
-                    render_creation: wgpu_settings.into(),
-                    synchronous_pipeline_compilation: false,
-                    debug_flags: RenderDebugFlags::empty(),
-                })
-                .set(WindowPlugin {
-                    primary_window: Some(Window {
-                        title: format!("🎆 Hanabi — {}", example_name),
+#[derive(Default)]
+pub struct DemoApp {
+    name: String,
+    desc: String,
+    wgpu_settings: WgpuSettings,
+    desc_position: DescPosition,
+}
+
+impl DemoApp {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            ..default()
+        }
+    }
+
+    pub fn with_desc(mut self, desc: &str) -> Self {
+        self.desc = desc.to_string();
+        self
+    }
+
+    pub fn with_desc_position(mut self, desc_position: DescPosition) -> Self {
+        self.desc_position = desc_position;
+        self
+    }
+
+    pub fn with_wgpu_settings(mut self, wgpu_settings: WgpuSettings) -> Self {
+        self.wgpu_settings = wgpu_settings;
+        self
+    }
+
+    pub fn build(self) -> App {
+        let mut app = App::default();
+        app.insert_resource(ClearColor(Color::BLACK))
+            .add_plugins(
+                DefaultPlugins
+                    .set(LogPlugin {
+                        level: bevy::log::Level::INFO,
+                        filter: get_log_filters(&self.name),
+                        ..default()
+                    })
+                    .set(RenderPlugin {
+                        render_creation: self.wgpu_settings.into(),
+                        synchronous_pipeline_compilation: false,
+                        debug_flags: RenderDebugFlags::empty(),
+                    })
+                    .set(WindowPlugin {
+                        primary_window: Some(Window {
+                            title: format!("🎆 Hanabi — {}", self.name),
+                            ..default()
+                        }),
                         ..default()
                     }),
-                    ..default()
-                }),
-        )
-        .add_plugins(HanabiPlugin)
-        .add_systems(Update, close_on_esc);
+            )
+            .add_plugins(HanabiPlugin)
+            .insert_resource(Demo {
+                name: self.name,
+                desc: self.desc,
+                desc_position: self.desc_position,
+            })
+            .add_systems(Startup, spawn_demo_ui)
+            .add_systems(Update, close_on_esc);
 
-    #[cfg(feature = "examples_world_inspector")]
-    app.add_plugins(WorldInspectorPlugin::default());
+        app
+    }
+}
 
-    app
+#[derive(Resource)]
+pub struct Demo {
+    pub name: String,
+    pub desc: String,
+    pub desc_position: DescPosition,
 }
 
 /// Error struct wrapping an app error code.
 #[derive(Debug)]
 pub struct ExampleFailedError(pub NonZeroU8);
 
-impl Display for ExampleFailedError {
+impl std::fmt::Display for ExampleFailedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "App terminated with error code {}", self.0.get())
     }
@@ -107,3 +157,75 @@ pub const COLOR_YELLOW: Color = Color::linear_rgb(1., 1., 0.);
 pub const COLOR_CYAN: Color = Color::linear_rgb(0., 1., 1.);
 pub const COLOR_OLIVE: Color = Color::linear_rgb(0.5, 0.5, 0.);
 pub const COLOR_PURPLE: Color = Color::linear_rgb(0.5, 0., 0.5);
+
+fn spawn_demo_ui(mut cmd: Commands, demo: Res<Demo>) {
+    debug!("Spawning UI for demo {}", demo.name);
+
+    // Camera
+    let ui_camera = cmd
+        .spawn((
+            Camera2d,
+            Projection::Orthographic(OrthographicProjection::default_2d()),
+            Camera {
+                hdr: false,
+                order: 1000, // render UI above everything
+                clear_color: ClearColorConfig::None,
+                output_mode: CameraOutputMode::Write {
+                    blend_state: Some(BlendState::ALPHA_BLENDING),
+                    clear_color: ClearColorConfig::None,
+                },
+                ..default()
+            },
+            Name::new("UI camera"),
+            RenderLayers::layer(63),
+        ))
+        .id();
+
+    // Description UI panel
+    let (left, top, right, bottom, width) = match demo.desc_position {
+        DescPosition::LeftColumn => (Val::Vw(5.), Val::Vw(5.), Val::Auto, Val::Auto, Val::Vw(30.)),
+        DescPosition::BottomRow => (Val::Vw(5.), Val::Auto, Val::Vw(5.), Val::Vw(5.), Val::Auto),
+    };
+    cmd.spawn((
+        Node {
+            display: Display::Block,
+            position_type: PositionType::Absolute,
+            overflow: Overflow::clip(),
+            left,
+            top,
+            right,
+            bottom,
+            min_width: width,
+            width,
+            border: UiRect::all(Val::Px(1.)),
+            ..default()
+        },
+        BackgroundColor(Color::linear_rgba(0., 0., 0., 0.8)),
+        BorderColor(Color::linear_rgb(0.8, 0.8, 0.8)),
+        BorderRadius::all(Val::Px(8.)),
+        ZIndex(3000),
+        children![
+            (
+                Node {
+                    padding: UiRect::all(Val::Px(3.)),
+                    margin: UiRect::all(Val::Px(8.)),
+                    ..default()
+                },
+                Text::new(demo.name.clone()),
+                TextColor(Color::linear_rgb(1., 1., 1.)),
+                TextFont::from_font_size(18.),
+            ),
+            (
+                Node {
+                    padding: UiRect::all(Val::Px(3.)),
+                    margin: UiRect::all(Val::Px(8.)),
+                    ..default()
+                },
+                Text::new(demo.desc.clone()),
+                TextColor(Color::linear_rgb(0.8, 0.8, 0.8)),
+                TextFont::from_font_size(12.),
+            )
+        ],
+        UiTargetCamera(ui_camera),
+    ));
+}

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -2,9 +2,9 @@
 //! or not when the entity is invisible.
 //!
 //! This example spawns two effects:
-//! - The top one is only simulated when visible
+//! - The bottom one is only simulated when visible
 //!   ([`SimulationCondition::WhenVisible`]; default behavior).
-//! - The bottom one is always simulated, even when invisible
+//! - The top one is always simulated, even when invisible
 //!   ([`SimulationCondition::Always`]).
 //!
 //! A system updates the visibility of the effects, toggling it ON and OFF. We
@@ -18,8 +18,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("visibility.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("visibility")
+    let app_exit = utils::DemoApp::new("visibility")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -18,7 +18,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("visibility.txt");
+const DEMO_DESC: &str = include_str!("visibility.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("visibility")

--- a/examples/visibility.txt
+++ b/examples/visibility.txt
@@ -1,0 +1,7 @@
+This example shows how visibility affects particle simulation.
+
+The bottom effect uses the default SimulationCondition::WhenVisible. When the effect is hidden, the simulation is suspended, and resumes at the last position once visible again. This is the recommended setup for most effects, as this is the most efficient.
+
+The top effect uses SimulationCondition::Always, which instructs Hanabi to always simulate the effect even when it's invisible. This is useful when the effect needs to mark a continuation, for example if the effect's timing is synchronized with other application elements, but means the application is spending time simulating an effect which is invisible.
+
+Both effects spawn all particles with the same constant velocity. After a few hide and show cycles, we can see that the particles of the top effect are further ahead, because they continued to move while invisible.

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -18,7 +18,7 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
-const DEMO_DESC: &'static str = include_str!("worms.txt");
+const DEMO_DESC: &str = include_str!("worms.txt");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("worms")

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -18,8 +18,12 @@ use bevy_hanabi::prelude::*;
 mod utils;
 use utils::*;
 
+const DEMO_DESC: &'static str = include_str!("worms.txt");
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app_exit = utils::make_test_app("worms")
+    let app_exit = utils::DemoApp::new("worms")
+        .with_desc(DEMO_DESC)
+        .build()
         .add_systems(Startup, setup)
         .run();
     app_exit.into_result()

--- a/examples/worms.txt
+++ b/examples/worms.txt
@@ -1,0 +1,5 @@
+This example shows a complex setup of ribbons and hierarchical effects.
+
+The overall VFX is composed of two effect instances. The first effect occasionally spawns a worm's "head" particle (slightly larger circle) with a random color and direction. It then simulates the motion of that particle alongside a sine curve. While alive, that particle also emits GPU spawn events to instruct the second effect to spawn "body" particles. Those body particles spawn in-place without velocity, but with a shared Attribute::RIBBON_ID (one ID per worm), making Hanabi render them as a single linked mesh.
+
+The setup is more complex than the ribbon example due to the use of several distict ribbons within a same effect, with more than one RIBBON_ID value. Because all particles for a single worm must share the same characteristics (color, ribbon ID, etc.), those attributes are derived from the parent particle.

--- a/gpu_tests/empty_effect.rs
+++ b/gpu_tests/empty_effect.rs
@@ -32,6 +32,6 @@ fn timeout(mut frame: ResMut<Frame>, mut ev_app_exit: EventWriter<AppExit>) {
     frame.0 += 1;
     if frame.0 >= 10 {
         info!("SUCCESS!");
-        ev_app_exit.send(AppExit::Success);
+        ev_app_exit.write(AppExit::Success);
     }
 }

--- a/gpu_tests/properties.rs
+++ b/gpu_tests/properties.rs
@@ -54,7 +54,7 @@ fn timeout(
     frame.0 += 1;
 
     if frame.0 == 10 {
-        let (_, mut effect) = query.single_mut();
+        let (_, mut effect) = query.single_mut().unwrap();
 
         // New effect without any property
         let mut module = Module::default();
@@ -67,12 +67,12 @@ fn timeout(
     }
 
     if frame.0 == 15 {
-        let (entity, _) = query.single();
-        commands.entity(entity).despawn_recursive();
+        let (entity, _) = query.single().unwrap();
+        commands.entity(entity).despawn();
     }
 
     if frame.0 >= 20 {
         info!("SUCCESS!");
-        ev_app_exit.send(AppExit::Success);
+        ev_app_exit.write(AppExit::Success);
     }
 }

--- a/gpu_tests/single_particle.rs
+++ b/gpu_tests/single_particle.rs
@@ -50,6 +50,6 @@ fn timeout(mut frame: ResMut<Frame>, mut ev_app_exit: EventWriter<AppExit>) {
     frame.0 += 1;
     if frame.0 >= 1000 {
         info!("SUCCESS!");
-        ev_app_exit.send(AppExit::Success);
+        ev_app_exit.write(AppExit::Success);
     }
 }

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -1,26 +1,26 @@
 @echo on
 echo Run all examples
 REM 3D
-cargo r --example firework --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example portal --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example expr --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example spawn --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example multicam --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example visibility --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example random --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example spawn_on_command --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example activate --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/bevy_ui bevy/default_font 3d "
-cargo r --example force_field --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example init --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example lifetime --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example ordering --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
-cargo r --example ribbon --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr 3d "
+cargo r --example firework
+cargo r --example portal
+cargo r --example expr
+cargo r --example spawn
+cargo r --example multicam
+cargo r --example visibility
+cargo r --example random
+cargo r --example spawn_on_command
+cargo r --example activate
+cargo r --example force_field
+cargo r --example init
+cargo r --example lifetime
+cargo r --example ordering
+cargo r --example ribbon
 REM 3D + PNG
-cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/png 3d "
-cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/png 3d "
-cargo r --example billboard --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/png 3d "
-cargo r --example worms --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/png 3d "
-cargo r --example instancing --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/png 3d "
-cargo r --example puffs --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_pbr bevy/bevy_scene bevy/bevy_gltf bevy/bevy_animation bevy/png 3d"
+cargo r --example gradient
+cargo r --example circle
+cargo r --example billboard
+cargo r --example worms
+cargo r --example instancing
+cargo r --example puffs
 REM 2D
-cargo r --example 2d --no-default-features --features="bevy/bevy_winit bevy/bevy_window bevy/bevy_sprite 2d "
+cargo r --example 2d

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -1,25 +1,25 @@
 echo Run all examples
 # 3D
-cargo r --example firework --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example portal --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example expr --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example spawn --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example multicam --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example visibility --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example random --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example spawn_on_command --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example activate --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_ui bevy/default_font 3d "
-cargo r --example force_field --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example init --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example lifetime --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example ordering --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
-cargo r --example ribbon --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr 3d "
+cargo r --example firework
+cargo r --example portal
+cargo r --example expr
+cargo r --example spawn
+cargo r --example multicam
+cargo r --example visibility
+cargo r --example random
+cargo r --example spawn_on_command
+cargo r --example activate
+cargo r --example force_field
+cargo r --example init
+cargo r --example lifetime
+cargo r --example ordering
+cargo r --example ribbon
 # 3D + PNG
-cargo r --example gradient --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d "
-cargo r --example circle --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d "
-cargo r --example billboard --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d "
-cargo r --example worms --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d "
-cargo r --example instancing --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/png 3d "
-cargo r --example puffs --no-default-features --features="bevy/bevy_winit bevy/bevy_pbr bevy/bevy_scene bevy/bevy_gltf bevy/bevy_animation bevy/png 3d"
+cargo r --example gradient
+cargo r --example circle
+cargo r --example billboard
+cargo r --example worms
+cargo r --example instancing
+cargo r --example puffs
 # 2D
-cargo r --example 2d --no-default-features --features="bevy/bevy_winit bevy/bevy_sprite 2d "
+cargo r --example 2d

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -774,7 +774,9 @@ mod tests {
     use bevy::prelude::*;
 
     use super::*;
-    use crate::{EvalContext, ModifierContext, ParticleLayout, PropertyLayout, ShaderWriter};
+    use crate::{
+        node::Node as _, EvalContext, ModifierContext, ParticleLayout, PropertyLayout, ShaderWriter,
+    };
 
     #[test]
     fn add() {


### PR DESCRIPTION
Add some basic UI to all examples, to describe what the example is doing and what feature of Hanabi it's demonstrating.

Remove the world inspector UI and the dependency of examples to `bevy_egui` and `bevy-inspector-egui`.