### PR TITLE
Re-add spawner padding to fix align

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -243,7 +243,7 @@ impl<T: Lerp + FromReflect> Gradient<T> {
             .into_iter()
             .map(|(ratio, value)| GradientKey { ratio, value })
             .collect::<Vec<_>>();
-        keys.sort_by(|a, b| FloatOrd(a.ratio).cmp(&FloatOrd(b.ratio)));
+        keys.sort_by_key(|a| FloatOrd(a.ratio));
         Self { keys }
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -40,11 +40,11 @@ use crate::{
         queue_init_indirect_workgroup_update, report_ready_state, start_stop_gpu_debug_capture,
         update_mesh_locations, DebugSettings, DispatchIndirectPipeline, DrawEffects,
         EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, EventCache, GpuBatchInfo,
-        GpuBufferOperations, GpuEffectMetadata, InitFillDispatchQueue, ParticlesInitPipeline,
-        ParticlesRenderPipeline, ParticlesUpdatePipeline, PrefixSumPipeline, PropertyBindGroups,
-        PropertyCache, RenderDebugSettings, ShaderCache, SimParams, SortBindGroups,
-        SortedEffectBatches, StorageType as _, UtilsPipeline, VfxSimulateDriverNode,
-        VfxSimulateNode,
+        GpuBufferOperations, GpuEffectMetadata, GpuSpawnerParams, InitFillDispatchQueue,
+        ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, PrefixSumPipeline,
+        PropertyBindGroups, PropertyCache, RenderDebugSettings, ShaderCache, SimParams,
+        SortBindGroups, SortedEffectBatches, StorageType as _, UtilsPipeline,
+        VfxSimulateDriverNode, VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_spawners,
@@ -150,6 +150,8 @@ impl HanabiPlugin {
     /// shader ready for the specific GPU device associated with that
     /// alignment.
     pub(crate) fn make_common_shader(min_storage_buffer_offset_alignment: u32) -> Shader {
+        let spawner_padding_code =
+            GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
         let batch_info_padding_code =
             GpuBatchInfo::padding_code(min_storage_buffer_offset_alignment);
         let effect_metadata_padding_code =
@@ -159,6 +161,7 @@ impl HanabiPlugin {
         let effect_metadata_stride_code =
             (render_effect_indirect_size.get() as u32).to_wgsl_string();
         let common_code = include_str!("render/vfx_common.wgsl")
+            .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
             .replace("{{BATCH_INFO_PADDING}}", &batch_info_padding_code)
             .replace("{{EFFECT_METADATA_PADDING}}", &effect_metadata_padding_code)
             .replace("{{EFFECT_METADATA_STRIDE}}", &effect_metadata_stride_code);

--- a/src/render/aligned_buffer_vec.rs
+++ b/src/render/aligned_buffer_vec.rs
@@ -261,11 +261,12 @@ impl<T: Pod + ShaderSize> AlignedBufferVec<T> {
             self.capacity = capacity;
             if let Some(old_buffer) = self.buffer.take() {
                 trace!(
-                    "reserve['{}']: destroying old buffer #{:?}",
+                    "reserve['{}']: forgetting old buffer #{:?}",
                     self.safe_label(),
                     old_buffer.id()
                 );
-                old_buffer.destroy();
+                // Do not explicitly destroy the old buffer here; let the
+                // backend drop it safely.
             }
             let new_buffer = device.create_buffer(&BufferDescriptor {
                 label: self.label.as_ref().map(|s| &s[..]),
@@ -826,8 +827,10 @@ impl HybridAlignedBufferVec {
                 capacity,
             );
             self.capacity = capacity;
-            if let Some(buffer) = self.buffer.take() {
-                buffer.destroy();
+            if let Some(old_buffer) = self.buffer.take() {
+                trace!("reserve: forgetting old buffer #{:?}", old_buffer.id());
+                // Do not explicitly destroy the old buffer here; let the
+                // backend drop it safely.
             }
             self.buffer = Some(device.create_buffer(&BufferDescriptor {
                 label: self.label.as_ref().map(|s| &s[..]),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -762,6 +762,8 @@ pub(crate) struct DispatchIndirectPipeline {
 
 impl FromWorld for DispatchIndirectPipeline {
     fn from_world(world: &mut World) -> Self {
+        let render_device = world.get_resource::<RenderDevice>().unwrap();
+
         // Copy the indirect pipeline shaders to self, because we can't access anything
         // else during pipeline specialization.
         let (indirect_shader_noevent, indirect_shader_events) = {
@@ -771,6 +773,9 @@ impl FromWorld for DispatchIndirectPipeline {
                 effects_meta.indirect_shader_events.clone(),
             )
         };
+
+        let storage_alignment = render_device.limits().min_storage_buffer_offset_alignment;
+        let spawner_min_binding_size = GpuSpawnerParams::aligned_size(storage_alignment);
 
         // @group(0) @binding(0) var<uniform> sim_params : SimParams;
         trace!("GpuSimParams: min_size={}", GpuSimParams::min_size());
@@ -805,8 +810,9 @@ impl FromWorld for DispatchIndirectPipeline {
         );
 
         trace!(
-            "GpuSpawnerParams: min_size={}",
-            GpuSpawnerParams::min_size()
+            "GpuSpawnerParams: min_size={} spawner_min_binding_size={}",
+            GpuSpawnerParams::min_size(),
+            spawner_min_binding_size
         );
         let spawner_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:dispatch_indirect:spawner@2",
@@ -815,7 +821,9 @@ impl FromWorld for DispatchIndirectPipeline {
                 (
                     // @group(2) @binding(0) var<storage, read_write> spawner_buffer :
                     // array<Spawner>;
-                    storage_buffer::<GpuSpawnerParams>(false),
+                    //storage_buffer::<GpuSpawnerParams>(false), // TODO - vfx_sort_fill still
+                    // needs aligned
+                    storage_buffer_sized(false, Some(spawner_min_binding_size)),
                     // @group(2) @binding(1) var<storage, read_write> prefix_sum : array<u32>;
                     storage_buffer::<u32>(false),
                 ),
@@ -2742,6 +2750,7 @@ pub struct EffectsMeta {
     sim_params_uniforms: UniformBuffer<GpuSimParams>,
     /// Global shared GPU buffer storing the various spawner parameter structs
     /// for the active effect instances.
+    // Note: we're still binding individual spawners in vfx_sort_fill.
     spawner_buffer: AlignedBufferVec<GpuSpawnerParams>,
     /// Global shared GPU buffer storing the various indirect dispatch structs
     /// for the indirect dispatch of the Update pass.

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -156,6 +156,7 @@ pub struct PropertyCache {
 impl PropertyCache {
     pub fn new(device: RenderDevice) -> Self {
         let align = device.limits().min_storage_buffer_offset_alignment;
+        let spawner_min_binding_size = GpuSpawnerParams::aligned_size(align);
 
         // Create the default bind group layout when no properties are present
         let bgl = BindGroupLayoutDescriptor::new(
@@ -164,7 +165,9 @@ impl PropertyCache {
                 ShaderStages::COMPUTE | ShaderStages::VERTEX,
                 (
                     // @group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
-                    storage_buffer_read_only::<GpuSpawnerParams>(false),
+                    //storage_buffer_read_only::<GpuSpawnerParams>(false), // TODO - vfx_sort_fill
+                    // still needs align
+                    storage_buffer_read_only_sized(false, Some(spawner_min_binding_size)),
                     // @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
                     storage_buffer_read_only::<u32>(false),
                     // @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -48,6 +48,12 @@ struct Spawner {
     /// slab (if the effect has a parent effect), in number of particles (row index).
     /// This is ignored if the effect has no parent.
     parent_slab_offset: u32,
+
+    // Keep this field here separate from auto-padding below, so that the WGSL and Rust
+    // struct definitions match.
+    unused: u32,
+
+    {{SPAWNER_PADDING}}
 }
 
 const SPAWNER_OFFSET_PONG: u32 = 27u;


### PR DESCRIPTION
Revert some change removing the `GpuSpawnerParams` padding to GPU device min storage buffer alignment. Although most shaders use an array of spawners with an entire buffer binding, `vfx_sort_fill` still binds a single spawner item. This means we need each element to be aligned to that GPU device limit. Things were inadvertently working on GPUs with lower limits (e.g. NVIDIA) because the `GpuSpawnerParams` size was a multiple of the alignment limit. But on platforms with higher limits (Metal; 256 bytes) things broke. This change re-add the explicit padding to restore the proper alignment and fix the indexing.

This fixes the regression added by #525 on macOS.