### PR TITLE
Fix codegen bugs around modifier and color mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug in `ColorBlendMask::to_component()` which ignored the last (alpha) component. (#479)
+- Fixed a codegen bug in `ColorOverLifetimeModifier` when values other than `ColorBlendMask::RGBA` are used. (#479)
+
 ## [0.16.0] 2025-05-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.16.0"
+version = "0.17.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 rust-version = "1.85.0"


### PR DESCRIPTION
Fix two bugs in codegen:
- `ColorBlendMask::to_component()` had a wrong `0..3` iterator for components, should be `0..=3` to include the Alpha one.
- `ColorOverLifetimeModifier` had a typo (double line ending), and was using some invalid WGSL construct (can't assign `color.rgb`, need to construct a full `vec4<f32>` then assign as a whole).

Fixes #479