### PR TITLE
Make `ParticleLayout::attributes()` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a fallible alternative `SpawnerSettings::try_new()` to the existing `new()`, to prevent panics
+  in editing context where inputs are not always validated.
+- Added `ParticleLayout::attributes()` returning an exact-size iterator over the `AttributeLayout` elements
+  forming the particle layout. This allows introspection of existing particle layouts.
+
 ### Changed
 
 - Spawners and properties are now bound as arrays in the various GPU passes.

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1841,7 +1841,7 @@ impl ParticleLayout {
     }
 
     /// Get the list of attributes forming this layout.
-    pub fn attributes(&self) -> impl Iterator<Item = &AttributeLayout> + ExactSizeIterator {
+    pub fn attributes(&self) -> impl ExactSizeIterator<Item = &AttributeLayout> {
         self.layout.iter()
     }
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1451,8 +1451,10 @@ impl Attribute {
 
 /// Layout for a single [`Attribute`] inside a [`ParticleLayout`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct AttributeLayout {
+pub struct AttributeLayout {
+    /// The particle attribute.
     pub attribute: Attribute,
+    /// Offset, in bytes, from the start of the particle.
     pub offset: u32,
 }
 
@@ -1838,8 +1840,9 @@ impl ParticleLayout {
         NonZeroU32::new(size.next_multiple_of(self.align)).unwrap()
     }
 
-    pub(crate) fn attributes(&self) -> &[AttributeLayout] {
-        &self.layout
+    /// Get the list of attributes forming this layout.
+    pub fn attributes(&self) -> impl Iterator<Item = &AttributeLayout> + ExactSizeIterator {
+        self.layout.iter()
     }
 
     /// Check if the layout contains the specified [`Attribute`].


### PR DESCRIPTION
Expose publicly `ParticleLayout::attributes()` to allow introspection of existing particle layouts. This returns an exact-size iterator over the laid out attributes `AttributeLayout`.