### PR TITLE
Transitively gather attributes from expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where `PropertyLayout` was misaligning `vec3` properties, leading to incorrect values on GPU. (#478)
 - Fixed a small bug in the `firework.rs` example where the sparkle trail velocity was initialized randomly
   in [0:1] instead of [-1:1] like the comment claimed. (#476)
+- Fixed a bug in `EffectAsset::particle_layout()` where attributes used in expressions but not directly
+  referenced by a modifier were not added to the layout, leading to invalid shader codegen. (#440)
 
 ## [0.16.0] 2025-05-31
 

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -104,7 +104,7 @@
 
 use std::{cell::RefCell, num::NonZeroU32, rc::Rc};
 
-use bevy::{prelude::default, reflect::Reflect};
+use bevy::{platform::collections::HashSet, prelude::default, reflect::Reflect};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -389,6 +389,16 @@ impl Module {
         #[allow(unsafe_code)]
         unsafe {
             TextureHandle::new_unchecked(self.texture_layout.layout.len())
+        }
+    }
+
+    /// Insert into the given set all attributes referenced by any
+    /// [`AttributeExpr`] present in the module.
+    pub fn gather_attributes(&self, set: &mut HashSet<Attribute>) {
+        for expr in &self.expressions {
+            if let Expr::Attribute(attr) = expr {
+                set.insert(attr.attr);
+            }
         }
     }
 


### PR DESCRIPTION
Gather attributes transitively used in expressions used in modifiers. This ensures the generated code is valid, and not referencing attributes not part of the `ParticleLayout`.

Fixes #440