### PR TITLE
Put spawners into an array in the shader instead of using dynamic offsets.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1178,8 +1178,8 @@ fn append_spawn_events_{0}(particle_index: u32, count: u32) {{
                 let tex_index = bind_index;
                 let sampler_index = bind_index + 1;
                 material_bindings_code.push_str(&format!(
-                    "@group(2) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
-@group(2) @binding({sampler_index}) var material_sampler_{slot}: sampler;
+                    "@group(3) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
+@group(3) @binding({sampler_index}) var material_sampler_{slot}: sampler;
 "
                 ));
                 bind_index += 2;

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -987,7 +987,7 @@ fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {{
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(1) @binding(0) var<storage, read_write> particle_buffer : ParticleBuffer;
-@group(2) @binding(0) var<storage, read_write> spawner : Spawner; // NOTE - same group as init
+@group(2) @binding(0) var<storage, read_write> spawners : array<Spawner>; // NOTE - same group as init
 
 @compute @workgroup_size(64)
 fn main() {{
@@ -1078,7 +1078,7 @@ struct View {{
 }}
 
 fn frand() -> f32 {{ return 0.0; }}
-fn get_camera_position_effect_space() -> vec3<f32> {{ return vec3<f32>(); }}
+fn get_camera_position_effect_space(spawner_index: u32) -> vec3<f32> {{ return vec3<f32>(); }}
 fn get_camera_rotation_effect_space() -> mat3x3<f32> {{ return mat3x3<f32>(); }}
 
 const tau: f32 = 6.283185307179586476925286766559;

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -623,7 +623,7 @@ axis_z = cam_rot[2].xyz;
                 if let Some(rotation) = self.rotation {
                     let rotation = context.eval(module, rotation)?;
                     context.vertex_code += &format!(
-                        r#"axis_z = normalize(get_camera_position_effect_space() - position);
+                        r#"axis_z = normalize(get_camera_position_effect_space(spawner_index) - position);
 let particle_rot_in_cam_space = {};
 let particle_rot_in_cam_space_cos = cos(particle_rot_in_cam_space);
 let particle_rot_in_cam_space_sin = sin(particle_rot_in_cam_space);
@@ -635,14 +635,14 @@ axis_y = axis_x0 * particle_rot_in_cam_space_sin - axis_y0 * particle_rot_in_cam
                         rotation
                     );
                 } else {
-                    context.vertex_code += r#"axis_z = normalize(get_camera_position_effect_space() - position);
+                    context.vertex_code += r#"axis_z = normalize(get_camera_position_effect_space(spawner_index) - position);
 axis_x = normalize(cross(view.world_from_view[1].xyz, axis_z));
 axis_y = cross(axis_z, axis_x);
 "#;
                 }
             }
             OrientMode::AlongVelocity => {
-                context.vertex_code += r#"let dir = normalize(position - get_camera_position_effect_space());
+                context.vertex_code += r#"let dir = normalize(position - get_camera_position_effect_space(spawner_index));
 axis_x = normalize(particle.velocity);
 axis_y = cross(dir, axis_x);
 axis_z = cross(axis_x, axis_y);

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -174,11 +174,7 @@ pub enum BufferState {
 
 impl EffectBuffer {
     /// Minimum buffer capacity to allocate, in number of particles.
-    // FIXME - Batching is broken due to binding a single GpuSpawnerParam instead of
-    // N, and inability for a particle index to tell which Spawner it should
-    // use. Setting this to 1 effectively ensures that all new buffers just fit
-    // the effect, so batching never occurs.
-    pub const MIN_CAPACITY: u32 = 1; // 65536; // at least 64k particles
+    pub const MIN_CAPACITY: u32 = 65536; // at least 64k particles
 
     /// Create a new group and a GPU buffer to back it up.
     ///

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -271,13 +271,13 @@ impl EffectBuffer {
                 },
                 count: None,
             },
-            // @group(1) @binding(2) var<storage, read> spawner : Spawner;
+            // @group(1) @binding(2) var<storage, read> spawners : array<Spawner>;
             BindGroupLayoutEntry {
                 binding: 2,
                 visibility: ShaderStages::VERTEX,
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: true },
-                    has_dynamic_offset: true,
+                    has_dynamic_offset: false,
                     min_binding_size: Some(spawner_params_size),
                 },
                 count: None,

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -321,16 +321,6 @@ impl EffectBuffer {
         &self.indirect_index_buffer
     }
 
-    #[inline]
-    pub fn particle_offset(&self, row: u32) -> u32 {
-        self.particle_layout.min_binding_size().get() as u32 * row
-    }
-
-    #[inline]
-    pub fn indirect_index_offset(&self, row: u32) -> u32 {
-        row * 12
-    }
-
     /// Return a binding for the entire particle buffer.
     pub fn max_binding(&self) -> BindingResource {
         let capacity_bytes = self.capacity as u64 * self.particle_layout.min_binding_size().get();
@@ -645,8 +635,11 @@ pub struct EffectCache {
     /// pass.
     metadata_init_bind_group_layout: [Option<BindGroupLayout>; 2],
     /// Cache of bind group layouts for the metadata@3 bind group of the
-    /// updatepass.
+    /// update pass.
     metadata_update_bind_group_layouts: HashMap<u32, BindGroupLayout>,
+    /// Cache of bind group layout for the metadata@2 bind group of the
+    /// render pass.
+    metadata_render_bind_group_layout: Option<BindGroupLayout>,
 }
 
 impl EffectCache {
@@ -657,6 +650,7 @@ impl EffectCache {
             particle_bind_group_layouts: default(),
             metadata_init_bind_group_layout: [None, None],
             metadata_update_bind_group_layouts: default(),
+            metadata_render_bind_group_layout: None,
         }
     }
 
@@ -884,6 +878,22 @@ impl EffectCache {
     ) -> Option<&BindGroupLayout> {
         self.metadata_update_bind_group_layouts
             .get(&num_event_buffers)
+    }
+
+    /// Get the bind group layout for the metadata@2 bind group of the
+    /// render pass.
+    pub fn metadata_render_bind_group_layout(&self) -> Option<&BindGroupLayout> {
+        self.metadata_render_bind_group_layout.as_ref()
+    }
+
+    /// Ensure a bind group layout exists for the metadata@2 bind group of
+    /// the render pass.
+    pub fn ensure_metadata_render_bind_group_layout(&mut self) {
+        if self.metadata_render_bind_group_layout.is_none() {
+            self.metadata_render_bind_group_layout = Some(create_metadata_render_bind_group_layout(
+                &self.render_device,
+            ))
+        }
     }
 
     //
@@ -1118,6 +1128,33 @@ fn create_metadata_update_bind_group_layout(
         num_event_buffers,
     );
     render_device.create_bind_group_layout(&label[..], &entries)
+}
+
+/// Create the bind group layout for the metadata@2 bind group of the render
+/// pass.
+fn create_metadata_render_bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
+    let storage_alignment = render_device.limits().min_storage_buffer_offset_alignment;
+    let effect_metadata_size = GpuEffectMetadata::aligned_size(storage_alignment);
+
+    // @group(2) @binding(0) var<storage, read> effect_metadata :
+    // EffectMetadata;
+
+    trace!("Creating particle bind group layout for render.",);
+    render_device.create_bind_group_layout(
+        "hanabi:bind_group_layout:render",
+        &[BindGroupLayoutEntry {
+            binding: 0,
+            visibility: ShaderStages::VERTEX,
+            ty: BindingType::Buffer {
+                ty: BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
+                // This WGSL struct is manually padded, so the Rust type GpuEffectMetadata doesn't
+                // reflect its true min size.
+                min_binding_size: Some(effect_metadata_size),
+            },
+            count: None,
+        }],
+    )
 }
 
 #[cfg(all(test, feature = "gpu_tests"))]

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -155,13 +155,13 @@ impl PropertyCache {
             GpuSpawnerParams::aligned_size(device.limits().min_storage_buffer_offset_alignment);
         let bgl = device.create_bind_group_layout(
             "hanabi:bind_group_layout:no_property",
-            // @group(2) @binding(0) var<storage, read> spawner: Spawner;
+            // @group(2) @binding(0) var<storage, read> spawners: array<Spawner>;
             &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::COMPUTE,
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Storage { read_only: true },
-                    has_dynamic_offset: true,
+                    has_dynamic_offset: false,
                     min_binding_size: Some(spawner_min_binding_size),
                 },
                 count: None,
@@ -225,13 +225,13 @@ impl PropertyCache {
                 let bgl = self.device.create_bind_group_layout(
                     Some(&label[..]),
                     &[
-                        // @group(2) @binding(0) var<storage, read> spawner: Spawner;
+                        // @group(2) @binding(0) var<storage, read> spawners: array<Spawner>;
                         BindGroupLayoutEntry {
                             binding: 0,
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
                                 ty: BufferBindingType::Storage { read_only: true },
-                                has_dynamic_offset: true,
+                                has_dynamic_offset: false,
                                 min_binding_size: Some(spawner_min_binding_size),
                             },
                             count: None,
@@ -362,7 +362,6 @@ impl PropertyBindGroups {
         property_key: &PropertyBindGroupKey,
         property_cache: &PropertyCache,
         spawner_buffer: &Buffer,
-        spawner_buffer_binding_size: NonZeroU64,
         render_device: &RenderDevice,
     ) -> Result<(), ()> {
         let Some(property_buffer) = property_cache.get_buffer(property_key.buffer_index) else {
@@ -405,7 +404,7 @@ impl PropertyBindGroups {
                             resource: BindingResource::Buffer(BufferBinding {
                                 buffer: spawner_buffer,
                                 offset: 0,
-                                size: Some(spawner_buffer_binding_size),
+                                size: None,
                             }),
                         },
                         BindGroupEntry {
@@ -427,7 +426,6 @@ impl PropertyBindGroups {
         &mut self,
         property_cache: &PropertyCache,
         spawner_buffer: &Buffer,
-        spawner_buffer_binding_size: NonZeroU64,
         render_device: &RenderDevice,
     ) -> Result<(), ()> {
         let Some(layout) = property_cache.bind_group_layout(None) else {
@@ -447,7 +445,7 @@ impl PropertyBindGroups {
                     resource: BindingResource::Buffer(BufferBinding {
                         buffer: spawner_buffer,
                         offset: 0,
-                        size: Some(spawner_buffer_binding_size),
+                        size: None,
                     }),
                 }],
             ));

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -168,7 +168,7 @@ impl SortBindGroups {
                     visibility: ShaderStages::COMPUTE,
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: true,
+                        has_dynamic_offset: false,
                         min_binding_size: Some(NonZeroU64::new(12).unwrap()), // ping/pong+dead
                     },
                     count: None,
@@ -310,7 +310,7 @@ impl SortBindGroups {
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
                                 ty: BufferBindingType::Storage { read_only: true },
-                                has_dynamic_offset: true,
+                                has_dynamic_offset: false,
                                 min_binding_size: Some(key.particle_min_binding_size.into()),
                             },
                             count: None,
@@ -321,7 +321,7 @@ impl SortBindGroups {
                             visibility: ShaderStages::COMPUTE,
                             ty: BindingType::Buffer {
                                 ty: BufferBindingType::Storage { read_only: true },
-                                has_dynamic_offset: true,
+                                has_dynamic_offset: false,
                                 min_binding_size: Some(NonZeroU64::new(12).unwrap()), // ping/pong+dead
                             },
                             count: None,

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -121,7 +121,7 @@ struct EffectMetadata {
     first_index_or_vertex_offset: u32,
     /// Vertex offset (if indexed) or base instance (if non-indexed).
     vertex_offset_or_base_instance: i32,
-    /// Base instance (if indexed).
+    /// Base instance.
     base_instance: u32,
 
     /// Number of particles alive after the init pass, used to calculate the number

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -39,9 +39,8 @@ struct Spawner {
     render_pong: u32,
     /// Index of the [`GpuEffectMetadata`] for this effect.
     effect_metadata_index: u32,
-#ifdef SPAWNER_PADDING
+    /// Padding. We always need this, since spawners are packed into an array.
     {{SPAWNER_PADDING}}
-#endif
 }
 
 const SPAWNER_OFFSET_PONG: u32 = 27u;
@@ -178,6 +177,9 @@ struct EffectMetadata {
     /// The value loops back after some time, but unless some particle lives
     /// forever there's little chance of repetition.
     particle_counter: atomic<u32>,
+
+    /// Index of the spawner associated with this effect in the spawner buffer.
+    spawner_index: u32,
 
     /// Padding for storage buffer alignment. This struct is sometimes bound as part
     /// of an array, or sometimes individually as a single unit. In the later case,

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -85,7 +85,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let read_index = 1u - write_index;
 
     // Recycle a dead particle from the destination group
-    let dead_index = atomicSub(&effect_metadata.dead_count, 1u) - 1u;
+    let dead_index = atomicSub(&effect_metadata.dead_count, 1u) - 1u +
+        effect_metadata.base_instance;
     let particle_index = indirect_buffer.indices[3u * dead_index + 2u];
 
     let particle_counter = atomicAdd(&effect_metadata.particle_counter, 1u);
@@ -130,7 +131,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     atomicAdd(&effect_metadata.alive_count, 1u);
 
     // Add to alive list
-    let instance_index = atomicAdd(&effect_metadata.instance_count, 1u);
+    let instance_index = atomicAdd(&effect_metadata.instance_count, 1u) +
+        effect_metadata.base_instance;
     indirect_buffer.indices[3u * instance_index + write_index] = particle_index;
 
     // Write back new particle

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -38,7 +38,7 @@ struct ParentParticleBuffer {
 #endif
 
 // "spawner" group @2
-@group(2) @binding(0) var<storage, read> spawner : Spawner;
+@group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
 {{PROPERTIES_BINDING}}
 
 // "metadata" group @3
@@ -63,6 +63,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Cap to the actual number of spawning requested by CPU or GPU, since compute shaders run
     // in workgroup_size(64) so more threads than needed are launched (rounded up to 64).
+    let spawner_index = effect_metadata.spawner_index;
 #ifdef CONSUME_GPU_SPAWN_EVENTS
     let event_index = thread_index;
     let global_child_index = effect_metadata.global_child_index;
@@ -74,7 +75,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Cap to the actual number of spawning requested by CPU (in the case of
     // spawners) or the number of particles present in the source group (in the
     // case of cloners).
-    let spawn_count: u32 = u32(spawner.spawn);
+    let spawn_count: u32 = u32(spawners[spawner_index].spawn);
     if (thread_index >= spawn_count) {
         return;
     }
@@ -92,14 +93,14 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let particle_counter = atomicAdd(&effect_metadata.particle_counter, 1u);
 
     // Initialize the PRNG seed
-    seed = pcg_hash(particle_index ^ spawner.seed);
+    seed = pcg_hash(particle_index ^ spawners[spawner_index].seed);
 
     // Spawner transform
     let transform = transpose(
         mat4x4(
-            spawner.transform[0],
-            spawner.transform[1],
-            spawner.transform[2],
+            spawners[spawner_index].transform[0],
+            spawners[spawner_index].transform[1],
+            spawners[spawner_index].transform[2],
             vec4<f32>(0.0, 0.0, 0.0, 1.0)
         )
     );

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -33,21 +33,21 @@ struct VertexOutput {
 
 @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
-@group(1) @binding(2) var<storage, read> spawner : Spawner;
+@group(1) @binding(2) var<storage, read> spawners : array<Spawner>;
 
 // "metadata" group @2
 @group(2) @binding(0) var<storage, read> effect_metadata : EffectMetadata;
 
 {{MATERIAL_BINDINGS}}
 
-fn get_camera_position_effect_space() -> vec3<f32> {
+fn get_camera_position_effect_space(spawner_index: u32) -> vec3<f32> {
     let view_pos = view.world_from_view[3].xyz;
 #ifdef LOCAL_SPACE_SIMULATION
     let inverse_transform = transpose(
         mat3x3(
-            spawner.inverse_transform[0].xyz,
-            spawner.inverse_transform[1].xyz,
-            spawner.inverse_transform[2].xyz,
+            spawners[spawner_index].inverse_transform[0].xyz,
+            spawners[spawner_index].inverse_transform[1].xyz,
+            spawners[spawner_index].inverse_transform[2].xyz,
         )
     );
     return inverse_transform * view_pos;
@@ -56,14 +56,14 @@ fn get_camera_position_effect_space() -> vec3<f32> {
 #endif
 }
 
-fn get_camera_rotation_effect_space() -> mat3x3<f32> {
+fn get_camera_rotation_effect_space(spawner_index: u32) -> mat3x3<f32> {
     let view_rot = mat3x3(view.world_from_view[0].xyz, view.world_from_view[1].xyz, view.world_from_view[2].xyz);
 #ifdef LOCAL_SPACE_SIMULATION
     let inverse_transform = transpose(
         mat3x3(
-            spawner.inverse_transform[0].xyz,
-            spawner.inverse_transform[1].xyz,
-            spawner.inverse_transform[2].xyz,
+            spawners[spawner_index].inverse_transform[0].xyz,
+            spawners[spawner_index].inverse_transform[1].xyz,
+            spawners[spawner_index].inverse_transform[2].xyz,
         )
     );
     return inverse_transform * view_rot;
@@ -97,21 +97,21 @@ fn unpack_compressed_transform_3x3_transpose(compressed_transform: mat3x4<f32>) 
 ///
 /// The simulation space depends on the effect's SimulationSpace value, and is either
 /// the effect space (SimulationSpace::Local) or the world space (SimulationSpace::Global).
-fn transform_position_simulation_to_world(sim_position: vec3<f32>) -> vec4<f32> {
+fn transform_position_simulation_to_world(sim_position: vec3<f32>, spawner_index: u32) -> vec4<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
-    let transform = unpack_compressed_transform(spawner.transform);
+    let transform = unpack_compressed_transform(spawners[spawner_index].transform);
     return transform * vec4<f32>(sim_position, 1.0);
 #else
     return vec4<f32>(sim_position, 1.0);
 #endif
 }
 
-fn transform_normal_simulation_to_world(sim_normal: vec3<f32>) -> vec3<f32> {
+fn transform_normal_simulation_to_world(sim_normal: vec3<f32>, spawner_index: u32) -> vec3<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
     // We use the inverse transpose transform to transform normals.
     // The inverse transpose is the same as the transposed inverse, so we can
     // safely use the inverse transform.
-    let transform = unpack_compressed_transform_3x3_transpose(spawner.inverse_transform);
+    let transform = unpack_compressed_transform_3x3_transpose(spawners[spawner_index].inverse_transform);
     return transform * sim_normal;
 #else
     return sim_normal;
@@ -124,8 +124,8 @@ fn transform_normal_simulation_to_world(sim_normal: vec3<f32>) -> vec3<f32> {
 /// the effect space (SimulationSpace::Local) or the world space (SimulationSpace::Global).
 /// The clip space is the final [-1:1]^3 space output from the vertex shader, before
 /// perspective divide and viewport transform are applied.
-fn transform_position_simulation_to_clip(sim_position: vec3<f32>) -> vec4<f32> {
-    return view.clip_from_world * transform_position_simulation_to_world(sim_position);
+fn transform_position_simulation_to_clip(sim_position: vec3<f32>, spawner_index: u32) -> vec4<f32> {
+    return view.clip_from_world * transform_position_simulation_to_world(sim_position, spawner_index);
 }
 
 fn inverse_transpose_mat3(m: mat3x3<f32>) -> mat3x3<f32> {
@@ -152,7 +152,8 @@ fn vertex(
     // @location(1) vertex_velocity: vec3<f32>,
 ) -> VertexOutput {
     // Fetch particle
-    let pong = spawner.render_pong;
+    let spawner_index = effect_metadata.spawner_index;
+    let pong = spawners[spawner_index].render_pong;
     let particle_index = indirect_buffer.indices[3u * instance_index + pong];
     var particle = particle_buffer.particles[particle_index];
 
@@ -211,13 +212,13 @@ fn vertex(
     // orientation and size of the particle mesh.
     let vpos = vertex_position * size;
     let sim_position = position + axis_x * vpos.x + axis_y * vpos.y + axis_z * vpos.z;
-    out.position = transform_position_simulation_to_clip(sim_position);
+    out.position = transform_position_simulation_to_clip(sim_position, spawner_index);
 
     out.color = color;
 
 #ifdef NEEDS_NORMAL
     let normal = inverse_transpose_mat3(mat3x3(axis_x, axis_y, axis_z)) * vertex_normal;
-    out.normal = transform_normal_simulation_to_world(normal);
+    out.normal = transform_normal_simulation_to_world(normal, spawner_index);
 #endif  // NEEDS_NORMAL
 
     return out;

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -1,6 +1,6 @@
 #import bevy_render::view::View
 #import bevy_hanabi::vfx_common::{
-    IndirectBuffer, SimParams, Spawner,
+    EffectMetadata, IndirectBuffer, SimParams, Spawner,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
     rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
@@ -34,6 +34,9 @@ struct VertexOutput {
 @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
 @group(1) @binding(2) var<storage, read> spawner : Spawner;
+
+// "metadata" group @2
+@group(2) @binding(0) var<storage, read> effect_metadata : EffectMetadata;
 
 {{MATERIAL_BINDINGS}}
 
@@ -161,7 +164,7 @@ fn vertex(
 
 #ifdef RIBBONS
     // Discard first instance; we draw from second one, and link to previous one
-    if (instance_index == 0) {
+    if (instance_index == effect_metadata.base_instance) {
         out.position = vec4(0.0);
         return out;
     }

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -50,6 +50,6 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         sort_buffer.pairs[j] = kv;
     }
 
-    // Clear for next frame
+    // Clear for next effect
     sort_buffer.count = 0;
 }

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -38,5 +38,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let write_index = effect_metadata.ping;
 
     let particle_index = sort_buffer.pairs[row_index].value;
-    indirect_index_buffer.data[row_index * 3u + write_index] = particle_index;
+    indirect_index_buffer.data[
+        (row_index + effect_metadata.base_instance) * 3u + write_index
+    ] = particle_index;
 }

--- a/src/render/vfx_sort_fill.wgsl
+++ b/src/render/vfx_sort_fill.wgsl
@@ -38,7 +38,9 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     }
 
     let read_index = effect_metadata.ping;
-    let particle_index = indirect_index_buffer[thread_index * 3u + read_index];
+    let particle_index = indirect_index_buffer[
+        (thread_index + effect_metadata.base_instance) * 3u + read_index
+    ];
 
     let particle_offset = particle_index * effect_metadata.particle_stride;
     let key_offset = particle_offset + effect_metadata.sort_key_offset;

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -38,7 +38,7 @@ struct ParentParticleBuffer {
 #endif
 
 // "spawner" group @2
-@group(2) @binding(0) var<storage, read> spawner : Spawner;
+@group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
 {{PROPERTIES_BINDING}}
 
 // "metadata" group @3
@@ -71,7 +71,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     ];
 
     // Initialize the PRNG seed
-    seed = pcg_hash(particle_index ^ spawner.seed);
+    let spawner_index = effect_metadata.spawner_index;
+    seed = pcg_hash(particle_index ^ spawners[spawner_index].seed);
 
     var particle: Particle = particle_buffer.particles[particle_index];
     {{AGE_CODE}}


### PR DESCRIPTION
Currently, we use a dynamic offset to point to the `Spawner`. This prevents batching, so this PR changes the shaders so that the effect metadata contains an index to the spawner, and the shader picks the spawner out of an array.

This is built on top of https://github.com/djeedai/bevy_hanabi/pull/480, so only the last commit (61c205f) needs to be reviewed.