### PR TITLE
Move indirect draw args to separate buffer

### DIFF
--- a/src/render/event.rs
+++ b/src/render/event.rs
@@ -22,7 +22,7 @@ use wgpu::{
 
 use super::{
     aligned_buffer_vec::HybridAlignedBufferVec, effect_cache::BufferState, gpu_buffer::GpuBuffer,
-    BufferBindingSource, EffectBindGroups, GpuDispatchIndirect,
+    BufferBindingSource, EffectBindGroups, GpuDispatchIndirectArgs,
 };
 use crate::ParticleLayout;
 
@@ -264,7 +264,7 @@ pub struct EventCache {
     // FIXME - merge with the update pass one, we don't need 2 buffers storing the same type; on
     // the other hand if we sync the allocations with GpuChildInfo we can guarantee a perfect
     // batching for the init fill dispatch pass (single dispatch for all instances at once).
-    init_indirect_dispatch_buffer: GpuBuffer<GpuDispatchIndirect>,
+    init_indirect_dispatch_buffer: GpuBuffer<GpuDispatchIndirectArgs>,
     /// Bind group layout for the indirect dispatch pass, which clears the GPU
     /// event counts ([`GpuChildInfo::event_count`]).
     indirect_child_info_buffer_bind_group_layout: BindGroupLayout,
@@ -299,7 +299,7 @@ impl EventCache {
             device,
             child_infos_buffer: HybridAlignedBufferVec::new(
                 BufferUsages::STORAGE,
-                Some(NonZeroU64::new(4).unwrap()),
+                NonZeroU64::new(4).unwrap(),
                 Some("hanabi:buffer:child_infos".to_string()),
             ),
             buffers: vec![],

--- a/src/render/gpu_buffer.rs
+++ b/src/render/gpu_buffer.rs
@@ -4,8 +4,8 @@ use bevy::{
     log::trace,
     render::{
         render_resource::{
-            BindingResource, Buffer, BufferAddress, BufferBinding, BufferDescriptor, BufferUsages,
-            ShaderSize, ShaderType,
+            BindingResource, Buffer, BufferAddress, BufferDescriptor, BufferUsages, ShaderSize,
+            ShaderType,
         },
         renderer::RenderDevice,
     },
@@ -194,14 +194,9 @@ impl<T: Pod + ShaderType + ShaderSize> GpuBuffer<T> {
 
     /// Get a binding for the entire GPU buffer, if allocated.
     #[inline]
-    #[allow(dead_code)]
-    pub fn binding(&self) -> Option<BindingResource<'_>> {
+    pub fn as_entire_binding(&self) -> Option<BindingResource<'_>> {
         let buffer = self.buffer()?;
-        Some(BindingResource::Buffer(BufferBinding {
-            buffer,
-            offset: 0,
-            size: None, // entire buffer
-        }))
+        Some(buffer.as_entire_binding())
     }
 
     /// Get the current buffer capacity, in element count.

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -68,7 +68,7 @@ impl PropertyBuffer {
         let align = NonZeroU64::new(align as u64).unwrap();
         let label = label.unwrap_or("hanabi:buffer:properties".to_string());
         Self {
-            buffer: HybridAlignedBufferVec::new(BufferUsages::STORAGE, Some(align), Some(label)),
+            buffer: HybridAlignedBufferVec::new(BufferUsages::STORAGE, align, Some(label)),
         }
     }
 
@@ -124,7 +124,7 @@ impl PropertyBuffer {
     }
 
     pub fn write(&mut self, offset: u32, data: &[u8]) {
-        self.buffer.update(offset, data);
+        self.buffer.update_raw(offset, data);
     }
 
     #[inline]

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -18,7 +18,7 @@ use wgpu::{
     BufferBindingType, BufferDescriptor, BufferUsages, CommandEncoder, ShaderStages,
 };
 
-use super::{gpu_buffer::GpuBuffer, GpuDispatchIndirect, GpuEffectMetadata, StorageType};
+use super::{gpu_buffer::GpuBuffer, GpuDispatchIndirectArgs, GpuEffectMetadata, StorageType};
 use crate::{Attribute, ParticleLayout};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -65,7 +65,7 @@ pub struct SortBindGroups {
     sort_buffer: Buffer,
     /// GPU buffer containing the [`GpuDispatchIndirect`] structs for the
     /// sort-fill and sort passes.
-    indirect_buffer: GpuBuffer<GpuDispatchIndirect>,
+    indirect_buffer: GpuBuffer<GpuDispatchIndirectArgs>,
     /// Bind group layouts for group #0 of the sort-fill compute pass.
     sort_fill_bind_group_layouts:
         HashMap<SortFillBindGroupLayoutKey, (BindGroupLayout, CachedComputePipelineId)>,

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -1,16 +1,21 @@
 #import bevy_hanabi::vfx_common::{
     ChildInfo, ChildInfoBuffer, SimParams, Spawner,
-    EM_OFFSET_ALIVE_COUNT, EM_OFFSET_MAX_UPDATE, EM_OFFSET_DEAD_COUNT,
-    EM_OFFSET_MAX_SPAWN, EM_OFFSET_INSTANCE_COUNT, EM_OFFSET_INDIRECT_DISPATCH_INDEX,
-    EM_OFFSET_PING, DISPATCH_INDIRECT_STRIDE, EFFECT_METADATA_STRIDE
+    EM_OFFSET_ALIVE_COUNT, EM_OFFSET_MAX_UPDATE, EM_OFFSET_CAPACITY,
+    EM_OFFSET_MAX_SPAWN, EM_OFFSET_INDIRECT_DISPATCH_INDEX, DRAW_INDEXED_INDIRECT_STRIDE,
+    EM_OFFSET_INDIRECT_WRITE_INDEX, DISPATCH_INDIRECT_STRIDE, EFFECT_METADATA_STRIDE
 }
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 
 // Tightly packed array of EffectMetadata[], accessed as u32 array.
 @group(1) @binding(0) var<storage, read_write> effect_metadata_buffer : array<u32>;
-// Tightly packed array of IndirectDispatch[], accessed as u32 array.
+// Tightly packed array of DispatchIndirectArgs[], accessed as u32 array.
 @group(1) @binding(1) var<storage, read_write> dispatch_indirect_buffer : array<u32>;
+// Tightly packed array of DrawIndexedIndirectArgs[], accessed as u32 array. This can contain
+// some DrawIndirectArgs[] instead, but in that case the stride is adjusted so all rows have
+// the same size. Since we access the instance_count, which is at the same position in both,
+// we ignore their size difference (the non-indexed one is padded).
+@group(1) @binding(2) var<storage, read_write> draw_indirect_buffer : array<u32>;
 
 @group(2) @binding(0) var<storage, read_write> spawner_buffer : array<Spawner>;
 
@@ -42,10 +47,13 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Clear the rendering instance count, which will be upgraded by the update pass
     // with the particles actually alive at the end of their update (after aged).
-    effect_metadata_buffer[em_base + EM_OFFSET_INSTANCE_COUNT] = 0u;
+    let draw_indirect_index = spawner_buffer[effect_index].draw_indirect_index;
+    let dri_base = DRAW_INDEXED_INDIRECT_STRIDE * draw_indirect_index;
+    draw_indirect_buffer[dri_base + 1u] = 0u;
 
+    let capacity = effect_metadata_buffer[em_base + EM_OFFSET_CAPACITY];
     let alive_count = effect_metadata_buffer[em_base + EM_OFFSET_ALIVE_COUNT];
-    let dead_count = effect_metadata_buffer[em_base + EM_OFFSET_DEAD_COUNT];
+    let dead_count = capacity - alive_count;
 
     // Update max_update from current value of alive_count, so that the
     // update pass coming next can cap its threads to this value, while also
@@ -53,7 +61,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     effect_metadata_buffer[em_base + EM_OFFSET_MAX_UPDATE] = alive_count;
 
     // Copy the number of dead particles to a constant location, so that the
-    // init pass on next frame can atomically modify dead_count in parallel
+    // init pass on next frame can atomically modify alive_count in parallel
     // yet still read its initial value at the beginning of the init pass,
     // and limit the number of particles spawned to the number of dead
     // particles to recycle.
@@ -69,11 +77,11 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Swap ping/pong buffers. The update pass always writes into ping, and both the update
     // pass and the render pass always read from pong.
-    let ping = effect_metadata_buffer[em_base + EM_OFFSET_PING];
+    let ping = effect_metadata_buffer[em_base + EM_OFFSET_INDIRECT_WRITE_INDEX];
     let pong = 1u - ping;
-    effect_metadata_buffer[em_base + EM_OFFSET_PING] = pong;
+    effect_metadata_buffer[em_base + EM_OFFSET_INDIRECT_WRITE_INDEX] = pong;
 
     // Copy the new pong into the spawner buffer, which will be used during rendering
     // to determine where to read particle indices.
-    spawner_buffer[effect_index].render_pong = pong;
+    spawner_buffer[effect_index].render_indirect_read_index = pong;
 }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -149,8 +149,8 @@ fn vertex(
     // @location(1) vertex_velocity: vec3<f32>,
 ) -> VertexOutput {
     // Fetch particle
-    let pong = spawner.render_pong;
-    let particle_index = indirect_buffer.indices[3u * instance_index + pong];
+    let indirect_read_index = spawner.render_indirect_read_index;
+    let particle_index = indirect_buffer.rows[instance_index].particle_index[indirect_read_index];
     var particle = particle_buffer.particles[particle_index];
 
     var out: VertexOutput;
@@ -167,7 +167,7 @@ fn vertex(
     }
 
     // Fetch previous particle
-    let prev_index = indirect_buffer.indices[3u * (instance_index - 1u) + pong];
+    let prev_index = indirect_buffer.rows[instance_index - 1u].particle_index[indirect_read_index];
     let prev_particle = particle_buffer.particles[prev_index];
 
     // Discard this instance if previous one is from a different ribbon. Again,

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -29,14 +29,12 @@ struct IndirectIndexBuffer {
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let row_index = global_invocation_id.x;
-    let count = atomicLoad(&effect_metadata.instance_count); // TODO - atomic not needed
+    let count = atomicLoad(&effect_metadata.alive_count); // TODO - atomic not needed
     if (row_index >= count) {
         return;
     }
     
-    // Always write into ping, read from pong
-    let write_index = effect_metadata.ping;
-
     let particle_index = sort_buffer.pairs[row_index].value;
+    let write_index = effect_metadata.indirect_write_index;
     indirect_index_buffer.data[row_index * 3u + write_index] = particle_index;
 }

--- a/src/render/vfx_sort_fill.wgsl
+++ b/src/render/vfx_sort_fill.wgsl
@@ -32,12 +32,14 @@ struct RawParticleBuffer {
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let thread_index = global_invocation_id.x;
-    let count = atomicLoad(&effect_metadata.instance_count); // TODO - atomic not needed
+    let count = atomicLoad(&effect_metadata.alive_count); // TODO - atomic not needed
     if (thread_index >= count) {
         return;
     }
 
-    let read_index = effect_metadata.ping;
+    // Because we're after the indirect pass, the buffers are already swapped in preparation
+    // of next frame, so the "write index" of next frame is really the read index of this one.
+    let read_index = effect_metadata.indirect_write_index;
     let particle_index = indirect_index_buffer[thread_index * 3u + read_index];
 
     let particle_offset = particle_index * effect_metadata.particle_stride;


### PR DESCRIPTION
Move the indirect draw args outside of `EffectMetadata`, and into a separate buffer of their own. This decouples the indirect draw args, which are largely driven by GPU, from the effect metadata, which are largely (and ideally, entirely) driven by CPU. The new indirect draw args buffer stores both indexed and non-indexed draw args, the latter padded with an extra `u32`. This ensures all entries are the same size and simplifies handling, but more importantly allows retaining a single unified dispatch of `vfx_indirect` for all effects without adding any extra indirection or having to split into two passes.

The main benefit is that this prevents resetting the effect when Bevy relocates the mesh, which requires re-uploading the mesh location info into the draw args (base vertex and/or first index, notably), but otherwise doesn't affect runtime info like the number of particles alive. Previously when this happened, the entire `EffectMetadata` was re-uploaded from CPU with default values for GPU-driven fields, effectively leading to a "reset" of the effect (alive particle reset to zero), as the warning in #471 used to highlight.

This change also cleans up the shaders by removing the `dead_count` atomic particle count, and instead adding the constant `capacity` particle count, which allows deducing the dead particle count from the existing `alive_count`. This means `alive_count` becomes the only source of truth for the number of alive particles. This makes several shaders much more readable, and saves a couple of atomic instructions.