### PR TITLE
Add `ParticleEffect::prng_seed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Compatible with Bevy 0.16
+- Silenced the warning "Updated metadata entry {N} for effect", which was triggering on all newly spawned effects. (#471)
+
+### Fixed
+
+- Allow changing the PRNG seed on a per-instance basis by assigning the new `ParticleEffect::prng_seed`,
+  which overrides the default value in `EffectAsset::prng_seed`.
+
 ## [0.15.1] 2025-04-23
 
 ### Fixed

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -298,7 +298,10 @@ pub struct EffectAsset {
     pub simulation_condition: SimulationCondition,
     /// Seed for the pseudo-random number generator.
     ///
-    /// This is uploaded to GPU and used for the various random expressions and
+    /// This value is used as the default value for all [`ParticleEffect`]
+    /// instances based on this asset. You can override this on a per-instance
+    /// basis by setting [`ParticleEffect::prng_seed`]. The resulting value
+    /// is uploaded to GPU and used for the various random expressions and
     /// quantities computed in shaders.
     pub prng_seed: u32,
     /// Init modifier defining the effect.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,12 +654,21 @@ pub struct EffectVisibilityClass;
 pub struct ParticleEffect {
     /// Handle of the effect to instantiate.
     pub handle: Handle<EffectAsset>,
+    /// Optional per-instance PRNG seed.
+    ///
+    /// Set this value to `Some(seed)` to override the default value set in
+    /// [`EffectAsset::prng_seed`] for this effect instance. By default this is
+    /// `None`, and the instance uses the same PRNG seed as its [`EffectAsset`].
+    pub prng_seed: Option<u32>,
 }
 
 impl ParticleEffect {
     /// Create a new particle effect instance from an existing asset.
     pub fn new(handle: Handle<EffectAsset>) -> Self {
-        Self { handle }
+        Self {
+            handle,
+            prng_seed: None,
+        }
     }
 }
 
@@ -1396,7 +1405,7 @@ impl CompiledParticleEffect {
         // diff what may or may not have changed.
         self.asset = instance.handle.clone();
         self.simulation_condition = asset.simulation_condition;
-        self.prng_seed = asset.prng_seed;
+        self.prng_seed = instance.prng_seed.unwrap_or(asset.prng_seed);
 
         // Check if the instance changed. If so, rebuild some data from this compiled
         // effect based on the new data of the effect instance.

--- a/src/render/gpu_buffer.rs
+++ b/src/render/gpu_buffer.rs
@@ -178,7 +178,7 @@ impl<T: Pod + ShaderType + ShaderSize> GpuBuffer<T> {
     pub fn free(&mut self, index: u32) {
         if index < self.used_size {
             debug_assert!(
-                !self.free_list.iter().any(|i| *i == index),
+                !self.free_list.contains(&index),
                 "Double-free in GpuBuffer at index #{}",
                 index
             );

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1257,6 +1257,7 @@ mod test {
                             InheritedVisibility::default(),
                             ParticleEffect {
                                 handle: handle.clone(),
+                                ..default()
                             },
                         ))
                         .id()
@@ -1264,6 +1265,7 @@ mod test {
                     world
                         .spawn((ParticleEffect {
                             handle: handle.clone(),
+                            ..default()
                         },))
                         .id()
                 };


### PR DESCRIPTION
Add a new field `prng_seed` on the particle effect component, which enables overridding the default PRNG seed value inherited from the `EffectAsset` on a per-instance basis. This allows making truly random effect instances.