### PR TITLE
fix(examples/billboard): filter out ui camera 

### DIFF
--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -162,12 +162,10 @@ fn setup(
     ));
 }
 
-fn rotate_camera(time: Res<Time>, mut query: Query<&mut Transform, With<Camera>>) {
-    if let Ok(mut transform) = query.single_mut() {
-        let radius_xz = 18_f32.sqrt();
-        let a = (time.elapsed_secs() * 0.3).sin();
-        let (s, c) = a.sin_cos();
-        *transform =
-            Transform::from_xyz(c * radius_xz, 3.0, s * radius_xz).looking_at(Vec3::ZERO, Vec3::Y)
-    }
+fn rotate_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera3d>>) {
+    let radius_xz = 18_f32.sqrt();
+    let a = (time.elapsed_secs() * 0.3).sin();
+    let (s, c) = a.sin_cos();
+    **camera_transform =
+        Transform::from_xyz(c * radius_xz, 3.0, s * radius_xz).looking_at(Vec3::ZERO, Vec3::Y)
 }


### PR DESCRIPTION
In the billboard example, the automatic camera rotation doesn't work as it filters for any cameras, and trying to get a single mutable camera, which won't work as `utils::DemoApp` also spawns a Camera2d for the UI. This breaks `single_mut` as now there are two cameras to query for.

This can easily be fixed by filtering for a `Camera3d`. Also, I've used the Single query filter to get rid of one level of indentation (: