### PR TITLE
Pack multiple effects per particle slab

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1248,7 +1248,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
         {
             writeln!(
                 &mut writeback_code,
-                "    particle_buffer.particles[particle_index].{0} = particle.{0};",
+                "    particle_buffer.particles[base_particle + particle_index].{0} = particle.{0};",
                 attribute.name()
             )
             .unwrap();

--- a/src/render/event.rs
+++ b/src/render/event.rs
@@ -166,6 +166,8 @@ pub(crate) struct CachedParentInfo {
 pub(crate) struct CachedChildInfo {
     /// ID of the slab storing the parent effect.
     pub parent_slab_id: SlabId,
+    /// Offset into the slab of the parent's particles.
+    pub parent_slab_offset: u32,
     /// Parent's particle layout.
     pub parent_particle_layout: ParticleLayout,
     /// Parent's buffer.
@@ -186,6 +188,7 @@ pub(crate) struct CachedChildInfo {
 impl CachedChildInfo {
     pub fn is_locally_equal(&self, other: &CachedChildInfo) -> bool {
         self.parent_slab_id == other.parent_slab_id
+        && self.parent_slab_offset == other.parent_slab_offset
         && self.parent_particle_layout == other.parent_particle_layout
         && self.parent_buffer_binding_source == other.parent_buffer_binding_source
         && self.local_child_index == other.local_child_index

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -41,6 +41,13 @@ struct Spawner {
     effect_metadata_index: u32,
     /// Index of the [`DrawIndirectArgs`] or [`DrawIndexedIndirectArgs`] for this effect.
     draw_indirect_index: u32,
+    /// Start offset of the particles and indirect indices into the effect's
+    /// slab, in number of particles (row index).
+    slab_offset: u32,
+    /// Start offset of the particles and indirect indices into the parent effect's
+    /// slab (if the effect has a parent effect), in number of particles (row index).
+    /// This is ignored if the effect has no parent.
+    parent_slab_offset: u32,
 #ifdef SPAWNER_PADDING
     {{SPAWNER_PADDING}}
 #endif


### PR DESCRIPTION
Sub-allocate each particle slab with the content of multiple effects.
- Introduce a `base_particle` value per effect instance, which is the equivalent of the `base_vertex` for rendering, and corresponds to the index of the first particle in the sub-allocated slice for that effect, inside the overall slab buffer.
- Store that `base_particle` in the `Spawner` and give access to all shaders which need it (most of them).
- Restore the default 64k particle count per slab, which allows packing multiple effects per buffer/slab.

When `debug_assertions` is active (in Debug build), fill the first value of each particle to a `NaN` (0xFFFFFFFF) to make it easier to see in RenderDoc or any other GPU debugger that the particle is unused.