### PR TITLE
Document serde (typetag) supports wasm with `bevy/reflect_auto_register`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,9 @@ default = ["2d", "3d", "serde", "gpu_tests"]
 # You need to activate either the 2d or 3d feature at least (or both).
 3d = []
 
-# Enable serializing and deserializing of assets. This doesn't work on WASM,
-# because typetag is not available for the wasm target.
+# Enable serializing and deserializing of assets.
+# This requires https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors on WASM because of typetag,
+# bevy will setup it for you on WASM if `bevy/reflect_auto_register` is enabled.
 serde = ["typetag"]
 
 # Enable tracing annotations. This is disabled by default for performance.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ This list contains the major fixed features provided by 🎆 Hanabi. Beyond that
 | `3d` | ✔ | Enable rendering through 3D cameras ([`Camera3d`](https://docs.rs/bevy/0.17.2/bevy/core_pipeline/core_3d/struct.Camera3d.html)) |
 | `serde`* | ✔ | Use `serde` to derive `Serialization` and `Deserialization` on asset-related types. |
 
-(*) `serde` is not compatible with WASM (due to the `typetag` dependency not being available on `wasm` without extra setup).
+(*) Needs `bevy/reflect_auto_register` (which is enabled by default) to setup [`inventory`](https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors) on `wasm` due to the `typetag` dependency.
 
 For optimization purpose, users of a single type of camera can disable the other type by skipping default features in their `Cargo.toml`. For example to use only the 3D mode:
 

--- a/build_examples_wasm.sh
+++ b/build_examples_wasm.sh
@@ -1,33 +1,33 @@
-echo Check that wasm-bindgen -V returns 0.2.100, otherwise cargo install wasm-bindgen-cli --version 0.2.100
+echo Check that wasm-bindgen -V returns 0.2.104, otherwise cargo install wasm-bindgen-cli --version 0.2.104
 
 echo Setting RUSTFLAGS to enable unstable web_sys APIs...
-export RUSTFLAGS=--cfg=web_sys_unstable_apis
+export RUSTFLAGS='--cfg=web_sys_unstable_apis  --cfg getrandom_backend="wasm_js"'
 
 echo Build all examples for WASM...
 # 3D
-cargo b --release --example firework --target wasm32-unknown-unknown
-cargo b --release --example portal --target wasm32-unknown-unknown
-cargo b --release --example expr --target wasm32-unknown-unknown
-cargo b --release --example spawn --target wasm32-unknown-unknown
-cargo b --release --example multicam --target wasm32-unknown-unknown
-cargo b --release --example visibility --target wasm32-unknown-unknown
-cargo b --release --example random --target wasm32-unknown-unknown
-cargo b --release --example spawn_on_command --target wasm32-unknown-unknown
-cargo b --release --example activate --target wasm32-unknown-unknown
-cargo b --release --example force_field --target wasm32-unknown-unknown
-cargo b --release --example init --target wasm32-unknown-unknown
-cargo b --release --example lifetime --target wasm32-unknown-unknown
-cargo b --release --example ordering --target wasm32-unknown-unknown
-cargo b --release --example ribbon --target wasm32-unknown-unknown
+cargo b --release --example firework --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example portal --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example expr --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example spawn --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example multicam --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example visibility --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example random --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example spawn_on_command --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example activate --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example force_field --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example init --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example lifetime --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example ordering --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example ribbon --target wasm32-unknown-unknown --features="bevy/webgpu"
 # 3D + PNG
-cargo b --release --example
-cargo b --release --example circle --target wasm32-unknown-unknown
-cargo b --release --example billboard --target wasm32-unknown-unknown
-cargo b --release --example worms --target wasm32-unknown-unknown
-cargo b --release --example instancing --target wasm32-unknown-unknown
-cargo b --release --example puffs --target wasm32-unknown-unknown
+cargo b --release --example gradient --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example circle --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example billboard --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example worms --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example instancing --target wasm32-unknown-unknown --features="bevy/webgpu"
+cargo b --release --example puffs --target wasm32-unknown-unknown --features="bevy/webgpu"
 # 2D
-cargo b --release --example 2d --target wasm32-unknown-unknown
+cargo b --release --example 2d --target wasm32-unknown-unknown --features="bevy/webgpu"
 
 echo Bindgen all examples...
 wasm-bindgen --out-name wasm_firework --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/firework.wasm

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -37,9 +37,9 @@ For more information about WebAssembly support, see also:
 
 The `serde` feature,
 which allows deriving the `Serialize` and `Deserialize` traits on asset-related types,
-is not compatible with the `wasm` target.
+needs `bevy/reflect_auto_register` with the `wasm` target.
 This is due to the use of the `typetag` dependency to handle trait objects,
-which itself is not available for `wasm`.
+which requires https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors and bevy will setup it for you with `bevy/reflect_auto_register` feature.
 
 To disable the `serde` feature,
 simply disable default features and explicitly list the features you need:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,7 @@
 //!
 //! The [`EffectAsset`] is intended to be the serialized effect format, which
 //! authors can save to disk and ship with their application. At this time
-//! however serialization and deserialization is still a work in progress. In
-//! particular, serialization and deserialization of all
-//! [modifiers](crate::modifier) is currently not supported on `wasm` target.
+//! however serialization and deserialization is still a work in progress.
 
 use std::fmt::Write as _;
 

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -34,12 +34,6 @@
 //! vector position can be assigned to a [property](crate::properties) and
 //! mutated each frame, giving CPU-side control over the behavior of the GPU
 //! particle effect. See [expressions](crate::graph::expr) for more details.
-//!
-//! # Limitations
-//!
-//! At this time, serialization and deserialization of modifiers is not
-//! supported on Wasm. This means assets authored and saved on a non-Wasm target
-//! cannot be read back into an application running on Wasm.
 
 use std::{
     collections::hash_map::DefaultHasher,


### PR DESCRIPTION
`typetag` needs setup `inventory` on wasm. Fortunately bevy reflect also uses `inventory` and setups it in https://github.com/bevyengine/bevy/blob/5925b1925841149a6df99beda0c4d831c53d4556/crates/bevy_app/src/app.rs#L118 with `bevy/reflect_auto_register` feature (enabled by default) thus `typetag` works out of box.

See also:
https://docs.rs/typetag/latest/typetag/#so-many-questions
https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors
https://github.com/bevyengine/bevy/blob/706fdd9800c4bf335d67f127ff6e5a93deadabb9/crates/bevy_reflect/src/lib.rs#L788-L804

To test this, run `portal` example on wasm with `ron` and with this change:
```rust

    let effect_asset = EffectAsset::new(16384, SpawnerSettings::rate(5000.0.into()), module)
        .with_name("portal")
        .init(init_pos)
        .init(init_age)
        .init(init_lifetime)
        .update(update_drag)
        .update(tangent_accel)
        .render(ColorOverLifetimeModifier::new(color_gradient1))
        .render(SizeOverLifetimeModifier {
            gradient: size_gradient1,
            screen_space_size: false,
        })
        .render(OrientModifier::new(OrientMode::AlongVelocity));
    bevy::log::info!("{:?}", ron::to_string(&effect_asset));
    let ron="(name:\"portal\",capacity:16384,spawner:(count:Single(5000.0),spawn_duration:Single(1.0),period:Single(1.0),cycle_count:0,starts_active:true,emit_on_start:true),z_layer_2d:0.0,simulation_space:Global,simulation_condition:WhenVisible,prng_seed:0,init_modifiers:[{\"SetPositionCircleModifier\":(center:1,axis:2,radius:3,dimension:Surface)},{\"SetAttributeModifier\":(attribute:\"age\",value:4)},{\"SetAttributeModifier\":(attribute:\"lifetime\",value:7)}],update_modifiers:[{\"LinearDragModifier\":(drag:8)},{\"TangentAccelModifier\":(origin:9,axis:10,accel:11)}],render_modifiers:[{\"ColorOverLifetimeModifier\":(gradient:(keys:[(ratio:0.0,value:(4.0,4.0,4.0,1.0)),(ratio:0.1,value:(4.0,4.0,0.0,1.0)),(ratio:0.9,value:(4.0,0.0,0.0,1.0)),(ratio:1.0,value:(4.0,0.0,0.0,0.0))]),blend:Overwrite,mask:(15))},{\"SizeOverLifetimeModifier\":(gradient:(keys:[(ratio:0.3,value:(0.2,0.02,1.0)),(ratio:1.0,value:(0.0,0.0,0.0))]),screen_space_size:false)},{\"OrientModifier\":(mode:AlongVelocity,rotation:None)}],motion_integration:PostUpdate,module:(expressions:[Literal(Vector(Vec3((0.0,0.0,0.0)))),Literal(Vector(Vec3((0.0,0.0,1.0)))),Literal(Scalar(Float(4.0))),Literal(Scalar(Float(0.0))),Literal(Scalar(Float(0.6))),Literal(Scalar(Float(1.3))),Binary(op:UniformRand,left:5,right:6),Literal(Scalar(Float(2.0))),Literal(Vector(Vec3((0.0,0.0,0.0)))),Literal(Vector(Vec3((0.0,0.0,1.0)))),Literal(Scalar(Float(30.0)))],properties:[],texture_layout:(layout:[])),alpha_mode:Blend)";
    assert_eq!(
        ron::to_string(&ron::from_str::<EffectAsset>(ron).unwrap())
            .unwrap()
            .as_str(),
        ron
    );
    let effect1 = effects.add(effect_asset);
```