### PR TITLE
Fix alignment of `vec3` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug in `ColorBlendMask::to_component()` which ignored the last (alpha) component. (#479)
 - Fixed a codegen bug in `ColorOverLifetimeModifier` when values other than `ColorBlendMask::RGBA` are used. (#479)
+- Fixed a bug where `PropertyLayout` was misaligning `vec3` properties, leading to incorrect values on GPU. (#478)
 
 ## [0.16.0] 2025-05-31
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -625,44 +625,37 @@ impl PropertyLayout {
         let index2 = index2 + (num2 / 2) * 2;
         let num2 = num2 % 2;
 
-        // Enqueue { Float3, Float2 } or { Float2, Float1 }
+        // Here we're always 16-byte aligned
+
+        // Enqueue { Float3+, Float2? } or { Float2?, Float1+ }
         if num3 > num1 {
             // Float1 is done, some Float3 left, and at most one Float2
             debug_assert_eq!(num1, 0);
 
-            // Try 3/3/2, fallback to 3/2
-            let num3head = if num2 > 0 {
-                debug_assert_eq!(num2, 1);
-                let num3head = num3.min(2);
-                for i in 0..num3head {
-                    let prop = properties[index3 + i];
-                    let entry = PropertyLayoutEntry {
-                        property: prop.clone(),
-                        offset,
-                    };
-                    offset += 12;
-                    layout.push(entry);
-                }
-                let prop = properties[index2];
-                let entry = PropertyLayoutEntry {
-                    property: prop.clone(),
-                    offset,
-                };
-                offset += 8;
-                layout.push(entry);
-                num3head
-            } else {
-                0
-            };
+            // Note: WGSL doesn't support packing 3/3/2 in 32 bytes, because vec3<f32> needs
+            // to be aligned to 16 bytes always. So we just output all remaining types as is
+            // proper align.
 
-            // End with remaining Float3
-            for i in num3head..num3 {
+            for i in 0..num3 {
                 let prop = properties[index3 + i];
                 let entry = PropertyLayoutEntry {
                     property: prop.clone(),
                     offset,
                 };
-                offset += 12;
+                // WARN: vec3<f32> is 16-byte aligned, not 12! And the last vec2<f32> if any
+                // will also benefit from this since it needs 8-byte alignment.
+                offset += 16;
+                layout.push(entry);
+            }
+
+            // Emit the single Float2 now if any
+            if num2 > 0 {
+                debug_assert_eq!(num2, 1);
+                let prop = properties[index2];
+                let entry = PropertyLayoutEntry {
+                    property: prop.clone(),
+                    offset,
+                };
                 layout.push(entry);
             }
         } else {
@@ -1039,6 +1032,40 @@ mod tests {
     vec3: vec3<f32>,
     f32: f32,
     vec2: vec2<f32>,
+}
+"#
+                .to_string()
+            )
+        );
+    }
+
+    // Regression test for #478
+    #[test]
+    fn layout_padding_vec3() {
+        let prop1 = Property::new("vec4a", Vec4::Y);
+        let prop2 = Property::new("vec3b", Vec3::ZERO);
+        let prop3 = Property::new("vec3c", Vec3::ONE);
+        let layout = PropertyLayout::new([&prop1, &prop2, &prop3]);
+        assert!(!layout.is_empty());
+        assert_eq!(layout.cpu_size(), 44); // 16 + 16 + 12
+        assert_eq!(layout.align(), 16);
+        assert_eq!(layout.min_binding_size(), NonZeroU64::new(48).unwrap());
+        let mut it = layout.properties();
+        // vec4 goes first as it doesn't disrupt the align
+        assert_eq!(it.next(), Some((0, &prop1)));
+        // vec3 goes next, with padding
+        assert_eq!(it.next(), Some((16, &prop2)));
+        // [padding] @24,+4
+        assert_eq!(it.next(), Some((32, &prop3)));
+        assert_eq!(it.next(), None);
+        let s = layout.generate_code();
+        assert_eq!(
+            s,
+            Some(
+                r#"struct Properties {
+    vec4a: vec4<f32>,
+    vec3b: vec3<f32>,
+    vec3c: vec3<f32>,
 }
 "#
                 .to_string()


### PR DESCRIPTION
`PropertyLayout` was incorrectly assuming that `vec3` and `vec2` can be packed in a 3/3/2 layout in 32 bytes. This is not the case; WGSL enforces a strict 16-byte alignment per `vec3` field in a struct. This change fixes `PropertyLayout` to emit a layout with proper alignment and implicit padding.

Fixes #478