### PR TITLE
Batch spawners and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Spawners and properties are now bound as arrays in the various GPU passes.
+  If you had custom shader code accessing those, you need to update your code.
+
 ## [0.18.0] 2026-02-01
 
 _This version is compatible with Bevy 0.18_

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1329,7 +1329,7 @@ impl PropertyExpr {
             )));
         }
 
-        Ok(format!("properties.{}", prop.name()))
+        Ok(prop.to_wgsl_string())
     }
 }
 
@@ -4114,7 +4114,7 @@ mod tests {
         let x = m.try_get(x).unwrap();
         let s = x.eval(&m, &mut context).unwrap();
         assert_eq!(
-            "(max(abs(3.), (particle.position) * (2.))) + (min(-4., properties.my_prop))"
+            "(max(abs(3.), (particle.position) * (2.))) + (min(-4., properties[properties_offset].my_prop))"
                 .to_string(),
             s
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -928,11 +928,13 @@ impl EffectShaderSource {
 
         // Generate the shader code defining the per-effect properties, if any
         let property_layout = asset.property_layout();
-        let properties_code = property_layout.generate_code().unwrap_or_default();
+        let properties_code = property_layout
+            .generate_property_struct_code()
+            .unwrap_or_default();
         let properties_binding_code = if property_layout.is_empty() {
             "// (no properties)".to_string()
         } else {
-            "@group(2) @binding(1) var<storage, read> properties : Properties;".to_string()
+            "@group(2) @binding(3) var<storage, read> properties : array<Properties>;".to_string()
         };
 
         // Event buffer bindings for the update pass, if the effect emits GPU events to
@@ -1176,8 +1178,8 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
                 let tex_index = bind_index;
                 let sampler_index = bind_index + 1;
                 material_bindings_code.push_str(&format!(
-                    "@group(2) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
-@group(2) @binding({sampler_index}) var material_sampler_{slot}: sampler;
+                    "@group(3) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
+@group(3) @binding({sampler_index}) var material_sampler_{slot}: sampler;
 "
                 ));
                 bind_index += 2;
@@ -1285,6 +1287,8 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
         let render_shader_source = PARTICLES_RENDER_SHADER_TEMPLATE
             .replace("{{ATTRIBUTES}}", &attributes_code)
             .replace("{{INPUTS}}", &inputs_code)
+            .replace("{{PROPERTIES}}", &properties_code)
+            .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
             .replace("{{MATERIAL_BINDINGS}}", &material_bindings_code)
             .replace("{{VERTEX_MODIFIERS}}", &vertex_code)
             .replace("{{FRAGMENT_MODIFIERS}}", &fragment_code)

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 #[cfg(feature = "2d")]
 use bevy::core_pipeline::core_2d::Transparent2d;
 #[cfg(feature = "3d")]
@@ -37,12 +39,12 @@ use crate::{
         propagate_ready_state, queue_effects, queue_init_fill_dispatch_ops,
         queue_init_indirect_workgroup_update, report_ready_state, start_stop_gpu_debug_capture,
         update_mesh_locations, DebugSettings, DispatchIndirectPipeline, DrawEffects,
-        EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, EventCache,
-        GpuBufferOperations, GpuEffectMetadata, GpuSpawnerParams, InitFillDispatchQueue,
-        ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline,
-        PropertyBindGroups, PropertyCache, RenderDebugSettings, ShaderCache, SimParams,
-        SortBindGroups, SortedEffectBatches, StorageType as _, UtilsPipeline,
-        VfxSimulateDriverNode, VfxSimulateNode,
+        EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, EventCache, GpuBatchInfo,
+        GpuBufferOperations, GpuEffectMetadata, InitFillDispatchQueue, ParticlesInitPipeline,
+        ParticlesRenderPipeline, ParticlesUpdatePipeline, PrefixSumPipeline, PropertyBindGroups,
+        PropertyCache, RenderDebugSettings, ShaderCache, SimParams, SortBindGroups,
+        SortedEffectBatches, StorageType as _, UtilsPipeline, VfxSimulateDriverNode,
+        VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_spawners,
@@ -50,6 +52,10 @@ use crate::{
     update_properties_from_asset, EffectSimulation, EffectVisibilityClass, ParticleEffect,
     SpawnerSettings, ToWgslString,
 };
+
+/// Source code for the `vfx_sort` compute shader.
+pub(crate) const VFX_SORT_WGSL: Cow<'static, str> =
+    Cow::Borrowed(include_str!("render/vfx_sort.wgsl"));
 
 /// Labels for the Hanabi systems.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
@@ -144,8 +150,8 @@ impl HanabiPlugin {
     /// shader ready for the specific GPU device associated with that
     /// alignment.
     pub(crate) fn make_common_shader(min_storage_buffer_offset_alignment: u32) -> Shader {
-        let spawner_padding_code =
-            GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
+        let batch_info_padding_code =
+            GpuBatchInfo::padding_code(min_storage_buffer_offset_alignment);
         let effect_metadata_padding_code =
             GpuEffectMetadata::padding_code(min_storage_buffer_offset_alignment);
         let render_effect_indirect_size =
@@ -153,7 +159,7 @@ impl HanabiPlugin {
         let effect_metadata_stride_code =
             (render_effect_indirect_size.get() as u32).to_wgsl_string();
         let common_code = include_str!("render/vfx_common.wgsl")
-            .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
+            .replace("{{BATCH_INFO_PADDING}}", &batch_info_padding_code)
             .replace("{{EFFECT_METADATA_PADDING}}", &effect_metadata_padding_code)
             .replace("{{EFFECT_METADATA_STRIDE}}", &effect_metadata_stride_code);
         Shader::from_wgsl(
@@ -197,6 +203,22 @@ impl HanabiPlugin {
                     min_storage_buffer_offset_alignment,
                     if has_events { "events" } else { "noevent" },
                 ))
+                .to_string_lossy(),
+        )
+    }
+
+    /// Create the `vfx_prefix_sum.wgsl` shader.
+    ///
+    /// This creates a new [`Shader`] from the `vfx_prefix_sum.wgsl` template
+    /// file.
+    pub(crate) fn make_prefix_sum_shader() -> Shader {
+        let prefix_sum_code = include_str!("render/vfx_prefix_sum.wgsl");
+        Shader::from_wgsl(
+            prefix_sum_code,
+            std::path::Path::new(file!())
+                .parent()
+                .unwrap()
+                .join("render/vfx_prefix_sum.wgsl")
                 .to_string_lossy(),
         )
     }
@@ -292,6 +314,7 @@ impl Plugin for HanabiPlugin {
         let (
             indirect_shader_noevent,
             indirect_shader_events,
+            prefix_sum_shader,
             sort_fill_shader,
             sort_shader,
             sort_copy_shader,
@@ -299,6 +322,7 @@ impl Plugin for HanabiPlugin {
             let align = render_device.limits().min_storage_buffer_offset_alignment;
             let indirect_shader_noevent = HanabiPlugin::make_indirect_shader(align, false);
             let indirect_shader_events = HanabiPlugin::make_indirect_shader(align, true);
+            let prefix_sum_shader = HanabiPlugin::make_prefix_sum_shader();
             let sort_fill_shader = Shader::from_wgsl(
                 include_str!("render/vfx_sort_fill.wgsl"),
                 std::path::Path::new(file!())
@@ -308,7 +332,7 @@ impl Plugin for HanabiPlugin {
                     .to_string_lossy(),
             );
             let sort_shader = Shader::from_wgsl(
-                include_str!("render/vfx_sort.wgsl"),
+                VFX_SORT_WGSL,
                 std::path::Path::new(file!())
                     .parent()
                     .unwrap()
@@ -327,6 +351,7 @@ impl Plugin for HanabiPlugin {
             let mut assets = app.world_mut().resource_mut::<Assets<Shader>>();
             let indirect_shader_noevent = assets.add(indirect_shader_noevent);
             let indirect_shader_events = assets.add(indirect_shader_events);
+            let prefix_sum_shader = assets.add(prefix_sum_shader);
             let sort_fill_shader = assets.add(sort_fill_shader);
             let sort_shader = assets.add(sort_shader);
             let sort_copy_shader = assets.add(sort_copy_shader);
@@ -334,6 +359,7 @@ impl Plugin for HanabiPlugin {
             (
                 indirect_shader_noevent,
                 indirect_shader_events,
+                prefix_sum_shader,
                 sort_fill_shader,
                 sort_shader,
                 sort_copy_shader,
@@ -344,6 +370,7 @@ impl Plugin for HanabiPlugin {
             render_device.clone(),
             indirect_shader_noevent,
             indirect_shader_events,
+            prefix_sum_shader,
         );
 
         let effect_cache = EffectCache::new(render_device.clone());
@@ -371,6 +398,7 @@ impl Plugin for HanabiPlugin {
             .insert_resource(sort_bind_groups)
             .init_resource::<UtilsPipeline>()
             .init_resource::<GpuBufferOperations>()
+            .init_resource::<PrefixSumPipeline>()
             .init_resource::<DispatchIndirectPipeline>()
             .init_resource::<SpecializedComputePipelines<DispatchIndirectPipeline>>()
             .init_resource::<ParticlesInitPipeline>()
@@ -502,6 +530,8 @@ impl Plugin for HanabiPlugin {
                         .after(fixup_parents)
                         // Need the indirect dispatch args index for GPU event based init pass
                         .after(allocate_events)
+                        // Need the properties block offset in GPU slab
+                        .after(allocate_properties)
                         // This may invalidate some bind groups when resizing the metadata buffer
                         .before(prepare_bind_groups),
                     queue_init_fill_dispatch_ops

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -167,7 +167,7 @@ impl Property {
 
 impl ToWgslString for Property {
     fn to_wgsl_string(&self) -> String {
-        format!("properties.{}", self.name)
+        format!("properties[properties_offset].{}", self.name)
     }
 }
 
@@ -828,7 +828,7 @@ impl PropertyLayout {
     /// This generates code declaring the `Properties` struct in WGSL, or `None`
     /// if the layout is empty. The `Properties` struct contains the values
     /// of all the effect properties, as defined by this layout.
-    pub fn generate_code(&self) -> Option<String> {
+    pub fn generate_property_struct_code(&self) -> Option<String> {
         // debug_assert!(self.layout.is_sorted_by_key(|entry| entry.offset));
         if self.layout.is_empty() {
             return None;
@@ -895,7 +895,10 @@ mod tests {
         assert_eq!(*p.default_value(), value);
         assert_eq!(p.value_type(), value.value_type());
         assert_eq!(p.size(), value.value_type().size());
-        assert_eq!(p.to_wgsl_string(), format!("properties.{}", p.name()));
+        assert_eq!(
+            p.to_wgsl_string(),
+            format!("properties[properties_offset].{}", p.name())
+        );
     }
 
     #[test]
@@ -992,7 +995,7 @@ mod tests {
         assert_eq!(l.cpu_size(), 0);
         assert_eq!(l.align(), 0);
         assert_eq!(l.properties().next(), None);
-        let s = l.generate_code();
+        let s = l.generate_property_struct_code();
         assert!(s.is_none());
     }
 
@@ -1023,7 +1026,7 @@ mod tests {
         // anything left go last
         assert_eq!(it.next(), Some((32, &prop3)));
         assert_eq!(it.next(), None);
-        let s = layout.generate_code();
+        let s = layout.generate_property_struct_code();
         assert_eq!(
             s,
             Some(
@@ -1058,7 +1061,7 @@ mod tests {
         // [padding] @24,+4
         assert_eq!(it.next(), Some((32, &prop3)));
         assert_eq!(it.next(), None);
-        let s = layout.generate_code();
+        let s = layout.generate_property_struct_code();
         assert_eq!(
             s,
             Some(
@@ -1089,7 +1092,7 @@ mod tests {
         assert_eq!(it.next(), Some((16, &prop3)));
         assert_eq!(it.next(), Some((32, &prop1)));
         assert_eq!(it.next(), None);
-        let s = layout.generate_code();
+        let s = layout.generate_property_struct_code();
         assert_eq!(
             s,
             Some(
@@ -1118,7 +1121,7 @@ mod tests {
         assert_eq!(it.next(), Some((0, &prop2)));
         assert_eq!(it.next(), Some((16, &prop1)));
         assert_eq!(it.next(), None);
-        let s = layout.generate_code();
+        let s = layout.generate_property_struct_code();
         assert_eq!(
             s,
             Some(
@@ -1146,7 +1149,7 @@ mod tests {
         assert_eq!(it.next(), Some((0, &prop2)));
         assert_eq!(it.next(), Some((8, &prop1)));
         assert_eq!(it.next(), None);
-        let s = layout.generate_code();
+        let s = layout.generate_property_struct_code();
         assert_eq!(
             s,
             Some(

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -223,6 +223,19 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
         index
     }
 
+    #[inline]
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn last(&self) -> Option<&T> {
+        self.values.last()
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn last_mut(&mut self) -> Option<&mut T> {
+        self.values.last_mut()
+    }
+
     /// Reserve some capacity into the buffer.
     ///
     /// If the buffer is reallocated, the old content (on the GPU) is lost, and

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -8,13 +8,14 @@ use bevy::{
 use fixedbitset::FixedBitSet;
 
 use super::{
-    effect_cache::{DispatchBufferIndices, EffectSlice},
+    effect_cache::EffectSlice,
     event::{CachedChildInfo, CachedEffectEvents},
     BufferBindingSource, ExtractedEffectMesh, LayoutFlags, PropertyBindGroupKey,
 };
 use crate::{
     render::{
         buffer_table::BufferTableId, effect_cache::SlabId, ExtractedEffect, ExtractedSpawner,
+        GpuSpawnerParams,
     },
     AlphaMode, EffectAsset, ParticleLayout, TextureLayout,
 };
@@ -48,6 +49,8 @@ pub(crate) enum BatchSpawnInfo {
 /// Batch of effects dispatched and rendered together.
 #[derive(Debug, Clone)]
 pub(crate) struct EffectBatch {
+    /// ID of the [`GpuBatchInfo`] in the global shared array for this batch.
+    pub batch_info_id: u32,
     /// Handle of the underlying effect asset describing the effect.
     pub handle: Handle<EffectAsset>,
     /// ID of the particle slab in the [`EffectBuffer`] where all the batched
@@ -77,19 +80,12 @@ pub(crate) struct EffectBatch {
     pub child_event_buffers: Vec<(Entity, BufferBindingSource)>,
     /// Index of the property buffer, if any.
     pub property_key: Option<PropertyBindGroupKey>,
-    /// Offset in bytes into the property buffer where the Property struct is
-    /// located for this effect.
-    // FIXME: This is a per-instance value which prevents batching :(
-    pub property_offset: Option<u32>,
     /// Index of the first [`GpuSpawnerParams`] entry of the effects in the
     /// batch. Subsequent batched effects have their entries following linearly
     /// after that one.
     ///
     /// [`GpuSpawnerParams`]: super::GpuSpawnerParams
     pub spawner_base: u32,
-    /// The indices within the various indirect dispatch buffers.
-    // FIXME - this is per-effect not per-batch
-    pub dispatch_buffer_indices: DispatchBufferIndices,
     /// Indirect draw args.
     pub draw_indirect_buffer_row_index: BufferTableId,
     /// Metadata table row index.
@@ -137,6 +133,14 @@ impl SortedEffectBatches {
         self.dispatch_queue_index = None;
     }
 
+    /// Insert a new batch into the collection.
+    ///
+    /// # Returns
+    ///
+    /// This returns the index of the new batch if the inserted one couldn't be
+    /// merged with a previous batch. Otherwise the input batch was merged with
+    /// an existing one, and therefore share its index; in that case `None` is
+    /// returned.
     pub fn push(&mut self, effect_batch: EffectBatch) -> EffectBatchIndex {
         let index = self.batches.len() as u32;
         self.batches.push(effect_batch);
@@ -354,14 +358,12 @@ impl EffectBatch {
         cached_mesh: &ExtractedEffectMesh,
         cached_effect_events: Option<&CachedEffectEvents>,
         cached_child_info: Option<&CachedChildInfo>,
+        spawner_index: u32,
         input: &mut BatchInput,
-        dispatch_buffer_indices: DispatchBufferIndices,
         draw_indirect_buffer_row_index: BufferTableId,
         metadata_table_id: BufferTableId,
         property_key: Option<PropertyBindGroupKey>,
-        property_offset: Option<u32>,
     ) -> EffectBatch {
-        assert_eq!(property_key.is_some(), property_offset.is_some());
         assert_eq!(
             input.event_buffer_index.is_some(),
             input.init_indirect_dispatch_index.is_some()
@@ -379,6 +381,7 @@ impl EffectBatch {
         };
 
         EffectBatch {
+            batch_info_id: u32::MAX, // allocated later once the batch is completed
             handle: extracted_effect.handle.clone(),
             slab_id: input.effect_slice.slab_id,
             slice: input.effect_slice.slice.clone(),
@@ -392,10 +395,8 @@ impl EffectBatch {
                 .map(|cci| cci.parent_buffer_binding_source.clone()),
             child_event_buffers: input.child_effects.clone(),
             property_key,
-            property_offset,
-            spawner_base: input.spawner_index,
+            spawner_base: spawner_index,
             particle_layout: input.effect_slice.particle_layout.clone(),
-            dispatch_buffer_indices,
             draw_indirect_buffer_row_index,
             metadata_table_id,
             layout_flags: extracted_effect.layout_flags,
@@ -423,10 +424,8 @@ pub(crate) struct BatchInput {
     pub event_buffer_index: Option<u32>,
     /// Child effects, if any.
     pub child_effects: Vec<(Entity, BufferBindingSource)>,
-
-    /// Index of the [`GpuSpawnerParams`] in the
-    /// [`EffectsCache::spawner_buffer`].
-    pub spawner_index: u32,
+    /// [`GpuSpawnerParams`] for this instance.
+    pub gpu_spawner_params: GpuSpawnerParams,
     /// Index of the init indirect dispatch struct, if any.
     // FIXME - Contains a single effect's data; should handle multiple ones.
     pub init_indirect_dispatch_index: Option<u32>,

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -26,7 +26,7 @@ use crate::{
     asset::EffectAsset,
     render::{
         calc_hash, event::GpuChildInfo, GpuDrawIndexedIndirectArgs, GpuDrawIndirectArgs,
-        GpuEffectMetadata, GpuIndirectIndex, GpuSpawnerParams, StorageType as _,
+        GpuEffectMetadata, GpuIndirectIndex, StorageType as _,
     },
     ParticleLayout,
 };
@@ -322,9 +322,7 @@ impl ParticleSlab {
         // Create the render layout.
         // TODO - move; this only depends on the particle and spawner layouts, can be
         // shared across slabs
-        let spawner_params_size = GpuSpawnerParams::aligned_size(
-            render_device.limits().min_storage_buffer_offset_alignment,
-        );
+        // FIXME - duplicated in ParticlesRenderPipeline::specialize()
         let label = format!("hanabi:bgl:render:particles@1:slab{}", slab_id.0);
         let render_particles_buffer_layout = render_device.create_bind_group_layout(
             &label[..],
@@ -336,8 +334,6 @@ impl ParticleSlab {
                         .visibility(ShaderStages::VERTEX_FRAGMENT),
                     // @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
                     storage_buffer_read_only::<GpuIndirectIndex>(false),
-                    // @group(1) @binding(2) var<storage, read> spawner : Spawner;
-                    storage_buffer_read_only_sized(true, Some(spawner_params_size)),
                 ),
             ),
         );

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -759,18 +759,6 @@ impl CachedDrawIndirectArgs {
     }
 }
 
-/// The indices in the indirect dispatch buffers for a single effect, as well as
-/// that of the metadata buffer.
-#[derive(Debug, Default, Clone, Copy, Component)]
-pub(crate) struct DispatchBufferIndices {
-    /// The index of the [`GpuDispatchIndirect`] row in the GPU buffer
-    /// [`EffectsMeta::update_dispatch_indirect_buffer`].
-    ///
-    /// [`GpuDispatchIndirect`]: super::GpuDispatchIndirect
-    /// [`EffectsMeta::update_dispatch_indirect_buffer`]: super::EffectsMeta::dispatch_indirect_buffer
-    pub(crate) update_dispatch_indirect_buffer_row_index: u32,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct ParticleBindGroupLayoutKey {
     pub min_binding_size: NonZeroU32,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4497,7 +4497,7 @@ pub(crate) fn batch_effects(
         // Now that the effects are sorted in batching order, we can allocate the
         // GpuSpawnerParams in the GPU buffer, such that they're contiguous for a single
         // batch.
-        let spawner_index = effects_meta.allocate_spawner(input.gpu_spawner_params.clone());
+        let spawner_index = effects_meta.allocate_spawner(input.gpu_spawner_params);
 
         // Spawn one EffectBatch per instance (no batching; TODO). This contains
         // most of the data needed to drive rendering. However this doesn't drive
@@ -5648,9 +5648,9 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
-                &property_cache,
+                property_cache,
                 &render_meshes,
-                &pipeline_cache,
+                pipeline_cache,
                 |id, entity, draw_batch, _view| Transparent2d {
                     sort_key: FloatOrd(draw_batch.translation.z),
                     entity,
@@ -5691,9 +5691,9 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
-                &property_cache,
+                property_cache,
                 &render_meshes,
-                &pipeline_cache,
+                pipeline_cache,
                 |id, entity, batch, view| Transparent3d {
                     distance: view.rangefinder3d().distance(&batch.translation),
                     pipeline: id,
@@ -5729,8 +5729,8 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
-                &property_cache,
-                &pipeline_cache,
+                property_cache,
+                pipeline_cache,
                 &render_meshes,
                 |id, _batch, _view| OpaqueNoLightmap3dBatchSetKey {
                     pipeline: id,
@@ -5771,8 +5771,8 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
-                &property_cache,
-                &pipeline_cache,
+                property_cache,
+                pipeline_cache,
                 &render_meshes,
                 |id, _batch, _view| Opaque3dBatchSetKey {
                     pipeline: id,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -929,7 +929,8 @@ impl FromWorld for PrefixSumPipeline {
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
                 (
-                    // @group(0) @binding(0) var<storage, read_write> batch_infos : array<BatchInfo>;
+                    // @group(0) @binding(0) var<storage, read_write> batch_infos :
+                    // array<BatchInfo>;
                     storage_buffer_sized(
                         false,
                         Some(GpuBatchInfo::aligned_size(
@@ -1757,7 +1758,6 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
 
 #[derive(Resource)]
 pub(crate) struct ParticlesRenderPipeline {
-    render_device: RenderDevice,
     view_layout_desc: BindGroupLayoutDescriptor,
     material_layout_descs: HashMap<TextureLayout, BindGroupLayoutDescriptor>,
 }
@@ -1823,9 +1823,7 @@ impl ParticlesRenderPipeline {
 }
 
 impl FromWorld for ParticlesRenderPipeline {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.get_resource::<RenderDevice>().unwrap();
-
+    fn from_world(_world: &mut World) -> Self {
         let view_layout_desc = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:render:view@0",
             &BindGroupLayoutEntries::sequential(
@@ -1840,7 +1838,6 @@ impl FromWorld for ParticlesRenderPipeline {
         );
 
         Self {
-            render_device: render_device.clone(),
             view_layout_desc,
             material_layout_descs: default(),
         }
@@ -1921,11 +1918,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         trace!("Specializing render pipeline for key: {key:?}");
 
         trace!("Creating layout for bind group particle@1 of render pass");
-        let alignment = self
-            .render_device
-            .limits()
-            .min_storage_buffer_offset_alignment;
-        let spawner_min_binding_size = GpuSpawnerParams::aligned_size(alignment);
+        // FIXME - duplicated in ParticleSlab::new()
         let particle_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:render:particle@1",
             &BindGroupLayoutEntries::sequential(
@@ -1939,8 +1932,6 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
                     .visibility(ShaderStages::VERTEX_FRAGMENT),
                     // @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
                     storage_buffer_read_only::<GpuIndirectIndex>(false),
-                    // @group(1) @binding(2) var<storage, read> spawner : Spawner;
-                    storage_buffer_read_only_sized(true, Some(spawner_min_binding_size)),
                 ),
             ),
         );
@@ -6308,9 +6299,6 @@ pub(crate) fn prepare_bind_groups(
             .or_insert_with(|| {
                 // Bind group particle@1 for render pass
                 trace!("Creating particle@1 bind group for buffer #{slab_index} in render pass");
-                let spawner_min_binding_size = GpuSpawnerParams::aligned_size(
-                    render_device.limits().min_storage_buffer_offset_alignment,
-                );
                 let render = render_device.create_bind_group(
                     &format!("hanabi:bg:render:particles@1:vfx{slab_index}")[..],
                     particle_slab.render_particles_buffer_layout(),
@@ -6321,12 +6309,6 @@ pub(crate) fn prepare_bind_groups(
                         // @group(1) @binding(1) var<storage, read> indirect_buffer :
                         // IndirectBuffer;
                         particle_slab.as_entire_binding_indirect(),
-                        // @group(1) @binding(2) var<storage, read> spawner : Spawner;
-                        BindingResource::Buffer(BufferBinding {
-                            buffer: &spawner_buffer,
-                            offset: 0,
-                            size: Some(spawner_min_binding_size),
-                        }),
                     )),
                 );
 
@@ -6641,16 +6623,12 @@ fn draw<'w>(
     );
 
     // Particles buffer
-    let spawner_base = effect_batch.spawner_base;
-    let spawner_buffer_aligned = effects_meta.spawner_buffer.aligned_size();
-    assert!(spawner_buffer_aligned >= GpuSpawnerParams::min_size().get() as usize);
-    let spawner_offset = spawner_base * spawner_buffer_aligned as u32;
     pass.set_bind_group(
         1,
         effect_bind_groups
             .particle_render(&effect_batch.slab_id)
             .unwrap(),
-        &[spawner_offset],
+        &[],
     );
 
     //

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -71,9 +71,7 @@ use crate::{
     calc_func_id,
     render::{
         batch::{BatchInput, EffectDrawBatch, EffectSorter, InitAndUpdatePipelineIds},
-        effect_cache::{
-            AnyDrawIndirectArgs, CachedDrawIndirectArgs, DispatchBufferIndices, SlabId,
-        },
+        effect_cache::{AnyDrawIndirectArgs, CachedDrawIndirectArgs, SlabId},
     },
     AlphaMode, Attribute, CompiledParticleEffect, EffectProperties, EffectShader, EffectSimulation,
     EffectSpawner, EffectVisibilityClass, ParticleLayout, PropertyLayout, SimulationCondition,
@@ -260,6 +258,7 @@ impl From<&SimParams> for GpuSimParams {
 /// three components of each column would introduce padding, and would use the
 /// same storage size on GPU as a full [`Mat4`].
 #[repr(C)]
+#[repr(align(16))] // alignof(mat3x4)
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable, ShaderType)]
 pub(crate) struct GpuCompressedTransform {
     pub x_row: [f32; 4],
@@ -383,6 +382,42 @@ pub(crate) struct GpuSpawnerParams {
     /// effect's slab (if the effect has a parent effect), in number of
     /// particles (row index). This is ignored if the effect has no parent.
     parent_slab_offset: u32,
+    // For Pod
+    _padding0: u32,
+}
+
+impl GpuSpawnerParams {
+    /// Create a new [`GpuSpawnerParams`] from gathered CPU data.
+    pub fn new(
+        global_transform: &GlobalTransform,
+        spawn_count: u32,
+        prng_seed: u32,
+        slab_offset: u32,
+        parent_slab_offset: Option<u32>,
+        effect_metadata_buffer_table_id: BufferTableId,
+        maybe_cached_draw_indirect_args: Option<&CachedDrawIndirectArgs>,
+    ) -> Self {
+        let transform = global_transform.to_matrix().into();
+        let inverse_transform = Mat4::from(
+            // Inverse the Affine3A first, then convert to Mat4. This is a lot more
+            // efficient than inversing the Mat4.
+            global_transform.affine().inverse(),
+        )
+        .into();
+        Self {
+            transform,
+            inverse_transform,
+            spawn: spawn_count as i32,
+            seed: prng_seed,
+            effect_metadata_index: effect_metadata_buffer_table_id.0,
+            draw_indirect_index: maybe_cached_draw_indirect_args
+                .map(|cdia| cdia.get_row().0)
+                .unwrap_or_default(),
+            slab_offset,
+            parent_slab_offset: parent_slab_offset.unwrap_or(u32::MAX),
+            ..default()
+        }
+    }
 }
 
 /// GPU representation of an indirect compute dispatch input.
@@ -468,9 +503,33 @@ impl Default for GpuDrawIndexedIndirectArgs {
     }
 }
 
-/// Stores metadata about each particle effect.
+/// Shared info for a single batch (single shader invocation).
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Pod, Zeroable, ShaderType)]
+pub struct GpuBatchInfo {
+    pub total_spawn_count: u32,
+    pub total_update_count: u32,
+    pub base_effect: u32,
+    /// Offset to apply to the workgroup thread index to determine the global
+    /// particle index in the currently bound slab. This is often (and ideally)
+    /// zero, but may be > 0 if the entire slab cannot be processed with a
+    /// single batch.
+    pub base_particle: u32,
+    /// Offset, in u32 count (4 bytes), into the prefix sum buffer where the
+    /// first value for this batch is located.
+    pub prefix_sum_offset: u32,
+    /// Number of consecutive values in the prefix sum buffer for this batch.
+    /// This is the number of effects batches together in the batch.
+    pub prefix_sum_count: u32,
+}
+
+/// Metadata describing a single effect instance.
 ///
-/// This is written by the CPU and read by the GPU.
+/// The metadata describes various effect settings, as well we the location in
+/// GPU buffers of the piece of data associated with that instance.
+///
+/// This is the CPU representation equivalent to the WGSL structure on GPU
+/// `EffectMetadata`.
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Pod, Zeroable, ShaderType)]
 pub struct GpuEffectMetadata {
@@ -490,11 +549,6 @@ pub struct GpuEffectMetadata {
     /// The buffers are swapped (ping = 1 - ping) during the indirect dispatch.
     pub indirect_write_index: u32,
 
-    //
-    // Some real metadata values depending on where the effect instance is allocated.
-    /// Index of the [`GpuDispatchIndirect`] struct inside the global
-    /// [`EffectsMeta::dispatch_indirect_buffer`].
-    pub indirect_dispatch_index: u32,
     /// Index of the [`GpuDrawIndirect`] or [`GpuDrawIndexedIndirect`] struct
     /// inside the global [`EffectsMeta::draw_indirect_buffer`] or
     /// [`EffectsMeta::draw_indexed_indirect_buffer`]. The actual buffer depends
@@ -505,6 +559,9 @@ pub struct GpuEffectMetadata {
     /// buffer. This avoids having to align those 16-byte structs to the GPU
     /// alignment (at least 32 bytes, even 256 bytes on some).
     pub init_indirect_dispatch_index: u32,
+    /// Offset (in u32 count) of the start of the property block for this
+    /// effect. This is ignored if the effect doesn't use properties.
+    pub properties_offset: u32,
     /// Index of this effect into its parent's ChildInfo array
     /// ([`EffectChildren::effect_cache_ids`] and its associated GPU
     /// array). This starts at zero for the first child of each effect, and is
@@ -705,8 +762,6 @@ pub(crate) struct DispatchIndirectPipeline {
 
 impl FromWorld for DispatchIndirectPipeline {
     fn from_world(world: &mut World) -> Self {
-        let render_device = world.get_resource::<RenderDevice>().unwrap();
-
         // Copy the indirect pipeline shaders to self, because we can't access anything
         // else during pipeline specialization.
         let (indirect_shader_noevent, indirect_shader_events) = {
@@ -717,13 +772,9 @@ impl FromWorld for DispatchIndirectPipeline {
             )
         };
 
-        let storage_alignment = render_device.limits().min_storage_buffer_offset_alignment;
-        let effect_metadata_size = GpuEffectMetadata::aligned_size(storage_alignment);
-        let spawner_min_binding_size = GpuSpawnerParams::aligned_size(storage_alignment);
-
         // @group(0) @binding(0) var<uniform> sim_params : SimParams;
         trace!("GpuSimParams: min_size={}", GpuSimParams::min_size());
-        let sim_params_bind_group_layout = BindGroupLayoutDescriptor::new(
+        let sim_params_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:dispatch_indirect:sim_params",
             &BindGroupLayoutEntries::single(
                 ShaderStages::COMPUTE,
@@ -732,18 +783,17 @@ impl FromWorld for DispatchIndirectPipeline {
         );
 
         trace!(
-            "GpuEffectMetadata: min_size={} padded_size={}",
-            GpuEffectMetadata::min_size(),
-            effect_metadata_size,
+            "GpuEffectMetadata: min_size={}",
+            GpuEffectMetadata::min_size()
         );
-        let effect_metadata_bind_group_layout = BindGroupLayoutDescriptor::new(
+        let effect_metadata_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:dispatch_indirect:effect_metadata@1",
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
                 (
                     // @group(1) @binding(0) var<storage, read_write> effect_metadata_buffer :
                     // array<u32>;
-                    storage_buffer_sized(false, Some(effect_metadata_size)),
+                    storage_buffer::<GpuEffectMetadata>(false),
                     // @group(1) @binding(1) var<storage, read_write> dispatch_indirect_buffer :
                     // array<u32>;
                     storage_buffer::<GpuIndirectIndex>(false),
@@ -754,31 +804,40 @@ impl FromWorld for DispatchIndirectPipeline {
             ),
         );
 
-        // @group(2) @binding(0) var<storage, read_write> spawner_buffer :
-        // array<Spawner>;
-        let spawner_bind_group_layout = BindGroupLayoutDescriptor::new(
+        trace!(
+            "GpuSpawnerParams: min_size={}",
+            GpuSpawnerParams::min_size()
+        );
+        let spawner_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:dispatch_indirect:spawner@2",
-            &BindGroupLayoutEntries::single(
+            &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
-                storage_buffer_sized(false, Some(spawner_min_binding_size)),
+                (
+                    // @group(2) @binding(0) var<storage, read_write> spawner_buffer :
+                    // array<Spawner>;
+                    storage_buffer::<GpuSpawnerParams>(false),
+                    // @group(2) @binding(1) var<storage, read_write> prefix_sum : array<u32>;
+                    storage_buffer::<u32>(false),
+                ),
             ),
         );
 
-        // @group(3) @binding(0) var<storage, read_write> child_info_buffer :
-        // ChildInfoBuffer;
-        let child_infos_bind_group_layout = BindGroupLayoutDescriptor::new(
-            "hanabi:bgl:dispatch_indirect:child_infos",
+        trace!("GpuChildInfo: min_size={}", GpuChildInfo::min_size());
+        let child_infos_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
+            "hanabi:bgl:dispatch_indirect:child_infos@3",
             &BindGroupLayoutEntries::single(
                 ShaderStages::COMPUTE,
+                // @group(3) @binding(0) var<storage, read_write> child_info_buffer :
+                // ChildInfoBuffer;
                 storage_buffer::<GpuChildInfo>(false),
             ),
         );
 
         Self {
-            sim_params_bind_group_layout_desc: sim_params_bind_group_layout,
-            effect_metadata_bind_group_layout_desc: effect_metadata_bind_group_layout,
-            spawner_bind_group_layout_desc: spawner_bind_group_layout,
-            child_infos_bind_group_layout_desc: child_infos_bind_group_layout,
+            sim_params_bind_group_layout_desc,
+            effect_metadata_bind_group_layout_desc,
+            spawner_bind_group_layout_desc,
+            child_infos_bind_group_layout_desc,
             indirect_shader_noevent,
             indirect_shader_events,
         }
@@ -805,9 +864,6 @@ impl SpecializedComputePipeline for DispatchIndirectPipeline {
         );
 
         let mut shader_defs = Vec::with_capacity(2);
-        // Spawner struct needs to be defined with padding, because it's bound as an
-        // array
-        shader_defs.push("SPAWNER_PADDING".into());
         if key.has_events {
             shader_defs.push("HAS_GPU_SPAWN_EVENTS".into());
         }
@@ -838,6 +894,73 @@ impl SpecializedComputePipeline for DispatchIndirectPipeline {
                 self.indirect_shader_noevent.clone()
             },
             shader_defs,
+            entry_point: Some("main".into()),
+            push_constant_ranges: vec![],
+            zero_initialize_workgroup_memory: false,
+        }
+    }
+}
+
+/// Compute pipeline to run the `vfx_prefix_sum` dispatch workgroup calculation
+/// shader.
+#[derive(Resource)]
+pub(crate) struct PrefixSumPipeline {
+    /// Layout of the (only) bind group.
+    bind_group_layout_desc: BindGroupLayoutDescriptor,
+    /// Shader.
+    compute_shader: Handle<Shader>,
+}
+
+impl FromWorld for PrefixSumPipeline {
+    fn from_world(world: &mut World) -> Self {
+        // FIXME - we don't really need to keep this in EffectsMeta, could move here,
+        // and replace the FromWorld with Default
+        let compute_shader = {
+            let effects_meta = world.get_resource::<EffectsMeta>().unwrap();
+            effects_meta.prefix_sum_shader.clone()
+        };
+        let min_storage_buffer_offset_alignment = {
+            let render_device = world.get_resource::<RenderDevice>().unwrap();
+            render_device.limits().min_storage_buffer_offset_alignment
+        };
+
+        let bind_group_layout_desc = BindGroupLayoutDescriptor::new(
+            "hanabi:bgl:prefix_sum:@0",
+            &BindGroupLayoutEntries::sequential(
+                ShaderStages::COMPUTE,
+                (
+                    // @group(0) @binding(0) var<storage, read_write> batch_infos : array<BatchInfo>;
+                    storage_buffer_sized(
+                        false,
+                        Some(GpuBatchInfo::aligned_size(
+                            min_storage_buffer_offset_alignment,
+                        )),
+                    ),
+                    // @group(0) @binding(1) var<storage, read_write> prefix_sum : array<u32>;
+                    storage_buffer::<u32>(false),
+                    // @group(0) @binding(2) var<storage, read_write> dispatch_indirect_buffer :
+                    // array<DispatchIndirectArgs>;
+                    storage_buffer::<GpuDispatchIndirectArgs>(false),
+                ),
+            ),
+        );
+
+        Self {
+            bind_group_layout_desc,
+            compute_shader,
+        }
+    }
+}
+
+impl PrefixSumPipeline {
+    pub fn make_pipeline_desc(&self) -> ComputePipelineDescriptor {
+        trace!("Create prefix sum pipeline");
+
+        ComputePipelineDescriptor {
+            label: Some("hanabi:compute_pipeline:prefix_sum".into()),
+            layout: vec![self.bind_group_layout_desc.clone()],
+            shader: self.compute_shader.clone(),
+            shader_defs: vec![],
             entry_point: Some("main".into()),
             push_constant_ranges: vec![],
             zero_initialize_workgroup_memory: false,
@@ -1775,6 +1898,8 @@ pub(crate) struct ParticleRenderPipelineKey {
     msaa_samples: u32,
     /// Is the camera using an HDR render target?
     hdr: bool,
+    /// Layout of the spawner@2 bind group this pipeline was specialized with.
+    spawner_bind_group_layout_desc: BindGroupLayoutDescriptor,
 }
 
 #[derive(Clone, Copy, Default, Hash, PartialEq, Eq, Debug)]
@@ -1787,29 +1912,6 @@ pub(crate) enum ParticleRenderAlphaMaskPipelineKey {
     /// Key: OPAQUE
     /// The effect is rendered fully-opaquely.
     Opaque,
-}
-
-impl Default for ParticleRenderPipelineKey {
-    fn default() -> Self {
-        Self {
-            shader: Handle::default(),
-            particle_layout: ParticleLayout::empty(),
-            mesh_layout: None,
-            texture_layout: default(),
-            local_space_simulation: false,
-            alpha_mask: default(),
-            alpha_mode: AlphaMode::Blend,
-            flipbook: false,
-            needs_uv: false,
-            needs_normal: false,
-            needs_particle_fragment: false,
-            ribbons: false,
-            #[cfg(all(feature = "2d", feature = "3d"))]
-            pipeline_mode: PipelineMode::Camera3d,
-            msaa_samples: Msaa::default().samples(),
-            hdr: false,
-        }
-    }
 }
 
 impl SpecializedRenderPipeline for ParticlesRenderPipeline {
@@ -1846,6 +1948,7 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
         let mut layout = vec![
             self.view_layout_desc.clone(),
             particle_bind_group_layout_desc,
+            key.spawner_bind_group_layout_desc.clone(),
         ];
         let mut shader_defs = vec![];
 
@@ -2635,10 +2738,9 @@ pub struct EffectsMeta {
     /// Bind group #0 of the vfx_update shader, for the simulation parameters
     /// like the current time and frame delta time.
     update_sim_params_bind_group: Option<BindGroup>,
-    /// Bind group #0 of the vfx_indirect shader, for the simulation parameters
-    /// like the current time and frame delta time. This is shared with the
-    /// vfx_init pass too.
-    indirect_sim_params_bind_group: Option<BindGroup>,
+    /// Bind group #0 of the vfx_init and vfx_indirect shaders, for the
+    /// simulation parameters like the current time and frame delta time.
+    init_and_indirect_sim_params_bind_group: Option<BindGroup>,
     /// Bind group #1 of the vfx_indirect shader, containing both the indirect
     /// compute dispatch and render buffers.
     indirect_metadata_bind_group: Option<BindGroup>,
@@ -2659,6 +2761,14 @@ pub struct EffectsMeta {
     /// other being GpuDrawIndirectArgs). For non-indexed entries, we ignore
     /// the last `u32` value.
     draw_indirect_buffer: BufferTable<GpuDrawIndexedIndirectArgs>,
+    /// Global shared GPU buffer storing the various `BatchInfo` structs for the
+    /// active batches. This is dynamically updated each frame based on current
+    /// batching, with one entry per batch (= one entry per dispatch/draw).
+    batch_info_buffer: AlignedBufferVec<GpuBatchInfo>,
+    /// Debug: was begin_batch() called without end_batch()?
+    is_batch_open: bool,
+    /// Buffer containing the prefix sums for all batches.
+    prefix_sum_buffer: BufferVec<u32>,
     /// Global shared GPU buffer storing the various `EffectMetadata`
     /// structs for the active effect instances.
     effect_metadata_buffer: BufferTable<GpuEffectMetadata>,
@@ -2674,6 +2784,10 @@ pub struct EffectsMeta {
     /// is either the -noevent or -events variant depending on whether there's
     /// any child effect with GPU events currently active.
     active_indirect_pipeline_id: CachedComputePipelineId,
+
+    prefix_sum_shader: Handle<Shader>,
+    prefix_sum_bind_group: Option<BindGroup>,
+    prefix_sum_pipeline_id: CachedComputePipelineId,
 }
 
 impl EffectsMeta {
@@ -2681,6 +2795,7 @@ impl EffectsMeta {
         device: RenderDevice,
         indirect_shader_noevent: Handle<Shader>,
         indirect_shader_events: Handle<Shader>,
+        prefix_sum_shader: Handle<Shader>,
     ) -> Self {
         let gpu_limits = GpuLimits::from_device(&device);
 
@@ -2692,10 +2807,13 @@ impl EffectsMeta {
             item_align.get()
         );
 
+        let mut prefix_sum_buffer = BufferVec::new(BufferUsages::STORAGE);
+        prefix_sum_buffer.set_label(Some("prefix_sum_buffer"));
+
         Self {
             view_bind_group: None,
             update_sim_params_bind_group: None,
-            indirect_sim_params_bind_group: None,
+            init_and_indirect_sim_params_bind_group: None,
             indirect_metadata_bind_group: None,
             indirect_spawner_bind_group: None,
             sim_params_uniforms: UniformBuffer::default(),
@@ -2713,6 +2831,13 @@ impl EffectsMeta {
                 Some(GpuDrawIndexedIndirectArgs::SHADER_SIZE),
                 Some("hanabi:buffer:draw_indirect".to_string()),
             ),
+            batch_info_buffer: AlignedBufferVec::new(
+                BufferUsages::STORAGE,
+                Some(item_align.into()),
+                Some("hanabi:buffer:batch_info".to_string()),
+            ),
+            is_batch_open: false,
+            prefix_sum_buffer,
             effect_metadata_buffer: BufferTable::new(
                 BufferUsages::STORAGE | BufferUsages::INDIRECT,
                 Some(item_align.into()),
@@ -2726,42 +2851,77 @@ impl EffectsMeta {
                 CachedComputePipelineId::INVALID,
             ],
             active_indirect_pipeline_id: CachedComputePipelineId::INVALID,
+            prefix_sum_shader,
+            prefix_sum_bind_group: None,
+            prefix_sum_pipeline_id: CachedComputePipelineId::INVALID,
         }
     }
 
-    pub fn allocate_spawner(
-        &mut self,
-        global_transform: &GlobalTransform,
-        spawn_count: u32,
-        prng_seed: u32,
-        slab_offset: u32,
-        parent_slab_offset: Option<u32>,
-        effect_metadata_buffer_table_id: BufferTableId,
-        maybe_cached_draw_indirect_args: Option<&CachedDrawIndirectArgs>,
-    ) -> u32 {
-        let spawner_base = self.spawner_buffer.len() as u32;
-        let transform = global_transform.to_matrix().into();
-        let inverse_transform = Mat4::from(
-            // Inverse the Affine3A first, then convert to Mat4. This is a lot more
-            // efficient than inversing the Mat4.
-            global_transform.affine().inverse(),
-        )
-        .into();
-        let spawner_params = GpuSpawnerParams {
-            transform,
-            inverse_transform,
-            spawn: spawn_count as i32,
-            seed: prng_seed,
-            effect_metadata_index: effect_metadata_buffer_table_id.0,
-            draw_indirect_index: maybe_cached_draw_indirect_args
-                .map(|cdia| cdia.get_row().0)
-                .unwrap_or_default(),
-            slab_offset,
-            parent_slab_offset: parent_slab_offset.unwrap_or(u32::MAX),
-            ..default()
+    /// Begin a new batch of effects.
+    pub fn begin_batch(&mut self, base_particle: u32, spawner_base: u32) -> u32 {
+        assert!(!self.is_batch_open, "Duplicate call to begin_batch()");
+
+        let prefix_sum_offset = self.prefix_sum_buffer.len() as u32;
+
+        let batch_info_base = self.batch_info_buffer.len() as u32;
+        let batch_info = GpuBatchInfo {
+            total_spawn_count: 0,
+            total_update_count: 0,
+            base_effect: spawner_base,
+            base_particle,
+            prefix_sum_offset,
+            prefix_sum_count: u32::MAX, // invalid; set in end_batch()
         };
-        trace!("spawner params = {:?}", spawner_params);
-        self.spawner_buffer.push(spawner_params);
+        trace!("batch info = {:?}", batch_info);
+        self.batch_info_buffer.push(batch_info);
+        self.is_batch_open = true;
+
+        // Ensure we allocate the DI entries with the same indexing as the batch info
+        // ones, so that shaders can index them with the batch info index.
+        let di_index = self.dispatch_indirect_buffer.allocate();
+        assert_eq!(di_index, batch_info_base);
+
+        batch_info_base
+    }
+
+    /// Add a single effect instance to the current batch.
+    pub fn add_effect_to_batch(&mut self, slab_offset: u32) {
+        assert!(
+            self.is_batch_open,
+            "Cannot add effect before calling begin_batch()"
+        );
+        self.prefix_sum_buffer.push(slab_offset);
+    }
+
+    /// End the current batch.
+    pub fn end_batch(&mut self) {
+        assert!(
+            self.is_batch_open,
+            "Call to end_batch() without begin_batch()"
+        );
+
+        let batch = self
+            .batch_info_buffer
+            .last_mut()
+            .expect("No open batch. Missing begin_batch() call?");
+        let end = self.prefix_sum_buffer.len() as u32;
+        assert!(end >= batch.prefix_sum_offset);
+        batch.prefix_sum_count = end - batch.prefix_sum_offset;
+
+        self.is_batch_open = false;
+    }
+
+    /// Allocate a [`GpuSpawnerParams`] entry into the global shared GPU buffer.
+    ///
+    /// The entry is allocated for a single render frame. It's automatically
+    /// deallocated at the end of this render frame.
+    ///
+    /// # Returns
+    ///
+    /// This returns the index of the entry into the global GPU buffer.
+    pub fn allocate_spawner(&mut self, gpu_spawner_params: GpuSpawnerParams) -> u32 {
+        let spawner_base = self.spawner_buffer.len() as u32;
+        self.spawner_buffer.push(gpu_spawner_params);
         spawner_base
     }
 
@@ -2839,14 +2999,12 @@ pub(crate) fn on_remove_cached_effect(
         Entity,
         &MainEntity,
         &CachedEffect,
-        &DispatchBufferIndices,
         Option<&CachedEffectProperties>,
         Option<&CachedParentInfo>,
         Option<&CachedEffectEvents>,
     )>,
     mut effect_cache: ResMut<EffectCache>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
-    mut effects_meta: ResMut<EffectsMeta>,
     mut event_cache: ResMut<EventCache>,
 ) {
     #[cfg(feature = "trace")]
@@ -2861,7 +3019,6 @@ pub(crate) fn on_remove_cached_effect(
         render_entity,
         main_entity,
         cached_effect,
-        dispatch_buffer_indices,
         _opt_props,
         _opt_parent,
         opt_cached_effect_events,
@@ -2907,9 +3064,6 @@ pub(crate) fn on_remove_cached_effect(
     effect_bind_groups
         .particle_slabs
         .remove(&cached_effect.slab_id);
-    effects_meta
-        .dispatch_indirect_buffer
-        .free(dispatch_buffer_indices.update_dispatch_indirect_buffer_row_index);
 }
 
 /// Observer raised when the [`CachedEffectMetadata`] component is removed, to
@@ -3039,20 +3193,16 @@ pub fn allocate_effects(
             &ExtractedEffect,
             Has<ChildEffectOf>,
             Option<&mut CachedEffect>,
-            Has<DispatchBufferIndices>,
         ),
         Changed<ExtractedEffect>,
     >,
     mut effect_cache: ResMut<EffectCache>,
-    mut effects_meta: ResMut<EffectsMeta>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("allocate_effects").entered();
     trace!("allocate_effects");
 
-    for (entity, extracted_effect, has_parent, maybe_cached_effect, has_dispatch_buffer_indices) in
-        &mut q_extracted_effects
-    {
+    for (entity, extracted_effect, has_parent, maybe_cached_effect) in &mut q_extracted_effects {
         // Insert or update the effect into the EffectCache
         if let Some(mut cached_effect) = maybe_cached_effect {
             trace!("Updating EffectCache entry for entity {entity:?}...");
@@ -3089,15 +3239,6 @@ pub fn allocate_effects(
                 .layout_flags
                 .contains(LayoutFlags::CONSUME_GPU_SPAWN_EVENTS);
             effect_cache.ensure_metadata_init_bind_group_layout_desc(consume_gpu_spawn_events);
-        }
-
-        // Allocate DispatchBufferIndices if not present yet
-        if !has_dispatch_buffer_indices {
-            let update_dispatch_indirect_buffer_row_index =
-                effects_meta.dispatch_indirect_buffer.allocate();
-            commands.entity(entity).insert(DispatchBufferIndices {
-                update_dispatch_indirect_buffer_row_index,
-            });
         }
     }
 }
@@ -3691,7 +3832,15 @@ pub fn prepare_indirect_pipeline(
     mut specialized_indirect_pipelines: ResMut<
         SpecializedComputePipelines<DispatchIndirectPipeline>,
     >,
+    prefix_sum_pipeline: Res<PrefixSumPipeline>,
 ) {
+    // Queue the vfx_prefix_sum pipeline if not already ready
+    // TODO - not really related to this system, should probably be moved?
+    if effects_meta.prefix_sum_pipeline_id == CachedComputePipelineId::INVALID {
+        effects_meta.prefix_sum_pipeline_id =
+            pipeline_cache.queue_compute_pipeline(prefix_sum_pipeline.make_pipeline_desc())
+    }
+
     // Ensure the 2 variants of the indirect pipelines are created.
     // TODO - move that elsewhere in some one-time setup?
     if effects_meta.indirect_pipeline_ids[0] == CachedComputePipelineId::INVALID {
@@ -3886,8 +4035,6 @@ impl CachedReadyState {
 #[derive(SystemParam)]
 pub struct PrepareEffectsReadOnlyParams<'w, 's> {
     sim_params: Res<'w, SimParams>,
-    render_device: Res<'w, RenderDevice>,
-    render_queue: Res<'w, RenderQueue>,
     marker: PhantomData<&'s usize>,
 }
 
@@ -4062,8 +4209,6 @@ pub(crate) fn prepare_batch_inputs(
     read_only_params: PrepareEffectsReadOnlyParams,
     pipeline_cache: Res<PipelineCache>,
     mut effects_meta: ResMut<EffectsMeta>,
-    mut effect_bind_groups: ResMut<EffectBindGroups>,
-    mut property_bind_groups: ResMut<PropertyBindGroups>,
     q_cached_effects: Query<(
         MainEntity,
         Entity,
@@ -4087,11 +4232,10 @@ pub(crate) fn prepare_batch_inputs(
 
     // Workaround for too many params in system (TODO: refactor to split work?)
     let sim_params = read_only_params.sim_params.into_inner();
-    let render_device = read_only_params.render_device.into_inner();
-    let render_queue = read_only_params.render_queue.into_inner();
 
     // Clear per-instance buffers, which are filled below and re-uploaded each frame
     effects_meta.spawner_buffer.clear();
+    effects_meta.dispatch_indirect_buffer.clear();
 
     // Build batcher inputs from extracted effects, updating all cached components
     // for each effect on the fly.
@@ -4210,7 +4354,7 @@ pub(crate) fn prepare_batch_inputs(
         let parent_slab_offset = maybe_cached_child_info.map(|cci| cci.parent_slab_offset);
 
         assert!(cached_effect_metadata.table_id.is_valid());
-        let spawner_index = effects_meta.allocate_spawner(
+        let gpu_spawner_params = GpuSpawnerParams::new(
             &extracted_spawner.transform,
             extracted_spawner.spawn_count,
             extracted_spawner.prng_seed,
@@ -4232,7 +4376,7 @@ pub(crate) fn prepare_batch_inputs(
                 .as_ref()
                 .map(|cp| cp.children.clone())
                 .unwrap_or_default(),
-            spawner_index,
+            gpu_spawner_params,
             init_indirect_dispatch_index: maybe_cached_child_info
                 .as_ref()
                 .map(|cc| cc.init_indirect_dispatch_index),
@@ -4259,21 +4403,6 @@ pub(crate) fn prepare_batch_inputs(
         );
         effects_meta.sim_params_uniforms.set(gpu_sim_params);
     }
-
-    // Write the entire spawner buffer for this frame, for all effects combined
-    assert_eq!(
-        prepared_effect_count,
-        effects_meta.spawner_buffer.len() as u32
-    );
-    if effects_meta
-        .spawner_buffer
-        .write_buffer(render_device, render_queue)
-    {
-        // All property bind groups use the spawner buffer, which was reallocate
-        effect_bind_groups.particle_slabs.clear();
-        property_bind_groups.clear(true);
-        effects_meta.indirect_spawner_bind_group = None;
-    }
 }
 
 /// Batch compatible effects together into a single pass.
@@ -4283,8 +4412,10 @@ pub(crate) fn prepare_batch_inputs(
 /// batch those groups together. Each batch can be updated and rendered with a
 /// single compute dispatch or draw call.
 pub(crate) fn batch_effects(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
     mut commands: Commands,
-    effects_meta: Res<EffectsMeta>,
+    mut effects_meta: ResMut<EffectsMeta>,
     mut sort_bind_groups: ResMut<SortBindGroups>,
     mut q_cached_effects: Query<(
         Entity,
@@ -4298,12 +4429,13 @@ pub(crate) fn batch_effects(
         Option<&ChildEffectOf>,
         Option<&CachedChildInfo>,
         Option<&CachedEffectProperties>,
-        &mut DispatchBufferIndices,
         // The presence of BatchInput ensure the effect is ready
         &mut BatchInput,
     )>,
     mut sorted_effect_batches: ResMut<SortedEffectBatches>,
     mut gpu_buffer_operations: ResMut<GpuBufferOperations>,
+    mut effect_bind_groups: ResMut<EffectBindGroups>,
+    mut property_bind_groups: ResMut<PropertyBindGroups>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("batch_effects").entered();
@@ -4317,7 +4449,7 @@ pub(crate) fn batch_effects(
     // - with parents before their children, to ensure ???? FIXME don't we need to
     //   opposite?!!!
     let mut effect_sorter = EffectSorter::new();
-    for (entity, _, _, _, _, _, _, _, child_of, _, _, _, input) in &q_cached_effects {
+    for (entity, _, _, _, _, _, _, _, child_of, _, _, input) in &q_cached_effects {
         effect_sorter.insert(
             entity,
             input.effect_slice.slab_id,
@@ -4332,6 +4464,9 @@ pub(crate) fn batch_effects(
     sort_bind_groups.clear_indirect_dispatch_buffer();
 
     let mut sort_queue = GpuBufferOperationQueue::new();
+
+    effects_meta.prefix_sum_buffer.clear();
+    effects_meta.batch_info_buffer.clear();
 
     // Loop on all extracted effects in sorted order, and try to batch them together
     // to reduce draw calls. -- currently does nothing, batching was broken and
@@ -4351,7 +4486,6 @@ pub(crate) fn batch_effects(
             _,
             cached_child_info,
             cached_properties,
-            dispatch_buffer_indices,
             mut input,
         )) = q_cached_effects.get_mut(entity)
         else {
@@ -4359,6 +4493,11 @@ pub(crate) fn batch_effects(
         };
 
         let translation = extracted_spawner.transform.translation();
+
+        // Now that the effects are sorted in batching order, we can allocate the
+        // GpuSpawnerParams in the GPU buffer, such that they're contiguous for a single
+        // batch.
+        let spawner_index = effects_meta.allocate_spawner(input.gpu_spawner_params.clone());
 
         // Spawn one EffectBatch per instance (no batching; TODO). This contains
         // most of the data needed to drive rendering. However this doesn't drive
@@ -4370,15 +4509,14 @@ pub(crate) fn batch_effects(
             extracted_effect_mesh,
             cached_effect_events,
             cached_child_info,
+            spawner_index,
             &mut input,
-            *dispatch_buffer_indices,
             cached_draw_indirect_args.row,
             cached_effect_metadata.table_id,
             cached_properties.map(|cp| PropertyBindGroupKey {
                 buffer_index: cp.buffer_index,
                 binding_size: cp.property_layout.min_binding_size().get() as u32,
             }),
-            cached_properties.map(|cp| cp.range.start),
         );
 
         // If the batch has ribbons, we need to sort the particles by RIBBON_ID and AGE
@@ -4459,10 +4597,41 @@ pub(crate) fn batch_effects(
             }
         }
 
+        // Append the batch to the (sorted) set of batches to render. If that batch
+        // couldn't be merged together with the previous one, then it creates a separate
+        // draw call. In that case, spawn an EffectDrawBatch to render that new separate
+        // batch.
+        // if let Some(effect_batch_index) = sorted_effect_batches.push(effect_batch) {
+        //     trace!(
+        //         "Queued new effect batch #{:?} from cached instance on entity {:?}.",
+        //         effect_batch_index,
+        //         entity,
+        //     );
+
+        //     // Spawn an EffectDrawBatch, to actually drive rendering of that new
+        // batch.     commands
+        //         .spawn(EffectDrawBatch {
+        //             effect_batch_index,
+        //             translation,
+        //             main_entity: *main_entity,
+        //         })
+        //         .insert(TemporaryRenderEntity);
+        // } else {
+        //     trace!("Cached instance on entity {entity:?} merged with last effect
+        // batch"); }
+
+        // FIXME - for now, no batching, so any new effect is a new batch...
+        let batch_info_id =
+            effects_meta.begin_batch(effect_batch.slice.start, effect_batch.spawner_base);
+        effect_batch.batch_info_id = batch_info_id;
+        effects_meta.add_effect_to_batch(effect_batch.slice.start);
+        effects_meta.end_batch();
+
         let effect_batch_index = sorted_effect_batches.push(effect_batch);
         trace!(
-            "Spawned effect batch #{:?} from cached instance on entity {:?}.",
+            "Spawned effect batch #{:?} with batch-info-id {} from cached instance on entity {:?}.",
             effect_batch_index,
+            batch_info_id,
             entity,
         );
 
@@ -4481,6 +4650,53 @@ pub(crate) fn batch_effects(
     if !sort_queue.operation_queue.is_empty() {
         sorted_effect_batches.dispatch_queue_index = Some(gpu_buffer_operations.submit(sort_queue));
     }
+
+    // Write the entire spawner buffer for this frame, for all effects combined
+    if effects_meta
+        .spawner_buffer
+        .write_buffer(&render_device, &render_queue)
+    {
+        // All property bind groups use the spawner buffer, which was reallocate
+        effect_bind_groups.particle_slabs.clear();
+        property_bind_groups.clear(true);
+        effects_meta.indirect_spawner_bind_group = None;
+    }
+
+    // Write the entire batch info buffer for this frame, for all batches combined
+    if effects_meta
+        .batch_info_buffer
+        .write_buffer(&render_device, &render_queue)
+    {
+        // All property bind groups use the spawner buffer, which was reallocate
+        effect_bind_groups.particle_slabs.clear();
+        property_bind_groups.clear(true);
+        effects_meta.indirect_spawner_bind_group = None;
+        effects_meta.prefix_sum_bind_group = None;
+    }
+
+    // Write the entire prefix sum buffer for this frame, for all batches combined
+    {
+        let cpu_len = effects_meta.prefix_sum_buffer.len();
+        if cpu_len > 0 {
+            let gpu_capacity = effects_meta.prefix_sum_buffer.capacity();
+            if cpu_len > gpu_capacity {
+                effects_meta
+                    .prefix_sum_buffer
+                    .reserve(cpu_len, &render_device);
+
+                // Reallocated!
+                // All property bind groups use the spawner buffer, which was reallocate
+                effect_bind_groups.particle_slabs.clear();
+                property_bind_groups.clear(true);
+                effects_meta.indirect_spawner_bind_group = None;
+                effects_meta.prefix_sum_bind_group = None;
+            }
+            assert!(effects_meta.prefix_sum_buffer.buffer().is_some());
+            effects_meta
+                .prefix_sum_buffer
+                .write_buffer(&render_device, &render_queue);
+        }
+    }
 }
 
 /// Per-buffer bind groups for a GPU effect buffer.
@@ -4494,7 +4710,6 @@ pub(crate) struct BufferBindGroups {
     /// ```wgsl
     /// @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
     /// @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
-    /// @binding(2) var<storage, read> spawner : Spawner;
     /// ```
     render: BindGroup,
     // /// Bind group for filling the indirect dispatch arguments of any child init
@@ -4927,6 +5142,9 @@ impl EffectBindGroups {
 
 #[derive(SystemParam)]
 pub struct QueueEffectsReadOnlyParams<'w, 's> {
+    effects_meta: Res<'w, EffectsMeta>,
+    property_cache: Res<'w, PropertyCache>,
+    pipeline_cache: Res<'w, PipelineCache>,
     #[cfg(feature = "2d")]
     draw_functions_2d: Res<'w, DrawFunctions<Transparent2d>>,
     #[cfg(feature = "3d")]
@@ -4946,6 +5164,7 @@ fn emit_sorted_draw<T, F>(
     effect_draw_batches: &Query<(Entity, &mut EffectDrawBatch)>,
     render_pipeline: &mut ParticlesRenderPipeline,
     mut specialized_render_pipelines: Mut<SpecializedRenderPipelines<ParticlesRenderPipeline>>,
+    property_cache: &PropertyCache,
     render_meshes: &RenderAssets<RenderMesh>,
     pipeline_cache: &PipelineCache,
     make_phase_item: F,
@@ -5076,6 +5295,21 @@ fn emit_sorted_draw<T, F>(
 
             let alpha_mode = effect_batch.alpha_mode;
 
+            // This should always exist by the time we reach this point, because we should
+            // have inserted any property in the cache, which would have allocated the
+            // proper bind group layout (or the default no-property one).
+            let property_layout_min_binding_size = effect_batch
+                .property_key
+                .map(|key| NonZeroU64::new(key.binding_size as u64).unwrap());
+            let spawner_bind_group_layout_desc = property_cache
+                .bind_group_layout_desc(property_layout_min_binding_size)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Failed to find spawner@2 bind group layout for property binding size {:?}",
+                        property_layout_min_binding_size,
+                    )
+                });
+
             #[cfg(feature = "trace")]
             let _span_specialize = bevy::log::info_span!("specialize").entered();
             let render_pipeline_id = specialized_render_pipelines.specialize(
@@ -5098,6 +5332,7 @@ fn emit_sorted_draw<T, F>(
                     pipeline_mode,
                     msaa_samples: msaa.samples(),
                     hdr: view.hdr,
+                    spawner_bind_group_layout_desc: spawner_bind_group_layout_desc.clone(),
                 },
             );
             #[cfg(feature = "trace")]
@@ -5131,6 +5366,7 @@ fn emit_binned_draw<T, F, G>(
     effect_draw_batches: &Query<(Entity, &mut EffectDrawBatch)>,
     render_pipeline: &mut ParticlesRenderPipeline,
     mut specialized_render_pipelines: Mut<SpecializedRenderPipelines<ParticlesRenderPipeline>>,
+    property_cache: &PropertyCache,
     pipeline_cache: &PipelineCache,
     render_meshes: &RenderAssets<RenderMesh>,
     make_batch_set_key: F,
@@ -5262,6 +5498,21 @@ fn emit_binned_draw<T, F, G>(
                 continue;
             };
 
+            // This should always exist by the time we reach this point, because we should
+            // have inserted any property in the cache, which would have allocated the
+            // proper bind group layout (or the default no-property one).
+            let property_layout_min_binding_size = effect_batch
+                .property_key
+                .map(|key| NonZeroU64::new(key.binding_size as u64).unwrap());
+            let spawner_bind_group_layout_desc = property_cache
+                .bind_group_layout_desc(property_layout_min_binding_size)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Failed to find spawner@2 bind group layout for property binding size {:?}",
+                        property_layout_min_binding_size,
+                    )
+                });
+
             #[cfg(feature = "trace")]
             let _span_specialize = bevy::log::info_span!("specialize").entered();
             let render_pipeline_id = specialized_render_pipelines.specialize(
@@ -5284,6 +5535,7 @@ fn emit_binned_draw<T, F, G>(
                     pipeline_mode,
                     msaa_samples: msaa.samples(),
                     hdr: view.hdr,
+                    spawner_bind_group_layout_desc: spawner_bind_group_layout_desc.clone(),
                 },
             );
             #[cfg(feature = "trace")]
@@ -5313,10 +5565,8 @@ fn emit_binned_draw<T, F, G>(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn queue_effects(
     views: Query<(&RenderVisibleEntities, &ExtractedView, &Msaa)>,
-    effects_meta: Res<EffectsMeta>,
     mut render_pipeline: ResMut<ParticlesRenderPipeline>,
     mut specialized_render_pipelines: ResMut<SpecializedRenderPipelines<ParticlesRenderPipeline>>,
-    pipeline_cache: Res<PipelineCache>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
     sorted_effect_batches: Res<SortedEffectBatches>,
     effect_draw_batches: Query<(Entity, &mut EffectDrawBatch)>,
@@ -5340,6 +5590,10 @@ pub(crate) fn queue_effects(
     let _span = bevy::log::info_span!("hanabi:queue_effects").entered();
 
     trace!("queue_effects");
+
+    let effects_meta = read_params.effects_meta.into_inner();
+    let property_cache = read_params.property_cache.into_inner();
+    let pipeline_cache = read_params.pipeline_cache.into_inner();
 
     // Bump the change tick so that Bevy is forced to rebuild the binned render
     // phase bins. We don't use the built-in caching so we don't want Bevy to
@@ -5394,6 +5648,7 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
+                &property_cache,
                 &render_meshes,
                 &pipeline_cache,
                 |id, entity, draw_batch, _view| Transparent2d {
@@ -5436,6 +5691,7 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
+                &property_cache,
                 &render_meshes,
                 &pipeline_cache,
                 |id, entity, batch, view| Transparent3d {
@@ -5473,6 +5729,7 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
+                &property_cache,
                 &pipeline_cache,
                 &render_meshes,
                 |id, _batch, _view| OpaqueNoLightmap3dBatchSetKey {
@@ -5514,6 +5771,7 @@ pub(crate) fn queue_effects(
                 &effect_draw_batches,
                 &mut render_pipeline,
                 specialized_render_pipelines.reborrow(),
+                &property_cache,
                 &pipeline_cache,
                 &render_meshes,
                 |id, _batch, _view| Opaque3dBatchSetKey {
@@ -5612,7 +5870,7 @@ pub(crate) fn prepare_gpu_resources(
     if prev_buffer_id != effects_meta.sim_params_uniforms.buffer().map(|b| b.id()) {
         // Buffer changed, invalidate bind groups
         effects_meta.update_sim_params_bind_group = None;
-        effects_meta.indirect_sim_params_bind_group = None;
+        effects_meta.init_and_indirect_sim_params_bind_group = None;
     }
 
     // Create the bind group for the camera/view parameters
@@ -5666,11 +5924,11 @@ pub(crate) fn prepare_effect_metadata(
         MainEntity,
         Ref<ExtractedEffect>,
         Ref<CachedEffect>,
-        Ref<DispatchBufferIndices>,
         Option<Ref<CachedChildInfo>>,
         Option<Ref<CachedParentInfo>>,
         Option<Ref<CachedDrawIndirectArgs>>,
         Option<Ref<CachedEffectEvents>>,
+        Option<Ref<CachedEffectProperties>>,
         &mut CachedEffectMetadata,
     )>,
     mut effects_meta: ResMut<EffectsMeta>,
@@ -5684,11 +5942,11 @@ pub(crate) fn prepare_effect_metadata(
         main_entity,
         extracted_effect,
         cached_effect,
-        dispatch_buffer_indices,
         maybe_cached_child_info,
         maybe_cached_parent_info,
         maybe_cached_draw_indirect_args,
         maybe_cached_effect_events,
+        maybe_cached_effect_properties,
         mut cached_effect_metadata,
     ) in &mut q_effects
     {
@@ -5696,7 +5954,6 @@ pub(crate) fn prepare_effect_metadata(
         // early out and skip this effect.
         let is_changed_ee = extracted_effect.is_changed();
         let is_changed_ce = cached_effect.is_changed();
-        let is_changed_dbi = dispatch_buffer_indices.is_changed();
         let is_changed_cci = maybe_cached_child_info
             .as_ref()
             .map(|cci| cci.is_changed())
@@ -5713,24 +5970,28 @@ pub(crate) fn prepare_effect_metadata(
             .as_ref()
             .map(|cee| cee.is_changed())
             .unwrap_or(false);
+        let is_changed_cep = maybe_cached_effect_properties
+            .as_ref()
+            .map(|cep| cep.is_changed())
+            .unwrap_or(false);
         trace!(
             "Preparting GpuEffectMetadata for effect {:?}: is_changed[] = {} {} {} {} {} {} {}",
             main_entity,
             is_changed_ee,
             is_changed_ce,
-            is_changed_dbi,
             is_changed_cci,
             is_changed_cpi,
             is_changed_cdia,
-            is_changed_cee
+            is_changed_cee,
+            is_changed_cep
         );
         if !is_changed_ee
             && !is_changed_ce
-            && !is_changed_dbi
             && !is_changed_cci
             && !is_changed_cpi
             && !is_changed_cdia
             && !is_changed_cee
+            && !is_changed_cep
         {
             continue;
         }
@@ -5771,13 +6032,14 @@ pub(crate) fn prepare_effect_metadata(
             max_update: 0,
             max_spawn: capacity,
             indirect_write_index: 0,
-            indirect_dispatch_index: dispatch_buffer_indices
-                .update_dispatch_indirect_buffer_row_index,
             indirect_draw_index: maybe_cached_draw_indirect_args
                 .map(|cdia| cdia.get_row().0)
                 .unwrap_or(u32::MAX),
             init_indirect_dispatch_index: maybe_cached_effect_events
                 .map(|cee| cee.init_indirect_dispatch_index)
+                .unwrap_or(u32::MAX),
+            properties_offset: maybe_cached_effect_properties
+                .map(|cep| cep.range.start / 4)
                 .unwrap_or(u32::MAX),
             local_child_index,
             global_child_index,
@@ -5857,6 +6119,7 @@ pub(crate) fn queue_init_fill_dispatch_ops(
 #[derive(SystemParam)]
 pub struct PipelineParams<'w, 's> {
     dispatch_indirect_pipeline: Res<'w, DispatchIndirectPipeline>,
+    prefix_sum_pipeline: Res<'w, PrefixSumPipeline>,
     utils_pipeline: Res<'w, UtilsPipeline>,
     init_pipeline: Res<'w, ParticlesInitPipeline>,
     update_pipeline: Res<'w, ParticlesUpdatePipeline>,
@@ -5884,11 +6147,26 @@ pub(crate) fn prepare_bind_groups(
         return;
     }
     let Some(spawner_buffer) = effects_meta.spawner_buffer.buffer().cloned() else {
+        error!("Missing spawner GPU buffer!");
+        return;
+    };
+    let Some(prefix_sum_buffer) = effects_meta.prefix_sum_buffer.buffer().cloned() else {
+        error!("Missing prefix sum GPU buffer!");
+        return;
+    };
+    let Some(batch_info_buffer) = effects_meta.batch_info_buffer.buffer().cloned() else {
+        error!("Missing batch info GPU buffer!");
+        return;
+    };
+    let Some(dispatch_indirect_buffer) = effects_meta.dispatch_indirect_buffer.buffer().cloned()
+    else {
+        error!("Missing dispatch indirect GPU buffer!");
         return;
     };
 
     // Workaround for too many params in system (TODO: refactor to split work?)
     let dispatch_indirect_pipeline = pipelines.dispatch_indirect_pipeline.into_inner();
+    let prefix_sum_pipeline = pipelines.prefix_sum_pipeline.into_inner();
     let utils_pipeline = pipelines.utils_pipeline.into_inner();
     let init_pipeline = pipelines.init_pipeline.into_inner();
     let update_pipeline = pipelines.update_pipeline.into_inner();
@@ -5902,13 +6180,6 @@ pub(crate) fn prepare_bind_groups(
     {
         #[cfg(feature = "trace")]
         let _span = bevy::log::info_span!("shared_bind_groups").entered();
-
-        // Make a copy of the buffer IDs before borrowing effects_meta mutably in the
-        // loop below. Also allows earlying out before doing any work in case some
-        // buffer is missing.
-        let Some(spawner_buffer) = effects_meta.spawner_buffer.buffer().cloned() else {
-            return;
-        };
 
         // Create the sim_params@0 bind group for the global simulation parameters,
         // which is shared by the init and update passes.
@@ -5929,27 +6200,27 @@ pub(crate) fn prepare_bind_groups(
                 debug!("Cannot allocate bind group for vfx_update:sim_params@0 - draw_indirect_buffer not ready");
             }
         }
-        if effects_meta.indirect_sim_params_bind_group.is_none() {
-            effects_meta.indirect_sim_params_bind_group = Some(render_device.create_bind_group(
-                "hanabi:bg:vfx_indirect:sim_params@0",
-                &pipeline_cache.get_bind_group_layout(&init_pipeline.sim_params_layout_desc), // FIXME - Shared with init
-                // @group(0) @binding(0) var<uniform> sim_params : SimParams;
-                &BindGroupEntries::single(effects_meta.sim_params_uniforms.binding().unwrap()),
-            ));
+        if effects_meta
+            .init_and_indirect_sim_params_bind_group
+            .is_none()
+        {
+            debug!("Re-creating init_and_indirect_sim_params_bind_group...");
+            effects_meta.init_and_indirect_sim_params_bind_group =
+                Some(render_device.create_bind_group(
+                    "hanabi:bg:vfx_indirect:sim_params@0",
+                    &pipeline_cache.get_bind_group_layout(&init_pipeline.sim_params_layout_desc), // FIXME - Shared with init
+                    // @group(0) @binding(0) var<uniform> sim_params : SimParams;
+                    &BindGroupEntries::single(effects_meta.sim_params_uniforms.binding().unwrap()),
+                ));
         }
 
         // Create the @1 bind group for the indirect dispatch preparation pass of all
         // effects at once
         effects_meta.indirect_metadata_bind_group = match (
             effects_meta.effect_metadata_buffer.buffer(),
-            effects_meta.dispatch_indirect_buffer.buffer(),
             effects_meta.draw_indirect_buffer.buffer(),
         ) {
-            (
-                Some(effect_metadata_buffer),
-                Some(dispatch_indirect_buffer),
-                Some(draw_indirect_buffer),
-            ) => {
+            (Some(effect_metadata_buffer), Some(draw_indirect_buffer)) => {
                 // Base bind group for indirect pass
                 Some(render_device.create_bind_group(
                     "hanabi:bg:vfx_indirect:metadata@1",
@@ -5982,13 +6253,34 @@ pub(crate) fn prepare_bind_groups(
                 &pipeline_cache.get_bind_group_layout(
                     &dispatch_indirect_pipeline.spawner_bind_group_layout_desc,
                 ),
-                &BindGroupEntries::single(
+                &BindGroupEntries::sequential((
                     // @group(2) @binding(0) var<storage, read> spawner_buffer : array<Spawner>;
                     spawner_buffer.as_entire_binding(),
-                ),
+                    // @group(2) @binding(1) var<storage, read_write> prefix_sum : array<u32>;
+                    prefix_sum_buffer.as_entire_binding(),
+                )),
             );
 
             effects_meta.indirect_spawner_bind_group = Some(bind_group);
+        }
+
+        // Create the @0 bind group for the prefix sum pass of all batches at once
+        if effects_meta.prefix_sum_bind_group.is_none() {
+            effects_meta.prefix_sum_bind_group = Some(render_device.create_bind_group(
+                "hanabi:bind_group:vfx_prefix_sum:@0",
+                &pipeline_cache.get_bind_group_layout(&prefix_sum_pipeline.bind_group_layout_desc),
+                &BindGroupEntries::sequential((
+                    // @group(0) @binding(0) var<storage, read> batch_infos :
+                    // array<BatchInfo>;
+                    batch_info_buffer.as_entire_binding(),
+                    // @group(0) @binding(1) var<storage, read_write> prefix_sum :
+                    // array<u32>;
+                    prefix_sum_buffer.as_entire_binding(),
+                    // @group(0) @binding(2) var<storage, read_write>
+                    // dispatch_indirect_buffer : array<DispatchIndirectArgs>;
+                    dispatch_indirect_buffer.as_entire_binding(),
+                )),
+            ));
         }
     }
 
@@ -6045,9 +6337,7 @@ pub(crate) fn prepare_bind_groups(
     // Create bind groups for queued GPU buffer operations
     gpu_buffer_operation_queue.create_bind_groups(&render_device, utils_pipeline);
 
-    // Create the per-effect bind groups
-    let spawner_buffer_binding_size =
-        NonZeroU64::new(effects_meta.spawner_buffer.aligned_size() as u64).unwrap();
+    // Create the per-effect-batch bind groups
     for effect_batch in sorted_effect_batched.iter() {
         #[cfg(feature = "trace")]
         let _span_buffer = bevy::log::info_span!("create_batch_bind_groups").entered();
@@ -6058,7 +6348,8 @@ pub(crate) fn prepare_bind_groups(
                 property_key,
                 &property_cache,
                 &spawner_buffer,
-                spawner_buffer_binding_size,
+                &prefix_sum_buffer,
+                &batch_info_buffer,
                 &render_device,
                 &pipeline_cache,
             ) {
@@ -6068,7 +6359,8 @@ pub(crate) fn prepare_bind_groups(
         } else if let Err(err) = property_bind_groups.ensure_exists_no_property(
             &property_cache,
             &spawner_buffer,
-            spawner_buffer_binding_size,
+            &prefix_sum_buffer,
+            &batch_info_buffer,
             &render_device,
             &pipeline_cache,
         ) {
@@ -6263,6 +6555,7 @@ pub(crate) fn prepare_bind_groups(
 type DrawEffectsSystemState = SystemState<(
     SRes<EffectsMeta>,
     SRes<EffectBindGroups>,
+    SRes<PropertyBindGroups>,
     SRes<PipelineCache>,
     SRes<RenderAssets<RenderMesh>>,
     SRes<MeshAllocator>,
@@ -6301,6 +6594,7 @@ fn draw<'w>(
     let (
         effects_meta,
         effect_bind_groups,
+        property_bind_groups,
         pipeline_cache,
         meshes,
         mesh_allocator,
@@ -6311,6 +6605,7 @@ fn draw<'w>(
     let view_uniform = views.get(view).unwrap();
     let effects_meta = effects_meta.into_inner();
     let effect_bind_groups = effect_bind_groups.into_inner();
+    let property_bind_groups = property_bind_groups.into_inner();
     let meshes = meshes.into_inner();
     let mesh_allocator = mesh_allocator.into_inner();
     let effect_draw_batch = effect_draw_batches.get(entity.0).unwrap();
@@ -6358,7 +6653,18 @@ fn draw<'w>(
         &[spawner_offset],
     );
 
-    // Particle texture
+    //
+    let batch_info_aligned_size = effects_meta.batch_info_buffer.aligned_size();
+    let batch_info_offset = effect_batch.batch_info_id * batch_info_aligned_size as u32;
+    pass.set_bind_group(
+        2,
+        property_bind_groups
+            .get(effect_batch.property_key.as_ref())
+            .unwrap(),
+        &[batch_info_offset],
+    );
+
+    // Effect materials (textures and samplers)
     // TODO = move
     let material = Material {
         layout: effect_batch.texture_layout.clone(),
@@ -6366,7 +6672,7 @@ fn draw<'w>(
     };
     if !effect_batch.texture_layout.layout.is_empty() {
         if let Some(bind_group) = effect_bind_groups.material_bind_groups.get(&material) {
-            pass.set_bind_group(2, bind_group, &[]);
+            pass.set_bind_group(3, bind_group, &[]);
         } else {
             // Texture(s) not ready; skip this drawing for now
             trace!(
@@ -6715,6 +7021,36 @@ impl Node for VfxSimulateNode {
             return Ok(());
         }
 
+        // Validate that the main buffers and other core resources are available. Avoid
+        // dispatching partial work if not all passes will complete, as this generally
+        // desynchronizes the buffers.
+        let (
+            Some(_),
+            true,
+            Some(indirect_metadata_bind_group),
+            Some(init_and_indirect_sim_params_bind_group),
+            Some(indirect_spawner_bind_group),
+        ) = (
+            effects_meta.spawner_buffer.buffer(),
+            !effects_meta.spawner_buffer.is_empty(),
+            &effects_meta.indirect_metadata_bind_group,
+            &effects_meta.init_and_indirect_sim_params_bind_group,
+            &effects_meta.indirect_spawner_bind_group,
+        )
+        else {
+            trace!("WARN - Some resource not ready, can't simulate this frame.");
+            return Ok(());
+        };
+        let Some(prefix_sum_bind_group) = &effects_meta.prefix_sum_bind_group else {
+            trace!("WARN - Prefix sum bind group not ready, can't simulate this frame.");
+            return Ok(());
+        };
+        let Some(indirect_buffer) = effects_meta.dispatch_indirect_buffer.buffer() else {
+            trace!("WARN - Missing indirect buffer for update pass, can't simulate this frame.");
+            // FIXME - Bevy doesn't allow returning custom errors here...
+            return Ok(());
+        };
+
         // Compute init pass
         {
             trace!("init: loop over effect batches...");
@@ -6726,7 +7062,7 @@ impl Node for VfxSimulateNode {
             compute_pass.set_bind_group(
                 0,
                 effects_meta
-                    .indirect_sim_params_bind_group
+                    .init_and_indirect_sim_params_bind_group
                     .as_ref()
                     .unwrap(),
                 &[],
@@ -6780,6 +7116,7 @@ impl Node for VfxSimulateNode {
                     .set_cached_compute_pipeline(effect_batch.init_and_update_pipeline_ids.init)
                     .is_err()
                 {
+                    error!("Failed to set init pipeline");
                     continue;
                 }
 
@@ -6788,21 +7125,17 @@ impl Node for VfxSimulateNode {
                 let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
                 debug_assert!(spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize);
                 let spawner_offset = spawner_base * spawner_aligned_size as u32;
-                let property_offset = effect_batch.property_offset;
+                let batch_info_aligned_size = effects_meta.batch_info_buffer.aligned_size();
+                let batch_info_offset = effect_batch.batch_info_id * batch_info_aligned_size as u32;
 
                 // Setup init pass
                 compute_pass.set_bind_group(1, particle_bind_group, &[]);
-                let offsets = if let Some(property_offset) = property_offset {
-                    vec![spawner_offset, property_offset]
-                } else {
-                    vec![spawner_offset]
-                };
                 compute_pass.set_bind_group(
                     2,
                     property_bind_groups
                         .get(effect_batch.property_key.as_ref())
                         .unwrap(),
-                    &offsets[..],
+                    &[batch_info_offset],
                 );
                 compute_pass.set_bind_group(3, &metadata_bind_group.bind_group, &[]);
 
@@ -6875,20 +7208,8 @@ impl Node for VfxSimulateNode {
             }
         }
 
-        // Compute indirect dispatch pass
-        if let (
-            Some(_),
-            true,
-            Some(indirect_metadata_bind_group),
-            Some(indirect_sim_params_bind_group),
-            Some(indirect_spawner_bind_group),
-        ) = (
-            effects_meta.spawner_buffer.buffer(),
-            !effects_meta.spawner_buffer.is_empty(),
-            &effects_meta.indirect_metadata_bind_group,
-            &effects_meta.indirect_sim_params_bind_group,
-            &effects_meta.indirect_spawner_bind_group,
-        ) {
+        // Indirect dispatch compute pass
+        {
             // Only start a compute pass if there's an effect; makes things clearer in
             // debugger.
             let mut compute_pass =
@@ -6906,9 +7227,7 @@ impl Node for VfxSimulateNode {
                     compute_pass.set_bind_group(3, indirect_child_info_buffer_bind_group, &[]);
                 } else {
                     error!("Missing child_info_buffer@3 bind group for the vfx_indirect pass.");
-                    // render_context
-                    //     .command_encoder()
-                    //     .insert_debug_marker("ERROR:MissingIndirectBindGroup3");
+                    compute_pass.insert_debug_marker("ERROR:MissingIndirectBindGroup3");
                     // FIXME - Bevy doesn't allow returning custom errors here...
                     return Ok(());
                 }
@@ -6918,6 +7237,7 @@ impl Node for VfxSimulateNode {
                 .set_cached_compute_pipeline(effects_meta.active_indirect_pipeline_id)
                 .is_err()
             {
+                compute_pass.insert_debug_marker("ERROR:FailedToSetIndirectComputePipeline");
                 // FIXME - Bevy doesn't allow returning custom errors here...
                 return Ok(());
             }
@@ -6930,7 +7250,7 @@ impl Node for VfxSimulateNode {
             let workgroup_count = total_effect_count.div_ceil(WORKGROUP_SIZE);
 
             // Setup vfx_indirect pass
-            compute_pass.set_bind_group(0, indirect_sim_params_bind_group, &[]);
+            compute_pass.set_bind_group(0, init_and_indirect_sim_params_bind_group, &[]);
             compute_pass.set_bind_group(1, indirect_metadata_bind_group, &[]);
             compute_pass.set_bind_group(2, indirect_spawner_bind_group, &[]);
             compute_pass.dispatch_workgroups(workgroup_count, 1, 1);
@@ -6941,17 +7261,49 @@ impl Node for VfxSimulateNode {
             );
         }
 
-        // Compute update pass
+        // Update prefix sum compute pass
+        //
+        // Compute the prefix sum of alive particles before the update pass, so that we
+        // can dispatch batches of effects in the update pass. The alive count is
+        // copied into the prefix sum buffer during the indirect dispatch pass just
+        // before.
         {
-            let Some(indirect_buffer) = effects_meta.dispatch_indirect_buffer.buffer() else {
-                warn!("Missing indirect buffer for update pass, cannot dispatch anything.");
-                render_context
-                    .command_encoder()
-                    .insert_debug_marker("ERROR:MissingUpdateIndirectBuffer");
-                // FIXME - Bevy doesn't allow returning custom errors here...
-                return Ok(());
-            };
+            // Only start a compute pass if there's an effect; makes things clearer in
+            // debugger.
+            let mut compute_pass =
+                self.begin_compute_pass("hanabi:update_prefix_sum", pipeline_cache, render_context);
 
+            trace!("record commands for update prefix sum pipeline...");
+
+            if compute_pass
+                .set_cached_compute_pipeline(effects_meta.prefix_sum_pipeline_id)
+                .is_err()
+            {
+                // FIXME - Bevy doesn't allow returning custom errors here...
+                trace!("ERROR - Failed to set prefix sum compute pipeline. Simulation aborted.");
+                return Ok(());
+            }
+
+            // Dispatch one thread per effect batch
+            const WORKGROUP_SIZE: u32 = 64;
+            let total_batch_count = effects_meta.batch_info_buffer.len() as u32;
+            let workgroup_count = total_batch_count.div_ceil(WORKGROUP_SIZE);
+
+            // Setup vfx_prefix_sum pass
+            compute_pass.set_bind_group(0, prefix_sum_bind_group, &[]);
+            compute_pass.dispatch_workgroups(workgroup_count, 1, 1);
+            trace!(
+                "prefix sum dispatched: total_batch_count={} workgroup_count={}",
+                total_batch_count,
+                workgroup_count
+            );
+        }
+
+        // Update compute pass
+        //
+        // Simulate all alive particles.
+        let mut needs_sort = false;
+        {
             let mut compute_pass =
                 self.begin_compute_pass("hanabi:update", pipeline_cache, render_context);
 
@@ -6964,6 +7316,11 @@ impl Node for VfxSimulateNode {
 
             // Dispatch update compute jobs
             for effect_batch in sorted_effect_batches.iter() {
+                // Remember if we need to sort any effect, for next pass
+                if effect_batch.layout_flags.contains(LayoutFlags::RIBBONS) {
+                    needs_sort = true;
+                }
+
                 // Fetch bind group particle@1
                 let Some(particle_bind_group) =
                     effect_cache.particle_sim_bind_group(&effect_batch.slab_id)
@@ -7001,39 +7358,30 @@ impl Node for VfxSimulateNode {
                 }
 
                 // Compute dynamic offsets
-                let spawner_base = effect_batch.spawner_base;
-                let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
-                assert!(spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize);
-                let spawner_offset = spawner_base * spawner_aligned_size as u32;
-                let property_offset = effect_batch.property_offset;
-
+                let batch_info_aligned_size = effects_meta.batch_info_buffer.aligned_size();
+                let batch_info_offset = effect_batch.batch_info_id * batch_info_aligned_size as u32;
                 trace!(
-                    "record commands for update pipeline of effect {:?} spawner_base={}",
+                    "record commands for update pipeline of effect {:?} spawner_base={} batch_info_id={} batch_info_offset={}B",
                     effect_batch.handle,
-                    spawner_base,
+                    effect_batch.spawner_base,
+                    effect_batch.batch_info_id,
+                    batch_info_offset,
                 );
 
                 // Setup update pass
                 compute_pass.set_bind_group(1, particle_bind_group, &[]);
-                let offsets = if let Some(property_offset) = property_offset {
-                    vec![spawner_offset, property_offset]
-                } else {
-                    vec![spawner_offset]
-                };
                 compute_pass.set_bind_group(
                     2,
                     property_bind_groups
                         .get(effect_batch.property_key.as_ref())
                         .unwrap(),
-                    &offsets[..],
+                    &[batch_info_offset],
                 );
                 compute_pass.set_bind_group(3, &metadata_bind_group.bind_group, &[]);
 
                 // Dispatch update job
-                let dispatch_indirect_offset = effect_batch
-                    .dispatch_buffer_indices
-                    .update_dispatch_indirect_buffer_row_index
-                    * 12;
+                let dispatch_indirect_offset =
+                    effect_batch.batch_info_id * GpuDispatchIndirectArgs::SHADER_SIZE.get() as u32;
                 trace!(
                     "dispatch_workgroups_indirect: buffer={:?} offset={}B",
                     indirect_buffer,
@@ -7046,181 +7394,248 @@ impl Node for VfxSimulateNode {
             }
         }
 
-        // Compute sort fill dispatch pass - Fill the indirect dispatch structs for any
-        // batch of particles which needs sorting, based on the actual number of alive
-        // particles in the batch after their update in the compute update pass. Since
-        // particles may die during update, this may be different from the number of
-        // particles updated.
-        if let Some(queue_index) = sorted_effect_batches.dispatch_queue_index.as_ref() {
-            gpu_buffer_operations.dispatch(
-                *queue_index,
-                render_context,
-                utils_pipeline,
-                Some("hanabi:sort_fill_dispatch"),
-            );
-        }
+        // Do sorting for ribbons
+        if needs_sort {
+            // Copy alive counts for sort prefix sum compute pass
+            //
+            // After the update pass (atomically) updated the particle alive count per
+            // effect instance, copy that number into the prefix sum buffer, so that
+            // the prefix sum pass can calculate the prefix sum for sorting.
+            // if let Some(queue_index) = sorted_effect_batches
+            //     .sort_fill_prefix_sum_queue_index
+            //     .as_ref()
+            // {
+            //     gpu_buffer_operations.dispatch(
+            //         *queue_index,
+            //         render_context,
+            //         utils_pipeline,
+            //         Some("hanabi:sort_fill_prefix_sum"),
+            //     );
+            // }
 
-        // Compute sort pass
-        {
-            let mut compute_pass =
-                self.begin_compute_pass("hanabi:sort", pipeline_cache, render_context);
+            // Sort prefix sum compute pass
+            //
+            // Calculate the prefix sum of the number of alive particles to sort.
+            {
+                // Only start a compute pass if there's an effect; makes things clearer in
+                // debugger.
+                let mut compute_pass = self.begin_compute_pass(
+                    "hanabi:sort_prefix_sum",
+                    pipeline_cache,
+                    render_context,
+                );
 
-            let effect_metadata_buffer = effects_meta.effect_metadata_buffer.buffer().unwrap();
-            let indirect_buffer = sort_bind_groups.indirect_buffer().unwrap();
+                trace!("record commands for sort prefix sum pass...");
 
-            // Loop on batches and find those which need sorting
-            for effect_batch in sorted_effect_batches.iter() {
-                trace!("Processing effect batch for sorting...");
-                if !effect_batch.layout_flags.contains(LayoutFlags::RIBBONS) {
-                    continue;
-                }
-                assert!(effect_batch.particle_layout.contains(Attribute::RIBBON_ID));
-                assert!(effect_batch.particle_layout.contains(Attribute::AGE)); // or is that optional?
-
-                let Some(effect_buffer) = effect_cache.get_slab(&effect_batch.slab_id) else {
-                    warn!("Missing sort-fill effect buffer.");
-                    // render_context
-                    //     .command_encoder()
-                    //     .insert_debug_marker("ERROR:MissingEffectBatchBuffer");
-                    continue;
-                };
-
-                let indirect_dispatch_index = *effect_batch
-                    .sort_fill_indirect_dispatch_index
-                    .as_ref()
-                    .unwrap();
-                let indirect_offset =
-                    sort_bind_groups.get_indirect_dispatch_byte_offset(indirect_dispatch_index);
-
-                // Fill the sort buffer with the key-value pairs to sort
+                if compute_pass
+                    .set_cached_compute_pipeline(effects_meta.prefix_sum_pipeline_id)
+                    .is_err()
                 {
-                    compute_pass.push_debug_group("hanabi:sort_fill");
-
-                    // Fetch compute pipeline
-                    let Some(pipeline_id) =
-                        sort_bind_groups.get_sort_fill_pipeline_id(&effect_batch.particle_layout)
-                    else {
-                        warn!("Missing sort-fill pipeline.");
-                        compute_pass.insert_debug_marker("ERROR:MissingSortFillPipeline");
-                        continue;
-                    };
-                    if compute_pass
-                        .set_cached_compute_pipeline(pipeline_id)
-                        .is_err()
-                    {
-                        compute_pass.insert_debug_marker("ERROR:FailedToSetSortFillPipeline");
-                        compute_pass.pop_debug_group();
-                        // FIXME - Bevy doesn't allow returning custom errors here...
-                        return Ok(());
-                    }
-
-                    let spawner_base = effect_batch.spawner_base;
-                    let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
-                    assert!(spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize);
-                    let spawner_offset = spawner_base * spawner_aligned_size as u32;
-
-                    // Bind group sort_fill@0
-                    let particle_buffer = effect_buffer.particle_buffer();
-                    let indirect_index_buffer = effect_buffer.indirect_index_buffer();
-                    let Some(bind_group) = sort_bind_groups.sort_fill_bind_group(
-                        particle_buffer.id(),
-                        indirect_index_buffer.id(),
-                        effect_metadata_buffer.id(),
-                    ) else {
-                        warn!("Missing sort-fill bind group.");
-                        compute_pass.insert_debug_marker("ERROR:MissingSortFillBindGroup");
-                        continue;
-                    };
-                    let effect_metadata_offset = effects_meta
-                        .gpu_limits
-                        .effect_metadata_offset(effect_batch.metadata_table_id.0)
-                        as u32;
-                    compute_pass.set_bind_group(
-                        0,
-                        bind_group,
-                        &[effect_metadata_offset, spawner_offset],
+                    // FIXME - Bevy doesn't allow returning custom errors here...
+                    trace!(
+                        "ERROR - Failed to set prefix sum compute pipeline. Simulation aborted."
                     );
-
-                    compute_pass
-                        .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
-                    trace!("Dispatched sort-fill with indirect offset +{indirect_offset}");
-
-                    compute_pass.pop_debug_group();
+                    return Ok(());
                 }
 
-                // Do the actual sort
-                {
-                    compute_pass.push_debug_group("hanabi:sort");
+                // Dispatch one thread per init effect batch.
+                const WORKGROUP_SIZE: u32 = 64;
+                // Note: This only works because we use the same batches for the init and update
+                // passes. A priori there's no reason why we couldn't split them, since likely
+                // the batches would be different.
+                let total_batch_count = effects_meta.batch_info_buffer.len() as u32;
+                let workgroup_count = total_batch_count.div_ceil(WORKGROUP_SIZE);
 
-                    if compute_pass
-                        .set_cached_compute_pipeline(sort_bind_groups.sort_pipeline_id())
-                        .is_err()
-                    {
-                        compute_pass.insert_debug_marker("ERROR:FailedToSetSortPipeline");
-                        compute_pass.pop_debug_group();
-                        // FIXME - Bevy doesn't allow returning custom errors here...
-                        return Ok(());
+                // Setup vfx_prefix_sum pass
+                compute_pass.set_bind_group(0, prefix_sum_bind_group, &[]);
+                compute_pass.dispatch_workgroups(workgroup_count, 1, 1);
+                trace!(
+                    "prefix sum dispatched: total_batch_count={} workgroup_count={}",
+                    total_batch_count,
+                    workgroup_count
+                );
+            }
+
+            // Compute sort fill dispatch pass - Fill the indirect dispatch structs for any
+            // batch of particles which needs sorting, based on the actual number of alive
+            // particles in the batch after their update in the compute update pass. Since
+            // particles may die during update, this may be different from the number of
+            // particles updated.
+            if let Some(queue_index) = sorted_effect_batches.dispatch_queue_index.as_ref() {
+                gpu_buffer_operations.dispatch(
+                    *queue_index,
+                    render_context,
+                    utils_pipeline,
+                    Some("hanabi:sort_fill_dispatch"),
+                );
+            }
+
+            // Compute sort pass
+            {
+                let mut compute_pass =
+                    self.begin_compute_pass("hanabi:sort", pipeline_cache, render_context);
+
+                let effect_metadata_buffer = effects_meta.effect_metadata_buffer.buffer().unwrap();
+                let indirect_buffer = sort_bind_groups.indirect_buffer().unwrap();
+
+                // Loop on batches and find those which need sorting
+                for effect_batch in sorted_effect_batches.iter() {
+                    trace!("Processing effect batch for sorting...");
+                    if !effect_batch.layout_flags.contains(LayoutFlags::RIBBONS) {
+                        continue;
                     }
+                    assert!(effect_batch.particle_layout.contains(Attribute::RIBBON_ID));
+                    assert!(effect_batch.particle_layout.contains(Attribute::AGE)); // or is that optional?
 
-                    let Some(bind_group) = sort_bind_groups.sort_bind_group() else {
-                        warn!("Missing sort bind group.");
-                        compute_pass.insert_debug_marker("ERROR:MissingSortBindGroup");
+                    let Some(effect_buffer) = effect_cache.get_slab(&effect_batch.slab_id) else {
+                        warn!("Missing sort-fill effect buffer.");
+                        // render_context
+                        //     .command_encoder()
+                        //     .insert_debug_marker("ERROR:MissingEffectBatchBuffer");
                         continue;
                     };
-                    compute_pass.set_bind_group(0, bind_group, &[]);
-                    compute_pass
-                        .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
-                    trace!("Dispatched sort with indirect offset +{indirect_offset}");
 
-                    compute_pass.pop_debug_group();
-                }
+                    let indirect_dispatch_index = *effect_batch
+                        .sort_fill_indirect_dispatch_index
+                        .as_ref()
+                        .unwrap();
+                    let indirect_offset =
+                        sort_bind_groups.get_indirect_dispatch_byte_offset(indirect_dispatch_index);
 
-                // Copy the sorted particle indices back into the indirect index buffer, where
-                // the render pass will read them.
-                {
-                    compute_pass.push_debug_group("hanabi:copy_sorted_indices");
-
-                    // Fetch compute pipeline
-                    let pipeline_id = sort_bind_groups.get_sort_copy_pipeline_id();
-                    if compute_pass
-                        .set_cached_compute_pipeline(pipeline_id)
-                        .is_err()
+                    // Fill the sort buffer with the key-value pairs to sort
                     {
-                        compute_pass.insert_debug_marker("ERROR:FailedToSetSortCopyPipeline");
+                        compute_pass.push_debug_group("hanabi:sort_fill");
+
+                        // Fetch compute pipeline
+                        let Some(pipeline_id) = sort_bind_groups
+                            .get_sort_fill_pipeline_id(&effect_batch.particle_layout)
+                        else {
+                            warn!("Missing sort-fill pipeline.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortFillPipeline");
+                            continue;
+                        };
+                        if compute_pass
+                            .set_cached_compute_pipeline(pipeline_id)
+                            .is_err()
+                        {
+                            compute_pass.insert_debug_marker("ERROR:FailedToSetSortFillPipeline");
+                            compute_pass.pop_debug_group();
+                            // FIXME - Bevy doesn't allow returning custom errors here...
+                            return Ok(());
+                        }
+
+                        let spawner_base = effect_batch.spawner_base;
+                        let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
+                        assert!(
+                            spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize
+                        );
+                        let spawner_offset = spawner_base * spawner_aligned_size as u32;
+
+                        // Bind group sort_fill@0
+                        let particle_buffer = effect_buffer.particle_buffer();
+                        let indirect_index_buffer = effect_buffer.indirect_index_buffer();
+                        let Some(bind_group) = sort_bind_groups.sort_fill_bind_group(
+                            particle_buffer.id(),
+                            indirect_index_buffer.id(),
+                            effect_metadata_buffer.id(),
+                        ) else {
+                            warn!("Missing sort-fill bind group.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortFillBindGroup");
+                            continue;
+                        };
+                        let effect_metadata_offset = effects_meta
+                            .gpu_limits
+                            .effect_metadata_offset(effect_batch.metadata_table_id.0)
+                            as u32;
+                        compute_pass.set_bind_group(
+                            0,
+                            bind_group,
+                            &[effect_metadata_offset, spawner_offset],
+                        );
+
+                        compute_pass
+                            .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
+                        trace!("Dispatched sort-fill with indirect offset +{indirect_offset}");
+
                         compute_pass.pop_debug_group();
-                        // FIXME - Bevy doesn't allow returning custom errors here...
-                        return Ok(());
                     }
 
-                    let spawner_base = effect_batch.spawner_base;
-                    let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
-                    assert!(spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize);
-                    let spawner_offset = spawner_base * spawner_aligned_size as u32;
+                    // Do the actual sort
+                    {
+                        compute_pass.push_debug_group("hanabi:sort");
 
-                    // Bind group sort_copy@0
-                    let indirect_index_buffer = effect_buffer.indirect_index_buffer();
-                    let Some(bind_group) = sort_bind_groups.sort_copy_bind_group(
-                        indirect_index_buffer.id(),
-                        effect_metadata_buffer.id(),
-                    ) else {
-                        warn!("Missing sort-copy bind group.");
-                        compute_pass.insert_debug_marker("ERROR:MissingSortCopyBindGroup");
-                        continue;
-                    };
-                    let effect_metadata_offset = effects_meta
-                        .effect_metadata_buffer
-                        .dynamic_offset(effect_batch.metadata_table_id);
-                    compute_pass.set_bind_group(
-                        0,
-                        bind_group,
-                        &[effect_metadata_offset, spawner_offset],
-                    );
+                        if compute_pass
+                            .set_cached_compute_pipeline(sort_bind_groups.sort_pipeline_id())
+                            .is_err()
+                        {
+                            compute_pass.insert_debug_marker("ERROR:FailedToSetSortPipeline");
+                            compute_pass.pop_debug_group();
+                            // FIXME - Bevy doesn't allow returning custom errors here...
+                            return Ok(());
+                        }
 
-                    compute_pass
-                        .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
-                    trace!("Dispatched sort-copy with indirect offset +{indirect_offset}");
+                        let Some(bind_group) = sort_bind_groups.sort_bind_group() else {
+                            warn!("Missing sort bind group.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortBindGroup");
+                            continue;
+                        };
+                        compute_pass.set_bind_group(0, bind_group, &[]);
+                        compute_pass
+                            .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
+                        trace!("Dispatched sort with indirect offset +{indirect_offset}");
 
-                    compute_pass.pop_debug_group();
+                        compute_pass.pop_debug_group();
+                    }
+
+                    // Copy the sorted particle indices back into the indirect index buffer, where
+                    // the render pass will read them.
+                    {
+                        compute_pass.push_debug_group("hanabi:copy_sorted_indices");
+
+                        // Fetch compute pipeline
+                        let pipeline_id = sort_bind_groups.get_sort_copy_pipeline_id();
+                        if compute_pass
+                            .set_cached_compute_pipeline(pipeline_id)
+                            .is_err()
+                        {
+                            compute_pass.insert_debug_marker("ERROR:FailedToSetSortCopyPipeline");
+                            compute_pass.pop_debug_group();
+                            // FIXME - Bevy doesn't allow returning custom errors here...
+                            return Ok(());
+                        }
+
+                        let spawner_base = effect_batch.spawner_base;
+                        let spawner_aligned_size = effects_meta.spawner_buffer.aligned_size();
+                        assert!(
+                            spawner_aligned_size >= GpuSpawnerParams::min_size().get() as usize
+                        );
+                        let spawner_offset = spawner_base * spawner_aligned_size as u32;
+
+                        // Bind group sort_copy@0
+                        let indirect_index_buffer = effect_buffer.indirect_index_buffer();
+                        let Some(bind_group) = sort_bind_groups.sort_copy_bind_group(
+                            indirect_index_buffer.id(),
+                            effect_metadata_buffer.id(),
+                        ) else {
+                            warn!("Missing sort-copy bind group.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortCopyBindGroup");
+                            continue;
+                        };
+                        let effect_metadata_offset = effects_meta
+                            .effect_metadata_buffer
+                            .dynamic_offset(effect_batch.metadata_table_id);
+                        compute_pass.set_bind_group(
+                            0,
+                            bind_group,
+                            &[effect_metadata_offset, spawner_offset],
+                        );
+
+                        compute_pass
+                            .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
+                        trace!("Dispatched sort-copy with indirect offset +{indirect_offset}");
+
+                        compute_pass.pop_debug_group();
+                    }
                 }
             }
         }

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -10,8 +10,9 @@ use bevy::{
     prelude::{Component, Entity, Query, Res, ResMut, Resource},
     render::{
         render_resource::{
-            binding_types::storage_buffer_read_only_sized, BindGroup, BindGroupEntries,
-            BindGroupLayoutDescriptor, BindGroupLayoutEntries, Buffer, PipelineCache,
+            binding_types::{storage_buffer_read_only, storage_buffer_read_only_sized},
+            BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries, Buffer,
+            PipelineCache,
         },
         renderer::{RenderDevice, RenderQueue},
     },
@@ -20,7 +21,7 @@ use wgpu::{BufferBinding, BufferUsages, ShaderStages};
 
 use super::{aligned_buffer_vec::HybridAlignedBufferVec, effect_cache::SlabState};
 use crate::{
-    render::{ExtractedProperties, GpuSpawnerParams, StorageType},
+    render::{ExtractedProperties, GpuBatchInfo, GpuSpawnerParams, StorageType},
     PropertyLayout,
 };
 
@@ -154,14 +155,21 @@ pub struct PropertyCache {
 
 impl PropertyCache {
     pub fn new(device: RenderDevice) -> Self {
-        let spawner_min_binding_size =
-            GpuSpawnerParams::aligned_size(device.limits().min_storage_buffer_offset_alignment);
+        let align = device.limits().min_storage_buffer_offset_alignment;
+
+        // Create the default bind group layout when no properties are present
         let bgl = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:no_property",
-            &BindGroupLayoutEntries::single(
-                ShaderStages::COMPUTE,
-                // @group(2) @binding(0) var<storage, read> spawner: Spawner;
-                storage_buffer_read_only_sized(true, Some(spawner_min_binding_size)),
+            &BindGroupLayoutEntries::sequential(
+                ShaderStages::COMPUTE | ShaderStages::VERTEX,
+                (
+                    // @group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
+                    storage_buffer_read_only::<GpuSpawnerParams>(false),
+                    // @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
+                    storage_buffer_read_only::<u32>(false),
+                    // @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
+                    storage_buffer_read_only_sized(true, Some(GpuBatchInfo::aligned_size(align))),
+                ),
             ),
         );
         trace!(
@@ -204,9 +212,7 @@ impl PropertyCache {
         // Ensure there's a bind group layout for the property variant with that binding
         // size
         let properties_min_binding_size = property_layout.min_binding_size();
-        let spawner_min_binding_size = GpuSpawnerParams::aligned_size(
-            self.device.limits().min_storage_buffer_offset_alignment,
-        );
+        let mut bgl = self.bind_group_layout_descs.get(&0).unwrap().clone();
         self.bind_group_layout_descs
             .entry(properties_min_binding_size.get() as u32)
             .or_insert_with(|| {
@@ -219,17 +225,11 @@ impl PropertyCache {
                     label,
                     properties_min_binding_size.get()
                 );
-                let bgl = BindGroupLayoutDescriptor::new(
-                    label,
-                    &BindGroupLayoutEntries::sequential(
-                        ShaderStages::COMPUTE,
-                        (
-                            // @group(2) @binding(0) var<storage, read> spawner: Spawner;
-                            storage_buffer_read_only_sized(true, Some(spawner_min_binding_size)),
-                            // @group(2) @binding(1) var<storage, read> properties : Properties;
-                            storage_buffer_read_only_sized(true, Some(properties_min_binding_size)),
-                        ),
-                    ),
+                // Clone the entry without properties, and append the Properties array binding
+                bgl.label = label.into();
+                bgl.entries.push(
+                    storage_buffer_read_only_sized(false, Some(properties_min_binding_size))
+                        .build(3, ShaderStages::COMPUTE | ShaderStages::VERTEX),
                 );
                 trace!(
                     "-> created bind group layout desc for size {}: {:?}",
@@ -350,7 +350,8 @@ impl PropertyBindGroups {
         property_key: &PropertyBindGroupKey,
         property_cache: &PropertyCache,
         spawner_buffer: &Buffer,
-        spawner_buffer_binding_size: NonZeroU64,
+        prefix_sum_buffer: &Buffer,
+        batch_info_buffer: &Buffer,
         render_device: &RenderDevice,
         pipeline_cache: &PipelineCache,
     ) -> Result<(), ()> {
@@ -373,6 +374,7 @@ impl PropertyBindGroups {
             return Err(());
         };
 
+        let align = render_device.limits().min_storage_buffer_offset_alignment;
         self.property_bind_groups
             .entry(*property_key)
             .or_insert_with(|| {
@@ -390,16 +392,14 @@ impl PropertyBindGroups {
                     ),
                     &pipeline_cache.get_bind_group_layout(layout_desc),
                     &BindGroupEntries::sequential((
+                        spawner_buffer.as_entire_binding(),
+                        prefix_sum_buffer.as_entire_binding(),
                         BufferBinding {
-                            buffer: spawner_buffer,
+                            buffer: batch_info_buffer,
                             offset: 0,
-                            size: Some(spawner_buffer_binding_size),
+                            size: Some(GpuBatchInfo::aligned_size(align)),
                         },
-                        BufferBinding {
-                            buffer: property_buffer,
-                            offset: 0,
-                            size: Some(property_binding_size),
-                        },
+                        property_buffer.as_entire_binding(),
                     )),
                 )
             });
@@ -411,7 +411,8 @@ impl PropertyBindGroups {
         &mut self,
         property_cache: &PropertyCache,
         spawner_buffer: &Buffer,
-        spawner_buffer_binding_size: NonZeroU64,
+        prefix_sum_buffer: &Buffer,
+        batch_info_buffer: &Buffer,
         render_device: &RenderDevice,
         pipeline_cache: &PipelineCache,
     ) -> Result<(), ()> {
@@ -423,15 +424,20 @@ impl PropertyBindGroups {
         };
 
         if self.no_property_bind_group.is_none() {
+            let align = render_device.limits().min_storage_buffer_offset_alignment;
             trace!("Creating new spawner@2 bind group for no-property variant");
             self.no_property_bind_group = Some(render_device.create_bind_group(
                 Some("hanabi:bg:spawner@2:no-property"),
                 &pipeline_cache.get_bind_group_layout(layout_desc),
-                &BindGroupEntries::single(BufferBinding {
-                    buffer: spawner_buffer,
-                    offset: 0,
-                    size: Some(spawner_buffer_binding_size),
-                }),
+                &BindGroupEntries::sequential((
+                    spawner_buffer.as_entire_binding(),
+                    prefix_sum_buffer.as_entire_binding(),
+                    BufferBinding {
+                        buffer: batch_info_buffer,
+                        offset: 0,
+                        size: Some(GpuBatchInfo::aligned_size(align)),
+                    },
+                )),
             ));
         }
 

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -48,9 +48,6 @@ struct Spawner {
     /// slab (if the effect has a parent effect), in number of particles (row index).
     /// This is ignored if the effect has no parent.
     parent_slab_offset: u32,
-#ifdef SPAWNER_PADDING
-    {{SPAWNER_PADDING}}
-#endif
 }
 
 const SPAWNER_OFFSET_PONG: u32 = 27u;
@@ -142,6 +139,30 @@ struct DrawIndexedIndirectArgs {
 /// Stride in u32 count (4 bytes) of the DrawIndexedIndirectArgs struct.
 const DRAW_INDEXED_INDIRECT_STRIDE: u32 = 5u;
 
+/// Shared info for a single batch (single shader invocation).
+struct BatchInfo {
+    total_spawn_count: u32,
+    total_update_count: u32,
+    base_effect: u32,
+    /// Offset to apply to the workgroup thread index to determine the global
+    /// particle index in the currently bound slab. This is often (and ideally)
+    /// zero, but may be > 0 if the entire slab cannot be processed with a
+    /// single invocation.
+    base_particle: u32,
+    /// Offset into the prefix sum buffer of the sum for the first effect of
+    /// this batch.
+    prefix_sum_offset: u32,
+    /// Number of active effects in the batch, and therefore number of
+    /// consecutive prefix sum values for effects of this batch.
+    prefix_sum_count: u32,
+
+    /// Padding for storage buffer alignment. This struct is sometimes bound as part
+    /// of an array, or sometimes individually as a single unit. In the later case,
+    /// we need it to be aligned to the GPU limits of the device. That limit is only
+    /// known at runtime when initializing the WebGPU device.
+    {{BATCH_INFO_PADDING}}
+}
+
 // Effect metadata offsets. Used when accessing a tightly packed array of EffectMetadata
 // as a raw array<u32>, so that we can avoid WGSL struct padding and keep data more compact
 // in the GPU buffer. Each offset corresponds to a field in the EffectMetadata struct.
@@ -153,7 +174,10 @@ const EM_OFFSET_MAX_SPAWN: u32 = 3u;
 const EM_OFFSET_INDIRECT_WRITE_INDEX: u32 = 4u;
 const EM_OFFSET_INDIRECT_DISPATCH_INDEX: u32 = 5u;
 
-/// Draw indirect parameters for GPU-driven rendering, and additional effect data.
+/// Metadata describing a single effect instance.
+///
+/// The metadata describes various effect settings, as well we the location in
+/// GPU buffers of the piece of data associated with that instance.
 struct EffectMetadata {
     /// Total number of particles for this effect. This is the capacity of the effect,
     /// in number of particles, which is used to sub-allocate various storages for this
@@ -182,9 +206,6 @@ struct EffectMetadata {
     /// are swapped during the indirect dispatch (although the render pass still uses
     /// the complement of this to write, so technically ignores that swap).
     indirect_write_index: u32,
-    /// Index of the [`GpuDispatchIndirect`] struct inside the global
-    /// [`EffectsMeta::dispatch_indirect_buffer`].
-    indirect_dispatch_index: u32,
     /// Index of the [`GpuRenderIndirect`] struct inside the global
     /// [`EffectsMeta::render_group_dispatch_buffer`].
     indirect_render_index: u32,
@@ -192,6 +213,11 @@ struct EffectMetadata {
     /// buffer. This avoids having to align those 16-byte structs to the GPU
     /// alignment (at least 32 bytes, even 256 bytes on some).
     init_indirect_dispatch_index: u32,
+    /// Index inside the global array of the spawner struct for this effect instance.
+    //spawner_index: u32,
+    /// Offset (in u32 count) of the start of the property block for this
+    /// effect. This is ignored if the effect doesn't use properties.
+    properties_offset: u32,
     /// Index of this effect into its parent's ChildInfo array
     /// ([`EffectChildren::effect_cache_ids`] and its associated GPU
     /// array). This starts at zero for the first child of each effect, and is

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -17,42 +17,55 @@
 @group(1) @binding(2) var<storage, read_write> draw_indirect_buffer : array<u32>;
 
 @group(2) @binding(0) var<storage, read_write> spawner_buffer : array<Spawner>;
+@group(2) @binding(1) var<storage, read_write> prefix_sum : array<u32>;
 
 #ifdef HAS_GPU_SPAWN_EVENTS
 @group(3) @binding(0) var<storage, read_write> child_info_buffer : ChildInfoBuffer;
 #endif
 
-/// Calculate the indirect workgroups counts based on the number of particles alive.
+/// Perform per-instance update between the init and update passes.
+///
+/// This is invoked once per instance, with the global invocation ID indexing the list of spawners,
+/// which is re-uploaded each frame so is guaranteed to be a tightly packed array with exactly the
+/// number of 
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let thread_index = global_invocation_id.x;
-
-#ifdef HAS_GPU_SPAWN_EVENTS
-    // Clear any GPU event. The indexing is safe because there are always less child effects
-    // than there are effects in total, so 'index' will always cover the entire child info array.
-    if (thread_index < arrayLength(&child_info_buffer.rows)) {
-        child_info_buffer.rows[thread_index].event_count = 0;
-    }
-#endif
-
     // Cap at maximum number of effects
-    let effect_index = thread_index;
-    if (effect_index >= sim_params.num_effects) {
+    let global_effect_index = global_invocation_id.x;
+    if (global_effect_index >= sim_params.num_effects) {
         return;
     }
 
-    let effect_metadata_index = spawner_buffer[effect_index].effect_metadata_index;
+#ifdef HAS_GPU_SPAWN_EVENTS
+    // Clear any GPU event. The indexing is inconsistent here (indexing child info buffer with an
+    // effect instance), but is safe because there are always less child effects than there are effects
+    // in total, so the index will always cover the entire child info array. And we're only resetting
+    // a value so don't read anything, so only need to visit each entry once but the order doesn't matter.
+    if (global_effect_index < arrayLength(&child_info_buffer.rows)) {
+        child_info_buffer.rows[global_effect_index].event_count = 0;
+    }
+#endif
+
+    let spawner = &spawner_buffer[global_effect_index];
+
+    let effect_metadata_index = (*spawner).effect_metadata_index;
     let em_base = EFFECT_METADATA_STRIDE * effect_metadata_index;
 
     // Clear the rendering instance count, which will be upgraded by the update pass
     // with the particles actually alive at the end of their update (after aged).
-    let draw_indirect_index = spawner_buffer[effect_index].draw_indirect_index;
+    let draw_indirect_index = (*spawner).draw_indirect_index;
     let dri_base = DRAW_INDEXED_INDIRECT_STRIDE * draw_indirect_index;
     draw_indirect_buffer[dri_base + 1u] = 0u;
 
     let capacity = effect_metadata_buffer[em_base + EM_OFFSET_CAPACITY];
     let alive_count = effect_metadata_buffer[em_base + EM_OFFSET_ALIVE_COUNT];
     let dead_count = capacity - alive_count;
+
+    // Prepare to rebuild the prefix sum of active instances by storing in the prefix sum array
+    // the actual number of alive particles for each instance. We will build the prefix sum in
+    // the next pass (vfx_prefix_sum) once that's done.
+    // The prefix sums and spawners are allocated in sync, so are indexed with the same index value.
+    prefix_sum[global_effect_index] = alive_count;
 
     // Update max_update from current value of alive_count, so that the
     // update pass coming next can cap its threads to this value, while also
@@ -81,5 +94,5 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Copy the new pong into the spawner buffer, which will be used during rendering
     // to determine where to read particle indices.
-    spawner_buffer[effect_index].render_indirect_read_index = pong;
+    (*spawner).render_indirect_read_index = pong;
 }

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -1,6 +1,6 @@
 #import bevy_hanabi::vfx_common::{
     ChildInfo, ChildInfoBuffer, EventBuffer, DispatchIndirectArgs, IndirectBuffer,
-    EffectMetadata, RenderGroupIndirect, SimParams, Spawner,
+    EffectMetadata, RenderGroupIndirect, SimParams, Spawner, BatchInfo,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
     rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
@@ -28,6 +28,49 @@ struct ParentParticleBuffer {
 
 {{PROPERTIES}}
 
+/// Location of an effect in a slab.
+struct EffectLocation {
+    /// Index of the effect in the global list of effects.
+    effect_index: u32,
+    /// Base particle index, that is index in the slab of the first particle for this instance.
+    base_particle: u32,
+    /// Index of this particle relative to its effect. Note that if there's an indirection
+    /// buffer then this is the linear index in [0:N[ of the particle to update, before the indirection.
+    update_index: u32,
+}
+
+/// Find the index of an effect from the index of a particle.
+///
+/// This uses a binary search on the slab_offset field of the spawners array, which
+/// represents a prefix sum of the particle count per effect (for previous effects;
+/// the value is actually the base particle so the first entry is always 0).
+///
+/// Requirements:
+/// - var<storage, read> batch_info : BatchInfo
+/// - var<storage, read> prefix_sum : array<u32>
+fn find_location_from_particle(slab_particle_index: u32) -> EffectLocation {
+    var lo = batch_info.prefix_sum_offset;
+    var hi = lo + batch_info.prefix_sum_count;
+    var num_iter = 0;  // avoid deadlocking the GPU by capping the iteration count
+    while (lo < hi) {
+        let mid = (hi + lo) >> 1u;
+        let base_particle = prefix_sum[mid];
+        if (slab_particle_index >= base_particle) {
+            lo = mid + 1u;
+        } else if (slab_particle_index < base_particle) {
+            hi = mid;
+        }
+        num_iter += 1;
+        if (num_iter >= 100) {
+            return EffectLocation(0xDEADBEEFu, 0xDEADBEEFu, 0xDEADBEEFu);
+        }
+    }
+    let base_particle = prefix_sum[lo - 1u];
+    let effect_index = lo - 1u - batch_info.prefix_sum_offset;
+    let update_index = slab_particle_index - base_particle;
+    return EffectLocation(effect_index, base_particle, update_index);
+}
+
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 
 // "particle" group @1
@@ -38,7 +81,9 @@ struct ParentParticleBuffer {
 #endif
 
 // "spawner" group @2
-@group(2) @binding(0) var<storage, read> spawner : Spawner;
+@group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
+@group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
+@group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
 {{PROPERTIES_BINDING}}
 
 // "metadata" group @3
@@ -50,22 +95,35 @@ struct ParentParticleBuffer {
 
 {{INIT_EXTRA}}
 
+var<private> effect_metadata_index: u32;
+var<private> properties_offset: u32;
+
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let thread_index = global_invocation_id.x;
+    // Global particle index into the slab, including those particles from other
+    // effect instances in the same batch, as well as possibly from other batches.
+    // This is rarely useful on its own.
+    let slab_particle_index = batch_info.base_particle + global_invocation_id.x;
+
+    // Find the index of the effect this particle is part of.
+    let location = find_location_from_particle(slab_particle_index);
+    let spawner = &spawners[batch_info.base_effect + location.effect_index];
+    effect_metadata_index = (*spawner).effect_metadata_index;
+    let base_particle = location.base_particle;
 
     // Cap to max number of dead particles, copied from (capacity - alive_count) at the end
     // of the previous iteration, and constant during this pass (unlike alive_count).
-    let effect_metadata = &effect_metadatas[spawner.effect_metadata_index];
+    let effect_metadata = &effect_metadatas[(*spawner).effect_metadata_index];
     let max_spawn = atomicLoad(&(*effect_metadata).max_spawn);
-    if (thread_index >= max_spawn) {
+    if (location.update_index >= max_spawn) {
         return;
     }
+    properties_offset = (*effect_metadata).properties_offset;
 
     // Cap to the actual number of spawning requested by CPU or GPU, since compute shaders run
     // in workgroup_size(64) so more threads than needed are launched (rounded up to 64).
 #ifdef CONSUME_GPU_SPAWN_EVENTS
-    let event_index = thread_index;
+    let event_index = location.update_index;
     let global_child_index = (*effect_metadata).global_child_index;
     let event_count = child_info_buffer.rows[global_child_index].event_count;
     if (event_index >= u32(event_count)) {
@@ -75,18 +133,16 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Cap to the actual number of spawning requested by CPU (in the case of
     // spawners) or the number of particles present in the source group (in the
     // case of cloners).
-    let spawn_count: u32 = u32(spawner.spawn);
-    if (thread_index >= spawn_count) {
+    let spawn_count: u32 = u32((*spawner).spawn);
+    if (location.update_index >= spawn_count) {
         return;
     }
 #endif
 
-    let base_particle = spawner.slab_offset;
-
     // Count as alive, and recycle a dead particle slot to store the newly spawned particle
     let alive_index = atomicAdd(&(*effect_metadata).alive_count, 1u);
-    let slab_particle_index = indirect_buffer.rows[base_particle + alive_index].dead_index;
-    let particle_index = slab_particle_index - base_particle;
+    let slab_particle_dead_index = indirect_buffer.rows[base_particle + alive_index].dead_index;
+    let particle_index = slab_particle_dead_index - base_particle;
 
     // DEBUG
     //indirect_buffer.rows[base_particle + alive_index].dead_index = 0xFFFFFFFFu;
@@ -97,21 +153,21 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let particle_counter = atomicAdd(&(*effect_metadata).particle_counter, 1u);
 
     // Initialize the PRNG seed
-    seed = pcg_hash(particle_index ^ spawner.seed);
+    seed = pcg_hash(particle_index ^ (*spawner).seed);
 
     // Spawner transform
     let transform = transpose(
         mat4x4(
-            spawner.transform[0],
-            spawner.transform[1],
-            spawner.transform[2],
+            (*spawner).transform[0],
+            (*spawner).transform[1],
+            (*spawner).transform[2],
             vec4<f32>(0.0, 0.0, 0.0, 1.0)
         )
     );
 
 #ifdef READ_PARENT_PARTICLE
     // Fetch parent particle which triggered this spawn
-    let parent_base_particle = spawner.parent_slab_offset;
+    let parent_base_particle = (*spawner).parent_slab_offset;
     let parent_particle_index = event_buffer.spawn_events[event_index].particle_index;
     let parent_particle = parent_particle_buffer.particles[parent_base_particle + parent_particle_index];
 #endif

--- a/src/render/vfx_prefix_sum.wgsl
+++ b/src/render/vfx_prefix_sum.wgsl
@@ -1,0 +1,43 @@
+#import bevy_hanabi::vfx_common::{BatchInfo, DispatchIndirectArgs}
+
+@group(0) @binding(0) var<storage, read_write> batch_infos : array<BatchInfo>;
+@group(0) @binding(1) var<storage, read_write> prefix_sum : array<u32>;
+@group(0) @binding(2) var<storage, read_write> dispatch_indirect_buffer : array<DispatchIndirectArgs>;
+
+/// Compute the prefix sum of each effect batch.
+///
+/// This is invoked once per effect batch each frame, before the update pass, to recalculate
+/// the prefix sum of the alive particle counts per instance in that batch. Before this pass,
+/// the prefix sum buffer contins the number of alive particles for each instance. After it,
+/// it contains a prefix sum of that number.
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    // Get the batch to update
+    let batch_index = global_invocation_id.x;
+    let batch_count = arrayLength(&batch_infos);
+    if (batch_index >= batch_count) {
+        return;
+    }
+
+    // Find the slice of prefix sum to update inside the global shared buffer
+    let offset = batch_infos[batch_index].prefix_sum_offset;
+    let count = batch_infos[batch_index].prefix_sum_count;
+
+    // Calculate the prefix sum
+    let end = offset + count;
+    var sum = 0u;
+    for (var i = offset; i < end; i += 1u) {
+        let count = prefix_sum[i];
+        // Exclusive: store current sum before incrementing
+        prefix_sum[i] = sum;
+        sum = sum + count;
+    }
+
+    // Store the sum back into the batch
+    batch_infos[batch_index].total_update_count = sum;
+
+    // Update the dispatch indirect count
+    dispatch_indirect_buffer[batch_index].x = (sum + 63u) >> 6u;
+    dispatch_indirect_buffer[batch_index].y = 1u;
+    dispatch_indirect_buffer[batch_index].z = 1u;
+}

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -1,6 +1,6 @@
 #import bevy_render::view::View
 #import bevy_hanabi::vfx_common::{
-    IndirectBuffer, SimParams, Spawner,
+    IndirectBuffer, SimParams, Spawner, BatchInfo,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
     rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
@@ -9,6 +9,8 @@
 struct Particle {
 {{ATTRIBUTES}}
 }
+
+{{PROPERTIES}}
 
 struct ParticleBuffer {
     particles: array<Particle>,
@@ -33,7 +35,12 @@ struct VertexOutput {
 
 @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
-@group(1) @binding(2) var<storage, read> spawner : Spawner;
+
+// "spawner" group @2
+@group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
+@group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
+@group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
+{{PROPERTIES_BINDING}}
 
 {{MATERIAL_BINDINGS}}
 
@@ -42,9 +49,9 @@ fn get_camera_position_effect_space() -> vec3<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
     let inverse_transform = transpose(
         mat3x3(
-            spawner.inverse_transform[0].xyz,
-            spawner.inverse_transform[1].xyz,
-            spawner.inverse_transform[2].xyz,
+            spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform[0].xyz,
+            spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform[1].xyz,
+            spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform[2].xyz,
         )
     );
     return inverse_transform * view_pos;
@@ -58,9 +65,9 @@ fn get_camera_rotation_effect_space() -> mat3x3<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
     let inverse_transform = transpose(
         mat3x3(
-            spawner.inverse_transform[0].xyz,
-            spawner.inverse_transform[1].xyz,
-            spawner.inverse_transform[2].xyz,
+            spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform[0].xyz,
+            spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform[1].xyz,
+            spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform[2].xyz,
         )
     );
     return inverse_transform * view_rot;
@@ -96,7 +103,7 @@ fn unpack_compressed_transform_3x3_transpose(compressed_transform: mat3x4<f32>) 
 /// the effect space (SimulationSpace::Local) or the world space (SimulationSpace::Global).
 fn transform_position_simulation_to_world(sim_position: vec3<f32>) -> vec4<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
-    let transform = unpack_compressed_transform(spawner.transform);
+    let transform = unpack_compressed_transform(spawners[batch_info.base_effect + effect_location.effect_index].transform);
     return transform * vec4<f32>(sim_position, 1.0);
 #else
     return vec4<f32>(sim_position, 1.0);
@@ -108,7 +115,7 @@ fn transform_normal_simulation_to_world(sim_normal: vec3<f32>) -> vec3<f32> {
     // We use the inverse transpose transform to transform normals.
     // The inverse transpose is the same as the transposed inverse, so we can
     // safely use the inverse transform.
-    let transform = unpack_compressed_transform_3x3_transpose(spawner.inverse_transform);
+    let transform = unpack_compressed_transform_3x3_transpose(spawners[batch_info.base_effect + effect_location.effect_index].inverse_transform);
     return transform * sim_normal;
 #else
     return sim_normal;
@@ -135,6 +142,58 @@ fn inverse_transpose_mat3(m: mat3x3<f32>) -> mat3x3<f32> {
 
 {{RENDER_EXTRA}}
 
+/// Location of an effect in a slab.
+struct EffectLocation {
+    /// Index of the effect in the global list of effects.
+    effect_index: u32,
+    /// Base particle index, that is index in the slab of the first particle for this instance.
+    base_particle: u32,
+    /// Index of this particle relative to its effect. Note that if there's an indirection
+    /// buffer then this is the linear index in [0:N[ of the particle to update, before the indirection.
+    update_index: u32,
+}
+
+/// Find the index of an effect from the index of a particle.
+///
+/// This uses a binary search on the slab_offset field of the spawners array, which
+/// represents a prefix sum of the particle count per effect (for previous effects;
+/// the value is actually the base particle so the first entry is always 0).
+///
+/// Requirements:
+/// - var<storage, read> batch_info : BatchInfo
+/// - var<storage, read> prefix_sum : array<u32>
+fn find_location_from_particle(slab_particle_index: u32) -> EffectLocation {
+    var lo = batch_info.prefix_sum_offset;
+    var hi = lo + batch_info.prefix_sum_count;
+    var num_iter = 0;  // avoid deadlocking the GPU by capping the iteration count
+    while (lo < hi) {
+        let mid = (hi + lo) >> 1u;
+        let base_particle = prefix_sum[mid];
+        if (slab_particle_index >= base_particle) {
+            lo = mid + 1u;
+        } else if (slab_particle_index < base_particle) {
+            hi = mid;
+        }
+        num_iter += 1;
+        if (num_iter >= 100) {
+            return EffectLocation(0xDEADBEEFu, 0xDEADBEEFu, 0xDEADBEEFu);
+        }
+    }
+    let base_particle = batch_info.base_particle + prefix_sum[lo - 1u];
+    let effect_index = lo - 1u - batch_info.prefix_sum_offset;
+    let update_index = slab_particle_index - base_particle;
+    return EffectLocation(effect_index, base_particle, update_index);
+}
+
+/// The resolved effect and particle location.
+///
+/// This is calculated at the start of the thread execution, and used after that
+/// in various functions.
+var<private> effect_location : EffectLocation;
+
+var<private> effect_metadata_index: u32;
+// var<private> properties_offset: u32;
+
 @vertex
 fn vertex(
     @builtin(instance_index) instance_index: u32,
@@ -148,10 +207,19 @@ fn vertex(
     // @location(1) vertex_color: u32,
     // @location(1) vertex_velocity: vec3<f32>,
 ) -> VertexOutput {
-    let base_particle = spawner.slab_offset;
+    // Global particle index into the slab, including those particles from other
+    // effect instances in the same batch, as well as possibly from other batches.
+    // This is rarely useful on its own.
+    let slab_particle_index = batch_info.base_particle + instance_index;
+
+    // Find the index of the effect this particle is part of.
+    effect_location = find_location_from_particle(slab_particle_index);
+    let spawner = &spawners[batch_info.base_effect + effect_location.effect_index];
+    effect_metadata_index = (*spawner).effect_metadata_index;
+    let base_particle = effect_location.base_particle;
 
     // Fetch particle
-    let indirect_read_index = spawner.render_indirect_read_index;
+    let indirect_read_index = (*spawner).render_indirect_read_index;
     let particle_index = indirect_buffer.rows[base_particle + instance_index].particle_index[indirect_read_index];
     var particle = particle_buffer.particles[base_particle + particle_index];
 

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -1,6 +1,6 @@
 #import bevy_hanabi::vfx_common::{
     ChildInfo, ChildInfoBuffer, EventBuffer, DispatchIndirectArgs, IndirectBuffer,
-    EffectMetadata, RenderGroupIndirect, SimParams, Spawner, DrawIndexedIndirectArgs,
+    EffectMetadata, RenderGroupIndirect, SimParams, Spawner, DrawIndexedIndirectArgs, BatchInfo,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
     rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
@@ -28,6 +28,49 @@ struct ParentParticleBuffer {
 
 {{PROPERTIES}}
 
+/// Location of an effect in a slab.
+struct EffectLocation {
+    /// Index of the effect in the global list of effects.
+    effect_index: u32,
+    /// Base particle index, that is index in the slab of the first particle for this instance.
+    base_particle: u32,
+    /// Index of this particle relative to its effect. Note that if there's an indirection
+    /// buffer then this is the linear index in [0:N[ of the particle to update, before the indirection.
+    update_index: u32,
+}
+
+/// Find the index of an effect from the index of a particle.
+///
+/// This uses a binary search on the slab_offset field of the spawners array, which
+/// represents a prefix sum of the particle count per effect (for previous effects;
+/// the value is actually the base particle so the first entry is always 0).
+///
+/// Requirements:
+/// - var<storage, read> batch_info : BatchInfo
+/// - var<storage, read> prefix_sum : array<u32>
+fn find_location_from_particle(slab_particle_index: u32) -> EffectLocation {
+    var lo = batch_info.prefix_sum_offset;
+    var hi = lo + batch_info.prefix_sum_count;
+    var num_iter = 0;  // avoid deadlocking the GPU by capping the iteration count
+    while (lo < hi) {
+        let mid = (hi + lo) >> 1u;
+        let base_particle = prefix_sum[mid];
+        if (slab_particle_index >= base_particle) {
+            lo = mid + 1u;
+        } else if (slab_particle_index < base_particle) {
+            hi = mid;
+        }
+        num_iter += 1;
+        if (num_iter >= 100) {
+            return EffectLocation(0xDEADBEEFu, 0xDEADBEEFu, 0xDEADBEEFu);
+        }
+    }
+    let base_particle = batch_info.base_particle + prefix_sum[lo - 1u];
+    let effect_index = lo - 1u - batch_info.prefix_sum_offset;
+    let update_index = slab_particle_index - base_particle;
+    return EffectLocation(effect_index, base_particle, update_index);
+}
+
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(0) @binding(1) var<storage, read_write> draw_indirect_buffer : array<DrawIndexedIndirectArgs>;
 
@@ -39,7 +82,9 @@ struct ParentParticleBuffer {
 #endif
 
 // "spawner" group @2
-@group(2) @binding(0) var<storage, read> spawner : Spawner;
+@group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
+@group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
+@group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
 {{PROPERTIES_BINDING}}
 
 // "metadata" group @3
@@ -54,30 +99,44 @@ struct ParentParticleBuffer {
 {{EMIT_EVENT_BUFFER_APPEND_FUNCS}}
 #endif
 
+var<private> effect_metadata_index: u32;
+var<private> properties_offset: u32;
+
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let thread_index = global_invocation_id.x;
+    // Global particle index into the slab, including those particles from other
+    // effect instances in the same batch, as well as possibly from other batches.
+    // This is rarely useful on its own.
+    let slab_particle_index = batch_info.base_particle + global_invocation_id.x;
 
-    // Cap at maximum number of alive particles.
-    let effect_metadata = &effect_metadatas[spawner.effect_metadata_index];
-    if (thread_index >= (*effect_metadata).max_update) {
+    // Find the index of the effect this particle is part of.
+    let location = find_location_from_particle(slab_particle_index);
+    let spawner = &spawners[batch_info.base_effect + location.effect_index];
+    effect_metadata_index = (*spawner).effect_metadata_index;
+    let base_particle = location.base_particle;
+
+    // Cap at maximum number of alive particles for the current effect
+    let effect_metadata = &effect_metadatas[effect_metadata_index];
+    if (location.update_index >= (*effect_metadata).max_update) {
         return;
     }
-
-    let base_particle = spawner.slab_offset;
-#ifdef READ_PARENT_PARTICLE
-    let parent_base_particle = spawner.parent_slab_offset;
-#endif
+    properties_offset = (*effect_metadata).properties_offset;
 
     let write_index = effect_metadata.indirect_write_index;
     let read_index = 1u - write_index;
 
+    // This is the actual particle index, from the indirection buffer, addressing an
+    // actually alive particle.
     let particle_index = indirect_buffer
-        .rows[base_particle + thread_index]
+        .rows[slab_particle_index]
         .particle_index[read_index];
 
+#ifdef READ_PARENT_PARTICLE
+    let parent_base_particle = (*spawner).parent_slab_offset;
+#endif
+
     // Initialize the PRNG seed
-    seed = pcg_hash(particle_index ^ spawner.seed);
+    seed = pcg_hash(particle_index ^ (*spawner).seed);
 
     var particle: Particle = particle_buffer.particles[base_particle + particle_index];
     {{AGE_CODE}}
@@ -88,7 +147,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Check if alive
     if (!is_alive) {
-        // Save dead index
+        // Save dead index. Note that dead_index is a global slab index.
         let alive_index = atomicSub(&((*effect_metadata).alive_count), 1u) - 1u;
         indirect_buffer.rows[base_particle + alive_index].dead_index = base_particle + particle_index;
 


### PR DESCRIPTION
Bind the entire spawner and property arrays in all passes, instead of a single entry. This removes the need to pad those structures. Access them via an offset in the effect's own metadata.

Add a new `BatchInfo` struct holding the per-batch data. This clarifies the responsibilites between this and `EffectMetadata`, the latter holding per-effect (not per-batch) data.

Remove the `DispatchBufferIndices` component, which was used to track the allocated entry for indirect compute dispatch. Instead, align those allocations 1:1 with the GPU batch info allocations, which are re-computed each frame.

Add a prefix sum pass before the update pass, which computes the prefix sum of alive particles after the init pass. This is used to enable batched update compute dispatch, where the number of compute threads maps to the total number of alive particles in the batch. In that case, we need to find which thread updates which particle of which batch, using that prefix sum. Note that in this change, due to other limitations still present, each effect instance is still in its own batch (there's effectively no batching). Enabling full batching requires more work, notably on the sort pass for ribbons, and the GPU-based init pass with GPU events.

Change the allocation of spawners to occur after sorting. This ensures all effects in a same batch have sequential allocations, which enables accessing those spawners with a simple {offset + index} strategy.

Change the render pass to use the same bind group "spawner@2" than other passes. This binds the property buffer, although in this change the metadata buffer is still not available, so properties can't be used yet in the render pass. The bind groups should be reviewed anyway because, with batching approaching, and with the current change, assumptions about frequency of changes is now wrong, and individual bindings should be re-grouped in more suitable frequency-based groups.

Finally, the entire sorting pass group is now skipped if there's no ribbon effect. This should have minimal performance impact, and is mainly to make RenderDoc captures more readable when debugging a single effect without sorting. It should help a tiny bit performance wise nonetheless if never using any ribbon effect.