### PR TITLE
Fix velocity in `firework.rs` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in `ColorBlendMask::to_component()` which ignored the last (alpha) component. (#479)
 - Fixed a codegen bug in `ColorOverLifetimeModifier` when values other than `ColorBlendMask::RGBA` are used. (#479)
 - Fixed a bug where `PropertyLayout` was misaligning `vec3` properties, leading to incorrect values on GPU. (#478)
+- Fixed a small bug in the `firework.rs` example where the sparkle trail velocity was initialized randomly
+  in [0:1] instead of [-1:1] like the comment claimed. (#476)
 
 ## [0.16.0] 2025-05-31
 

--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -131,7 +131,9 @@ fn create_sparkle_trail_effect() -> EffectAsset {
     let init_pos = InheritAttributeModifier::new(Attribute::POSITION);
 
     // The velocity is random in any direction
-    let vel = writer.rand(VectorType::VEC3F).normalized();
+    let vel = writer.rand(VectorType::VEC3F);
+    let vel = vel * writer.lit(2.) - writer.lit(1.); // remap [0:1] to [-1:1]
+    let vel = vel.normalized();
     let speed = writer.lit(1.); //.uniform(writer.lit(4.));
     let vel = (vel * speed).expr();
     let init_vel = SetAttributeModifier::new(Attribute::VELOCITY, vel);


### PR DESCRIPTION
Fix the sparkle trail velocity to be random in [-1:1] like the comment claims, instead of [0:1] like `rand()` returns.

Fixes #476