### PR TITLE
Add missing `clamp` and `vec3` expressions

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4951,7 +4951,8 @@ impl EffectBindGroups {
         let make_entry = || {
             let mut entries = Vec::with_capacity(3);
             entries.push(
-                // @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>;
+                // @group(3) @binding(0) var<storage, read_write> effect_metadatas :
+                // array<EffectMetadata>;
                 BindGroupEntry {
                     binding: 0,
                     resource: BindingResource::Buffer(BufferBinding {


### PR DESCRIPTION
- Add missing `clamp(x, lo, hi)` expression.
- Expose `vec3(x, y, z)` to `Module`; it was only available in `WriterExpr` by mistake.
- Same for `vec4_xyz_w(xyz, w)`.
- Add tests for those.