### PR TITLE
Disable motion integration in `init.rs` example

### DIFF
--- a/examples/init.rs
+++ b/examples/init.rs
@@ -43,6 +43,9 @@ where
 
     EffectAsset::new(32768, SpawnerSettings::once(COUNT.into()), writer.finish())
         .with_name(name)
+        // Disable motion integration; in this demo particles don't move. This silences some warning
+        // about missing the VELOCITY attribute.
+        .with_motion_integration(MotionIntegration::None)
         .with_simulation_space(SimulationSpace::Local)
         .init(init)
         .render(OrientModifier::new(OrientMode::FaceCameraPosition))


### PR DESCRIPTION
Particles in that example don't move. Having the default motion integration triggers a warning because there's no `VELOCITY` attribute on particles. Disable the motion integration to remove the warning, since motion integration is not needed.