### PR TITLE
Directly use `DispatchIndirectArgs` in shaders

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2885,10 +2885,10 @@ impl EffectsMeta {
 
         // Ensure individual GpuSpawnerParams elements are properly aligned so they can
         // be addressed individually by the computer shaders.
-        let item_align = gpu_limits.storage_buffer_align().get() as u64;
+        let item_align = gpu_limits.storage_buffer_align();
         trace!(
             "Aligning storage buffers to {} bytes as device limits requires.",
-            item_align
+            item_align.get()
         );
 
         Self {
@@ -2900,7 +2900,7 @@ impl EffectsMeta {
             sim_params_uniforms: UniformBuffer::default(),
             spawner_buffer: AlignedBufferVec::new(
                 BufferUsages::STORAGE,
-                NonZeroU64::new(item_align),
+                Some(item_align.into()),
                 Some("hanabi:buffer:spawner".to_string()),
             ),
             dispatch_indirect_buffer: GpuBuffer::new(
@@ -2914,7 +2914,7 @@ impl EffectsMeta {
             ),
             effect_metadata_buffer: BufferTable::new(
                 BufferUsages::STORAGE | BufferUsages::INDIRECT,
-                Some(NonZeroU64::new(item_align).unwrap()),
+                Some(item_align.into()),
                 Some("hanabi:buffer:effect_metadata".to_string()),
             ),
             gpu_limits,
@@ -6180,7 +6180,7 @@ pub(crate) fn prepare_bind_groups(
                             resource: effect_metadata_buffer.as_entire_binding(),
                         },
                         // @group(1) @binding(1) var<storage, read_write> dispatch_indirect_buffer
-                        // : array<u32>;
+                        // : array<DispatchIndirectArgs>;
                         BindGroupEntry {
                             binding: 1,
                             resource: dispatch_indirect_buffer.as_entire_binding(),

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -110,9 +110,6 @@ struct DispatchIndirectArgs {
     z: u32,
 }
 
-/// Stride in u32 count (4 bytes) of the DispatchIndirectArgs struct.
-const DISPATCH_INDIRECT_STRIDE: u32 = 3u;
-
 /// Indirect draw (non-indexed) dispatch struct for GPU-driven passes. The layout of this struct is dictated by WGSL.
 /// See https://docs.rs/wgpu/latest/wgpu/util/struct.DrawIndirectArgs.html.
 struct DrawIndirectArgs {
@@ -216,7 +213,6 @@ struct EffectMetadata {
     /// of an array, or sometimes individually as a single unit. In the later case,
     /// we need it to be aligned to the GPU limits of the device. That limit is only
     /// known at runtime when initializing the WebGPU device.
-    // FIXME - not anymore, but would be again with proper batching, so keep for now
     {{EFFECT_METADATA_PADDING}}
 }
 


### PR DESCRIPTION
Switch to directly using an `array<DispatchIndirectArgs>` in the `vfx_indirect` compute pass, instead of a `u32` array, since those structs are already tightly packed. This makes the shader more readable.