### PR TITLE
Allow multiple effects to be packed into a single buffer again.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1178,8 +1178,8 @@ fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
                 let tex_index = bind_index;
                 let sampler_index = bind_index + 1;
                 material_bindings_code.push_str(&format!(
-                    "@group(2) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
-@group(2) @binding({sampler_index}) var material_sampler_{slot}: sampler;
+                    "@group(3) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
+@group(3) @binding({sampler_index}) var material_sampler_{slot}: sampler;
 "
                 ));
                 bind_index += 2;

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -174,11 +174,7 @@ pub enum BufferState {
 
 impl EffectBuffer {
     /// Minimum buffer capacity to allocate, in number of particles.
-    // FIXME - Batching is broken due to binding a single GpuSpawnerParam instead of
-    // N, and inability for a particle index to tell which Spawner it should
-    // use. Setting this to 1 effectively ensures that all new buffers just fit
-    // the effect, so batching never occurs.
-    pub const MIN_CAPACITY: u32 = 1; // 65536; // at least 64k particles
+    pub const MIN_CAPACITY: u32 = 65536; // at least 64k particles
 
     /// Create a new group and a GPU buffer to back it up.
     ///

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -321,16 +321,6 @@ impl EffectBuffer {
         &self.indirect_index_buffer
     }
 
-    #[inline]
-    pub fn particle_offset(&self, row: u32) -> u32 {
-        self.particle_layout.min_binding_size().get() as u32 * row
-    }
-
-    #[inline]
-    pub fn indirect_index_offset(&self, row: u32) -> u32 {
-        row * 12
-    }
-
     /// Return a binding for the entire particle buffer.
     pub fn max_binding(&self) -> BindingResource {
         let capacity_bytes = self.capacity as u64 * self.particle_layout.min_binding_size().get();
@@ -645,8 +635,11 @@ pub struct EffectCache {
     /// pass.
     metadata_init_bind_group_layout: [Option<BindGroupLayout>; 2],
     /// Cache of bind group layouts for the metadata@3 bind group of the
-    /// updatepass.
+    /// update pass.
     metadata_update_bind_group_layouts: HashMap<u32, BindGroupLayout>,
+    /// Cache of bind group layout for the metadata@2 bind group of the
+    /// render pass.
+    metadata_render_bind_group_layout: Option<BindGroupLayout>,
 }
 
 impl EffectCache {
@@ -657,6 +650,7 @@ impl EffectCache {
             particle_bind_group_layouts: default(),
             metadata_init_bind_group_layout: [None, None],
             metadata_update_bind_group_layouts: default(),
+            metadata_render_bind_group_layout: None,
         }
     }
 
@@ -884,6 +878,22 @@ impl EffectCache {
     ) -> Option<&BindGroupLayout> {
         self.metadata_update_bind_group_layouts
             .get(&num_event_buffers)
+    }
+
+    /// Get the bind group layout for the metadata@2 bind group of the
+    /// render pass.
+    pub fn metadata_render_bind_group_layout(&self) -> Option<&BindGroupLayout> {
+        self.metadata_render_bind_group_layout.as_ref()
+    }
+
+    /// Ensure a bind group layout exists for the metadata@2 bind group of
+    /// the render pass.
+    pub fn ensure_metadata_render_bind_group_layout(&mut self) {
+        if self.metadata_render_bind_group_layout.is_none() {
+            self.metadata_render_bind_group_layout = Some(create_metadata_render_bind_group_layout(
+                &self.render_device,
+            ))
+        }
     }
 
     //
@@ -1118,6 +1128,33 @@ fn create_metadata_update_bind_group_layout(
         num_event_buffers,
     );
     render_device.create_bind_group_layout(&label[..], &entries)
+}
+
+/// Create the bind group layout for the metadata@2 bind group of the render
+/// pass.
+fn create_metadata_render_bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
+    let storage_alignment = render_device.limits().min_storage_buffer_offset_alignment;
+    let effect_metadata_size = GpuEffectMetadata::aligned_size(storage_alignment);
+
+    // @group(2) @binding(0) var<storage, read> effect_metadata :
+    // EffectMetadata;
+
+    trace!("Creating particle bind group layout for render.",);
+    render_device.create_bind_group_layout(
+        "hanabi:bind_group_layout:render",
+        &[BindGroupLayoutEntry {
+            binding: 0,
+            visibility: ShaderStages::VERTEX,
+            ty: BindingType::Buffer {
+                ty: BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
+                // This WGSL struct is manually padded, so the Rust type GpuEffectMetadata doesn't
+                // reflect its true min size.
+                min_binding_size: Some(effect_metadata_size),
+            },
+            count: None,
+        }],
+    )
 }
 
 #[cfg(all(test, feature = "gpu_tests"))]

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -168,7 +168,7 @@ impl SortBindGroups {
                     visibility: ShaderStages::COMPUTE,
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: true,
+                        has_dynamic_offset: false,
                         min_binding_size: Some(NonZeroU64::new(12).unwrap()), // ping/pong+dead
                     },
                     count: None,
@@ -310,7 +310,7 @@ impl SortBindGroups {
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
                                 ty: BufferBindingType::Storage { read_only: true },
-                                has_dynamic_offset: true,
+                                has_dynamic_offset: false,
                                 min_binding_size: Some(key.particle_min_binding_size.into()),
                             },
                             count: None,
@@ -321,7 +321,7 @@ impl SortBindGroups {
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
                                 ty: BufferBindingType::Storage { read_only: true },
-                                has_dynamic_offset: true,
+                                has_dynamic_offset: false,
                                 min_binding_size: Some(NonZeroU64::new(12).unwrap()), // ping/pong+dead
                             },
                             count: None,

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -121,7 +121,7 @@ struct EffectMetadata {
     first_index_or_vertex_offset: u32,
     /// Vertex offset (if indexed) or base instance (if non-indexed).
     vertex_offset_or_base_instance: i32,
-    /// Base instance (if indexed).
+    /// Base instance.
     base_instance: u32,
 
     /// Number of particles alive after the init pass, used to calculate the number

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -85,7 +85,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let read_index = 1u - write_index;
 
     // Recycle a dead particle from the destination group
-    let dead_index = atomicSub(&effect_metadata.dead_count, 1u) - 1u;
+    let dead_index = atomicSub(&effect_metadata.dead_count, 1u) - 1u +
+        effect_metadata.base_instance;
     let particle_index = indirect_buffer.indices[3u * dead_index + 2u];
 
     let particle_counter = atomicAdd(&effect_metadata.particle_counter, 1u);
@@ -130,7 +131,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     atomicAdd(&effect_metadata.alive_count, 1u);
 
     // Add to alive list
-    let instance_index = atomicAdd(&effect_metadata.instance_count, 1u);
+    let instance_index = atomicAdd(&effect_metadata.instance_count, 1u) +
+        effect_metadata.base_instance;
     indirect_buffer.indices[3u * instance_index + write_index] = particle_index;
 
     // Write back new particle

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -1,6 +1,6 @@
 #import bevy_render::view::View
 #import bevy_hanabi::vfx_common::{
-    IndirectBuffer, SimParams, Spawner,
+    EffectMetadata, IndirectBuffer, SimParams, Spawner,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
     rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
@@ -34,6 +34,9 @@ struct VertexOutput {
 @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
 @group(1) @binding(2) var<storage, read> spawner : Spawner;
+
+// "metadata" group @2
+@group(2) @binding(0) var<storage, read> effect_metadata : EffectMetadata;
 
 {{MATERIAL_BINDINGS}}
 
@@ -161,7 +164,7 @@ fn vertex(
 
 #ifdef RIBBONS
     // Discard first instance; we draw from second one, and link to previous one
-    if (instance_index == 0) {
+    if (instance_index == effect_metadata.base_instance) {
         out.position = vec4(0.0);
         return out;
     }

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -50,6 +50,6 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         sort_buffer.pairs[j] = kv;
     }
 
-    // Clear for next frame
+    // Clear for next effect
     sort_buffer.count = 0;
 }

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -38,5 +38,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let write_index = effect_metadata.ping;
 
     let particle_index = sort_buffer.pairs[row_index].value;
-    indirect_index_buffer.data[row_index * 3u + write_index] = particle_index;
+    indirect_index_buffer.data[
+        (row_index + effect_metadata.base_instance) * 3u + write_index
+    ] = particle_index;
 }

--- a/src/render/vfx_sort_fill.wgsl
+++ b/src/render/vfx_sort_fill.wgsl
@@ -38,7 +38,9 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     }
 
     let read_index = effect_metadata.ping;
-    let particle_index = indirect_index_buffer[thread_index * 3u + read_index];
+    let particle_index = indirect_index_buffer[
+        (thread_index + effect_metadata.base_instance) * 3u + read_index
+    ];
 
     let particle_offset = particle_index * effect_metadata.particle_stride;
     let key_offset = particle_offset + effect_metadata.sort_key_offset;


### PR DESCRIPTION
This commit restores the functionality present in older versions of Hanabi that allows multiple effects to be packed into a single buffer. This is in preparation for reenabling batching.

I use the `base_instance` field on the effects metadata to supply the offset within each indirect buffer to the shader. This is convenient, because it naturally paves the way to use multi-draw as a follow-up, and it avoids having to add more fields to the effects metadata.

As suggested in the code, I rewrote sorting to be prior to batching instead of after batching. It now uses a modified version of [Tarjan's algorithm] to sort the effects into the optimum batching order. Not only does it make sure that parents precede children, but it also groups buffers together, and sorts by offset, in order to make batching easier as a follow-up. Sorting by offset within the buffer should enable the use of binary search in order for the shader to map from the global thread ID to the effect instance.

[Tarjan's algorithm]: https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search