### PR TITLE
Add `particle` access in the fragment shader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1123,6 +1123,9 @@ fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
             if render_context.needs_normal {
                 layout_flags |= LayoutFlags::NEEDS_NORMAL;
             }
+            if render_context.needs_particle_fragment {
+                layout_flags |= LayoutFlags::NEEDS_PARTICLE_FRAGMENT;
+            }
 
             let alpha_cutoff_code = if let AlphaMode::Mask(cutoff) = &asset.alpha_mode {
                 render_context.eval(&module, *cutoff).unwrap_or_else(|err| {
@@ -2108,6 +2111,10 @@ else { return c1; }
             shader_defs.insert("LOCAL_SPACE_SIMULATION".into(), ShaderDefValue::Bool(true));
             shader_defs.insert("NEEDS_UV".into(), ShaderDefValue::Bool(true));
             shader_defs.insert("NEEDS_NORMAL".into(), ShaderDefValue::Bool(false));
+            shader_defs.insert(
+                "NEEDS_PARTICLE_FRAGMENT".into(),
+                ShaderDefValue::Bool(false),
+            );
             shader_defs.insert(
                 "PARTICLE_SCREEN_SPACE_SIZE".into(),
                 ShaderDefValue::Bool(true),

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -387,6 +387,8 @@ pub struct RenderContext<'a> {
     pub needs_uv: bool,
     /// The particle needs normals for lighting effects.
     pub needs_normal: bool,
+    /// The particle needs access to its data in the fragment shader.
+    pub needs_particle_fragment: bool,
     /// Counter for unique variable names.
     var_counter: u32,
     /// Cache of evaluated expressions.
@@ -415,6 +417,7 @@ impl<'a> RenderContext<'a> {
             size_gradients: HashMap::default(),
             needs_uv: false,
             needs_normal: false,
+            needs_particle_fragment: false,
             var_counter: 0,
             expr_cache: Default::default(),
             is_attribute_pointer: false,
@@ -429,6 +432,11 @@ impl<'a> RenderContext<'a> {
     /// Mark the rendering shader as needing normals.
     pub fn set_needs_normal(&mut self) {
         self.needs_normal = true;
+    }
+
+    /// Mark the rendering shader as needing particle data in the fragment shader.
+    pub fn set_needs_particle_fragment(&mut self) {
+        self.needs_particle_fragment = true;
     }
 
     /// Add a color gradient.

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -256,7 +256,7 @@ impl EffectBuffer {
             // @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
             BindGroupLayoutEntry {
                 binding: 0,
-                visibility: ShaderStages::VERTEX,
+                visibility: ShaderStages::VERTEX_FRAGMENT,
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: true },
                     has_dynamic_offset: false,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1851,6 +1851,9 @@ pub(crate) struct ParticleRenderPipelineKey {
     /// Key: NEEDS_NORMAL
     /// The effect needs normals.
     needs_normal: bool,
+    /// Key: NEEDS_PARTICLE_IN_FRAGMENT
+    /// The effect needs access to the particle index and buffer in the fragment shader.
+    needs_particle_fragment: bool,
     /// Key: RIBBONS
     /// The effect has ribbons.
     ribbons: bool,
@@ -1890,6 +1893,7 @@ impl Default for ParticleRenderPipelineKey {
             flipbook: false,
             needs_uv: false,
             needs_normal: false,
+            needs_particle_fragment: false,
             ribbons: false,
             #[cfg(all(feature = "2d", feature = "3d"))]
             pipeline_mode: PipelineMode::Camera3d,
@@ -1915,7 +1919,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
             // @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
             BindGroupLayoutEntry {
                 binding: 0,
-                visibility: ShaderStages::VERTEX,
+                visibility: ShaderStages::VERTEX_FRAGMENT,
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: true },
                     has_dynamic_offset: false,
@@ -1998,6 +2002,10 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         // Key: NEEDS_NORMAL
         if key.needs_normal {
             shader_defs.push("NEEDS_NORMAL".into());
+        }
+
+        if key.needs_particle_fragment {
+            shader_defs.push("NEEDS_PARTICLE_FRAGMENT".into());
         }
 
         // Key: RIBBONS
@@ -2893,6 +2901,8 @@ bitflags! {
         /// a particle init or update pass to read the data of a parent particle, for
         /// example to inherit some of the attributes.
         const READ_PARENT_PARTICLE = (1 << 11);
+        /// The effect access to the particle data in the fragment shader.
+        const NEEDS_PARTICLE_FRAGMENT = (1 << 12);
     }
 }
 
@@ -4917,6 +4927,9 @@ fn emit_sorted_draw<T, F>(
             let needs_normal = effect_batch
                 .layout_flags
                 .contains(LayoutFlags::NEEDS_NORMAL);
+            let needs_particle_fragment = effect_batch
+                .layout_flags
+                .contains(LayoutFlags::NEEDS_PARTICLE_FRAGMENT);
             let ribbons = effect_batch.layout_flags.contains(LayoutFlags::RIBBONS);
             let image_count = effect_batch.texture_layout.layout.len() as u8;
 
@@ -4959,6 +4972,7 @@ fn emit_sorted_draw<T, F>(
                     flipbook,
                     needs_uv,
                     needs_normal,
+                    needs_particle_fragment,
                     ribbons,
                     #[cfg(all(feature = "2d", feature = "3d"))]
                     pipeline_mode,
@@ -5101,6 +5115,9 @@ fn emit_binned_draw<T, F, G>(
             let needs_normal = effect_batch
                 .layout_flags
                 .contains(LayoutFlags::NEEDS_NORMAL);
+            let needs_particle_fragment = effect_batch
+                .layout_flags
+                .contains(LayoutFlags::NEEDS_PARTICLE_FRAGMENT);
             let ribbons = effect_batch.layout_flags.contains(LayoutFlags::RIBBONS);
             let image_count = effect_batch.texture_layout.layout.len() as u8;
             let render_mesh = render_meshes.get(effect_batch.mesh);
@@ -5141,6 +5158,7 @@ fn emit_binned_draw<T, F, G>(
                     flipbook,
                     needs_uv,
                     needs_normal,
+                    needs_particle_fragment,
                     ribbons,
                     #[cfg(all(feature = "2d", feature = "3d"))]
                     pipeline_mode,

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -23,6 +23,9 @@ struct VertexOutput {
 #ifdef NEEDS_NORMAL
     @location(2) normal: vec3<f32>,
 #endif
+#ifdef NEEDS_PARTICLE_FRAGMENT
+    @location(3) particle_index: u32,
+#endif
 }
 
 @group(0) @binding(0) var<uniform> view: View;
@@ -152,6 +155,10 @@ fn vertex(
 
     var out: VertexOutput;
 
+#ifdef NEEDS_PARTICLE_FRAGMENT
+    out.particle_index = particle_index;
+#endif // NEEDS_PARTICLE_FRAGMENT
+
 #ifdef RIBBONS
     // Discard first instance; we draw from second one, and link to previous one
     if (instance_index == 0) {
@@ -226,6 +233,9 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
 #ifdef NEEDS_NORMAL
     var normal = in.normal;
 #endif
+#ifdef NEEDS_PARTICLE_FRAGMENT
+    var particle = particle_buffer.particles[in.particle_index];
+#endif // NEEDS_PARTICLE_FRAGMENT
 
 {{FRAGMENT_MODIFIERS}}
 


### PR DESCRIPTION
Allow `RenderModifier`s fragment shader to access the `Particle` buffer (just like the vertex shader) with `RenderContext::set_needs_particle_fragment`

My use case is sampling a small part of a noise texture for each rendered particle
I want to sample a different part of the noise texture according to a seed
So i need access to the particle custom attributes in the fragment shader

let me know if it's worth upstreaming