### PR TITLE
Fix ribbon sort buffer overruns: metadata fill-dispatch timing + spawner bind-group key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `typetag` dependency.
 - Removed the `serde` feature. Serialization is always available.
 
+### Fixed
+
+- Fixed a crash when growing the effect metadata buffer while a ribbon effect was alive, caused by the ribbon sort fill-dispatch binding a stale, too-small metadata buffer. (#537)
+
 ## [0.18.0] 2026-02-01
 
 _This version is compatible with Bevy 0.18_
@@ -86,7 +90,6 @@ _This version is compatible with Bevy 0.17_
 
 ### Fixed
 
-- Fixed a crash (wgpu validation error about a dynamic offset overrunning the buffer) when growing the effect metadata buffer while a ribbon effect was alive, caused by the ribbon sort fill-dispatch binding a stale, too-small metadata buffer. (#537)
 - Fixed a bug in `ColorBlendMask::to_component()` which ignored the last (alpha) component. (#479)
 - Fixed a codegen bug in `ColorOverLifetimeModifier` when values other than `ColorBlendMask::RGBA` are used. (#479)
 - Fixed a bug where `PropertyLayout` was misaligning `vec3` properties, leading to incorrect values on GPU. (#478)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ _This version is compatible with Bevy 0.17_
 
 ### Fixed
 
+- Fixed a crash (wgpu validation error about a dynamic offset overrunning the buffer) when growing the effect metadata buffer while a ribbon effect was alive, caused by the ribbon sort fill-dispatch binding a stale, too-small metadata buffer. (#493)
 - Fixed a bug in `ColorBlendMask::to_component()` which ignored the last (alpha) component. (#479)
 - Fixed a codegen bug in `ColorOverLifetimeModifier` when values other than `ColorBlendMask::RGBA` are used. (#479)
 - Fixed a bug where `PropertyLayout` was misaligning `vec3` properties, leading to incorrect values on GPU. (#478)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ _This version is compatible with Bevy 0.17_
 
 ### Fixed
 
-- Fixed a crash (wgpu validation error about a dynamic offset overrunning the buffer) when growing the effect metadata buffer while a ribbon effect was alive, caused by the ribbon sort fill-dispatch binding a stale, too-small metadata buffer. (#493)
+- Fixed a crash (wgpu validation error about a dynamic offset overrunning the buffer) when growing the effect metadata buffer while a ribbon effect was alive, caused by the ribbon sort fill-dispatch binding a stale, too-small metadata buffer. (#537)
 - Fixed a bug in `ColorBlendMask::to_component()` which ignored the last (alpha) component. (#479)
 - Fixed a codegen bug in `ColorOverLifetimeModifier` when values other than `ColorBlendMask::RGBA` are used. (#479)
 - Fixed a bug where `PropertyLayout` was misaligning `vec3` properties, leading to incorrect values on GPU. (#478)

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -1,16 +1,21 @@
-//! Draw a "tracer" or a "trail" following an Entity.
+//! Draw "tracers" or "trails", each following an Entity.
 //!
-//! The emitter associated with the Entity is moved by the [move_head] system,
+//! The emitter associated with an Entity is moved by the [move_head] system,
 //! which simply assigns its [`Transform`]. Each frame some particle is spawned
 //! at that new position, in global space. By decreasing the particle size over
 //! its lifetime, and using a constant lifetime for all particles, the particles
 //! appear to create a trail following the emitter's Transform. This is just an
 //! illusion though; the particles don't move.
 //!
-//! To complete the illusion, all particles are assigned a same
+//! To complete the illusion, all particles of a same trail are assigned a same
 //! [`Attribute::RIBBON_ID`], which causes them to be rendered as a single
 //! continuous ribbon of quads, each linking the current particle to the
 //! previous one (the first particle is skipped in ribbon mode).
+//!
+//! This example also demonstrates managing several ribbon effects at runtime:
+//! ribbons are spawned and despawned continuously over time (see
+//! [spawn_ribbons] / [recycle_ribbons]) rather than once on startup, so several
+//! trails are alive at the same time.
 
 use bevy::math::vec4;
 use bevy::prelude::*;
@@ -26,21 +31,25 @@ use utils::*;
 const K: f32 = 0.64;
 const L: f32 = 0.384;
 
+#[derive(Clone)]
 enum ShapeConfig {
     Spirograph { k: f32, l: f32 },
     Lissajou { a: f32, b: f32 },
 }
 
-#[derive(Component)]
+#[derive(Component, Clone)]
 struct Shape {
     pub config: ShapeConfig,
     pub time_scale: f32,
     pub shape_scale: Vec3,
+    /// Per-instance offset along the curve, so each spawned ribbon starts at a
+    /// different position instead of on top of the previous one.
+    pub phase: f32,
 }
 
 impl Shape {
     pub fn tick(&mut self, time: f32) -> Vec3 {
-        let time = time * self.time_scale;
+        let time = (time + self.phase) * self.time_scale;
         let pos = match self.config {
             ShapeConfig::Spirograph { k, l } => vec3(
                 (1.0 - k) * (time.cos()) + (l * k) * (((1.0 - k) / k) * time).cos(),
@@ -67,15 +76,33 @@ const PARTICLE_CAPACITY: u32 = 100;
 
 const DEMO_DESC: &str = include_str!("ribbon.txt");
 
+const RIBBON_SPAWN_INTERVAL: f32 = 2.0;
+const RIBBON_DESPAWN_AFTER: f32 = 10.0;
+// Curve offset added per spawned ribbon, in seconds (before time_scale), so
+// successive ribbons appear at distinct positions instead of overlapping.
+const RIBBON_PHASE_STEP: f32 = 0.7;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_exit = utils::DemoApp::new("ribbon")
         .with_desc(DEMO_DESC)
         .build()
         .add_systems(Startup, setup)
-        .add_systems(Update, move_head)
+        .add_systems(Update, (spawn_ribbons, recycle_ribbons, move_head))
         .run();
     app_exit.into_result()
 }
+
+/// Drives the continuous ribbon spawn/despawn cycle.
+#[derive(Resource)]
+struct RibbonSpawner {
+    effect: Handle<EffectAsset>,
+    shapes: Vec<Shape>,
+    timer: Timer,
+    next: usize,
+}
+
+#[derive(Component)]
+struct DespawnAfter(Timer);
 
 fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
     commands.spawn((
@@ -116,9 +143,8 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         value: writer.lit(0.5).expr(),
     };
 
-    // In this example the entire effect is a single ribbon/trail, so all its
-    // particle are connected. This means they all share the same RIBBON_ID, which
-    // can be any value.
+    // Each effect is a single ribbon/trail, so all its particles are connected.
+    // This means they all share the same RIBBON_ID, which can be any value.
     let init_ribbon_id = SetAttributeModifier {
         attribute: Attribute::RIBBON_ID,
         value: writer.lit(0u32).expr(),
@@ -126,7 +152,7 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
 
     let render_color = ColorOverLifetimeModifier::new(bevy_hanabi::Gradient::linear(
         vec4(3.0, 0.0, 0.0, 1.0),
-        vec4(3.0, 0.0, 0.0, 0.0),
+        vec4(0.0, 0.0, 3.0, 0.0),
     ));
 
     let spawner = SpawnerSettings::rate(RIBBON_SPAWN_RATE.into());
@@ -151,27 +177,70 @@ fn setup(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
         })
         .render(render_color);
 
-    let effect = effects.add(effect);
+    // The ribbons share a single effect asset; each spawned instance is an
+    // independent effect, only the immutable asset is reused.
+    commands.insert_resource(RibbonSpawner {
+        effect: effects.add(effect),
+        timer: Timer::from_seconds(RIBBON_SPAWN_INTERVAL, TimerMode::Repeating),
+        next: 0,
+        shapes: vec![
+            Shape {
+                config: ShapeConfig::Spirograph { k: K, l: L },
+                time_scale: TIME_SCALE,
+                shape_scale: Vec3::ONE * SHAPE_SCALE,
+                phase: 0.0, // set per-instance in spawn_ribbons()
+            },
+            Shape {
+                config: ShapeConfig::Lissajou { a: 3., b: 4. },
+                time_scale: 2.,
+                shape_scale: Vec3::ONE * 18.,
+                phase: 0.0, // set per-instance in spawn_ribbons()
+            },
+        ],
+    });
+}
+
+/// Spawn one ribbon every [`RIBBON_SPAWN_INTERVAL`], cycling through the
+/// registered shapes. Each ribbon is despawned a few seconds later by
+/// [`recycle_ribbons`], keeping a rolling set of ribbons alive.
+fn spawn_ribbons(time: Res<Time>, mut commands: Commands, mut spawner: ResMut<RibbonSpawner>) {
+    if !spawner.timer.tick(time.delta()).just_finished() {
+        return;
+    }
+
+    let mut shape = spawner.shapes[spawner.next % spawner.shapes.len()].clone();
+    // Offset each spawn along the curve so successive ribbons don't land on top
+    // of the previous one (move_head() drives all ribbons from the same clock).
+    shape.phase = spawner.next as f32 * RIBBON_PHASE_STEP;
+    spawner.next = spawner.next.wrapping_add(1);
 
     commands.spawn((
-        ParticleEffect::new(effect.clone()),
-        Name::new("spirograph"),
-        Shape {
-            config: ShapeConfig::Spirograph { k: K, l: L },
-            time_scale: TIME_SCALE,
-            shape_scale: Vec3::ONE * SHAPE_SCALE,
-        },
+        ParticleEffect::new(spawner.effect.clone()),
+        shape,
+        DespawnAfter(Timer::from_seconds(RIBBON_DESPAWN_AFTER, TimerMode::Once)),
     ));
+}
 
-    commands.spawn((
-        ParticleEffect::new(effect),
-        Name::new("lissajou"),
-        Shape {
-            config: ShapeConfig::Lissajou { a: 3., b: 4. },
-            time_scale: 2.,
-            shape_scale: Vec3::ONE * 18.,
-        },
-    ));
+/// Recycle ribbons at the end of their [`DespawnAfter`] lifetime: stop emitting
+/// for the final [`RIBBON_LIFETIME`] so the existing particles age out and fade
+/// the tail away (via the size/color-over-lifetime modifiers), then despawn the
+/// now-empty entity.
+fn recycle_ribbons(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut DespawnAfter, Option<&mut EffectSpawner>)>,
+) {
+    for (entity, mut despawn_after, spawner) in query.iter_mut() {
+        despawn_after.0.tick(time.delta());
+        if despawn_after.0.just_finished() {
+            commands.entity(entity).despawn();
+        } else if despawn_after.0.remaining_secs() <= RIBBON_LIFETIME {
+            // Stop spawning new particles; the live ones keep aging and fade out.
+            if let Some(mut spawner) = spawner {
+                spawner.active = false;
+            }
+        }
+    }
 }
 
 fn move_head(

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -37,14 +37,15 @@ use crate::{
         prepare_batch_inputs, prepare_bind_groups, prepare_effect_metadata, prepare_gpu_resources,
         prepare_indirect_pipeline, prepare_init_update_pipelines, prepare_property_buffers,
         propagate_ready_state, queue_effects, queue_init_fill_dispatch_ops,
-        queue_init_indirect_workgroup_update, report_ready_state, start_stop_gpu_debug_capture,
-        update_mesh_locations, DebugSettings, DispatchIndirectPipeline, DrawEffects,
-        EffectAssetEvents, EffectBindGroups, EffectCache, EffectsMeta, EventCache, GpuBatchInfo,
-        GpuBufferOperations, GpuEffectMetadata, GpuSpawnerParams, InitFillDispatchQueue,
-        ParticlesInitPipeline, ParticlesRenderPipeline, ParticlesUpdatePipeline, PrefixSumPipeline,
-        PropertyBindGroups, PropertyCache, RenderDebugSettings, ShaderCache, SimParams,
-        SortBindGroups, SortedEffectBatches, StorageType as _, UtilsPipeline,
-        VfxSimulateDriverNode, VfxSimulateNode,
+        queue_init_indirect_workgroup_update, queue_sort_fill_dispatch_ops, report_ready_state,
+        start_stop_gpu_debug_capture, update_mesh_locations, DebugSettings,
+        DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache,
+        EffectsMeta, EventCache, GpuBatchInfo, GpuBufferOperations, GpuEffectMetadata,
+        GpuSpawnerParams, InitFillDispatchQueue, ParticlesInitPipeline, ParticlesRenderPipeline,
+        ParticlesUpdatePipeline, PrefixSumPipeline, PropertyBindGroups, PropertyCache,
+        RenderDebugSettings, ShaderCache, SimParams, SortBindGroups, SortFillDispatchQueue,
+        SortedEffectBatches, StorageType as _, UtilsPipeline, VfxSimulateDriverNode,
+        VfxSimulateNode,
     },
     spawn::{self, Random},
     tick_spawners,
@@ -403,6 +404,7 @@ impl Plugin for HanabiPlugin {
             .init_resource::<EffectBindGroups>()
             .init_resource::<PropertyBindGroups>()
             .init_resource::<InitFillDispatchQueue>()
+            .init_resource::<SortFillDispatchQueue>()
             .insert_resource(sort_bind_groups)
             .init_resource::<UtilsPipeline>()
             .init_resource::<GpuBufferOperations>()
@@ -541,6 +543,18 @@ impl Plugin for HanabiPlugin {
                         // Need the properties block offset in GPU slab
                         .after(allocate_properties)
                         // This may invalidate some bind groups when resizing the metadata buffer
+                        .before(prepare_bind_groups),
+                    // Queue the dispatch ops to fill the indirect dispatch args of the ribbon
+                    // particle sort pass. Deferred from batch_effects() so it runs after the
+                    // effect metadata buffer has been (re-)allocated to this frame's size.
+                    queue_sort_fill_dispatch_ops
+                        .in_set(EffectSystems::PrepareEffectGpuResources)
+                        // Need the metadata buffer (re-)allocated so the captured handle and
+                        // dynamic offsets are correct and in-bounds
+                        .after(prepare_effect_metadata)
+                        // Must submit into the shared GpuBufferOperations before
+                        // queue_init_fill_dispatch_ops uploads its args buffer (end_frame)
+                        .before(queue_init_fill_dispatch_ops)
                         .before(prepare_bind_groups),
                     queue_init_fill_dispatch_ops
                         .in_set(EffectSystems::PrepareEffectGpuResources)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -7629,10 +7629,17 @@ impl Node for VfxSimulateNode {
                         // Bind group sort_fill@0
                         let particle_buffer = effect_buffer.particle_buffer();
                         let indirect_index_buffer = effect_buffer.indirect_index_buffer();
+                        // Part of the bind group key; reallocates as effects grow.
+                        let Some(spawner_buffer) = effects_meta.spawner_buffer.buffer() else {
+                            warn!("Missing spawner buffer for sort-fill.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortFillSpawnerBuffer");
+                            continue;
+                        };
                         let Some(bind_group) = sort_bind_groups.sort_fill_bind_group(
                             particle_buffer.id(),
                             indirect_index_buffer.id(),
                             effect_metadata_buffer.id(),
+                            spawner_buffer.id(),
                         ) else {
                             warn!("Missing sort-fill bind group.");
                             compute_pass.insert_debug_marker("ERROR:MissingSortFillBindGroup");
@@ -7708,9 +7715,16 @@ impl Node for VfxSimulateNode {
 
                         // Bind group sort_copy@0
                         let indirect_index_buffer = effect_buffer.indirect_index_buffer();
+                        // Part of the bind group key; reallocates as effects grow.
+                        let Some(spawner_buffer) = effects_meta.spawner_buffer.buffer() else {
+                            warn!("Missing spawner buffer for sort-copy.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortCopySpawnerBuffer");
+                            continue;
+                        };
                         let Some(bind_group) = sort_bind_groups.sort_copy_bind_group(
                             indirect_index_buffer.id(),
                             effect_metadata_buffer.id(),
+                            spawner_buffer.id(),
                         ) else {
                             warn!("Missing sort-copy bind group.");
                             compute_pass.insert_debug_marker("ERROR:MissingSortCopyBindGroup");

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -742,6 +742,123 @@ impl InitFillDispatchQueue {
     }
 }
 
+/// Single sort fill dispatch item in a [`SortFillDispatchQueue`].
+#[derive(Debug)]
+pub(super) struct SortFillDispatchItem {
+    /// Metadata table entry of the ribbon effect batch to read the
+    /// [`GpuEffectMetadata::alive_count`] from.
+    pub metadata_table_id: BufferTableId,
+    /// Index of the [`GpuDispatchIndirect`] entry to write the workgroup count
+    /// to.
+    pub sort_fill_indirect_dispatch_index: u32,
+}
+
+/// Queue of fill dispatch operations for the ribbon particle sort pass.
+///
+/// The queue stores the sort fill dispatch operations for the current frame,
+/// without the reference to the effect metadata buffer, which may be reallocated
+/// later in the frame. This allows enqueuing operations during batching, while
+/// deferring the buffer capture to after the metadata buffer is (re-)allocated.
+/// Mirrors [`InitFillDispatchQueue`].
+#[derive(Debug, Default, Resource)]
+pub(super) struct SortFillDispatchQueue {
+    queue: Vec<SortFillDispatchItem>,
+}
+
+impl SortFillDispatchQueue {
+    /// Clear the queue.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+
+    /// Enqueue a new operation.
+    #[inline]
+    pub fn enqueue(
+        &mut self,
+        metadata_table_id: BufferTableId,
+        sort_fill_indirect_dispatch_index: u32,
+    ) {
+        self.queue.push(SortFillDispatchItem {
+            metadata_table_id,
+            sort_fill_indirect_dispatch_index,
+        });
+    }
+
+    /// Submit the queued operations, returning the index of the submitted queue
+    /// (or `None` if there was nothing to submit). Must be called after
+    /// `effect_metadata_buffer` has been (re-)allocated for the frame.
+    pub fn submit(
+        &self,
+        effect_metadata_buffer: &BufferTable<GpuEffectMetadata>,
+        effect_metadata_aligned_size: NonZeroU32,
+        sort_bind_groups: &SortBindGroups,
+        gpu_buffer_operations: &mut GpuBufferOperations,
+    ) -> Option<u32> {
+        if self.queue.is_empty() {
+            return None;
+        }
+
+        let Some(src_buffer) = effect_metadata_buffer.buffer() else {
+            error!("Failed to find effect metadata buffer. This is a bug.");
+            return None;
+        };
+        let Some(dst_buffer) = sort_bind_groups.indirect_buffer() else {
+            error!("Missing indirect dispatch buffer for sorting, cannot schedule particle sort for ribbons. This is a bug.");
+            return None;
+        };
+
+        let src_offset = std::mem::offset_of!(GpuEffectMetadata, alive_count) as u32 / 4;
+        debug_assert_eq!(
+            src_offset, 1,
+            "GpuEffectMetadata changed, update this assert."
+        );
+        let src_stride = effect_metadata_aligned_size.get() / 4;
+        let dst_stride = GpuDispatchIndirectArgs::SHADER_SIZE.get() as u32 / 4;
+
+        let mut fill_queue = GpuBufferOperationQueue::new();
+        for item in &self.queue {
+            let src_binding_offset = effect_metadata_buffer.dynamic_offset(item.metadata_table_id);
+            // We bind the entire destination buffer (size `None`) and fold the row offset into
+            // `dst_offset`, because the indirect dispatch structs are only 12 bytes and so are not
+            // aligned to `min_storage_buffer_offset_alignment` for use as a dynamic binding offset.
+            let dst_offset = sort_bind_groups
+                .get_indirect_dispatch_byte_offset(item.sort_fill_indirect_dispatch_index)
+                / 4;
+            trace!(
+                "queue_sort_fill_dispatch(): src#{:?}@+{}B ({}B) -> dst#{:?}@+{}B (whole)",
+                src_buffer.id(),
+                src_binding_offset,
+                effect_metadata_aligned_size.get(),
+                dst_buffer.id(),
+                dst_offset * 4,
+            );
+            fill_queue.enqueue(
+                GpuBufferOperationType::FillDispatchArgs,
+                GpuBufferOperationArgs {
+                    src_offset,
+                    src_stride,
+                    dst_offset,
+                    dst_stride,
+                    count: 1,
+                },
+                src_buffer.clone(),
+                src_binding_offset,
+                Some(effect_metadata_aligned_size),
+                dst_buffer.clone(),
+                0,
+                None,
+            );
+        }
+
+        if fill_queue.operation_queue.is_empty() {
+            None
+        } else {
+            Some(gpu_buffer_operations.submit(fill_queue))
+        }
+    }
+}
+
 /// Compute pipeline to run the `vfx_indirect` dispatch workgroup calculation
 /// shader.
 #[derive(Resource)]
@@ -1203,6 +1320,24 @@ impl GpuBufferOperations {
         );
         for queue in &self.queues {
             for qop in queue {
+                // For dynamic-offset operations the dynamic offset is applied at dispatch time on
+                // top of the bound binding. Validate here that offset + size fits the source
+                // buffer, to turn a stale/too-small buffer capture into an actionable panic rather
+                // than a deep wgpu validation error at set_bind_group time.
+                #[cfg(debug_assertions)]
+                if matches!(qop.op, GpuBufferOperationType::FillDispatchArgs) {
+                    if let Some(size) = qop.src_binding_size {
+                        debug_assert!(
+                            qop.src_binding_offset as u64 + size.get() as u64
+                                <= qop.src_buffer.size(),
+                            "FillDispatchArgs src binding [{}..{}] overruns source buffer #{:?} of size {}.",
+                            qop.src_binding_offset,
+                            qop.src_binding_offset as u64 + size.get() as u64,
+                            qop.src_buffer.id(),
+                            qop.src_buffer.size(),
+                        );
+                    }
+                }
                 let key: QueuedOperationBindGroupKey = qop.into();
                 self.bind_groups.entry(key).or_insert_with(|| {
                     let src_id: NonZeroU32 = qop.src_buffer.id().into();
@@ -3109,12 +3244,14 @@ pub(crate) fn clear_previous_frame_resizes(
     mut effects_meta: ResMut<EffectsMeta>,
     mut sort_bind_groups: ResMut<SortBindGroups>,
     mut init_fill_dispatch_queue: ResMut<InitFillDispatchQueue>,
+    mut sort_fill_dispatch_queue: ResMut<SortFillDispatchQueue>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("clear_previous_frame_resizes").entered();
     trace!("clear_previous_frame_resizes");
 
     init_fill_dispatch_queue.clear();
+    sort_fill_dispatch_queue.clear();
 
     // Clear last frame's buffer resizes which may have occured during last frame,
     // during `Node::run()` while the `BufferTable` could not be mutated. This is
@@ -4436,6 +4573,7 @@ pub(crate) fn batch_effects(
     mut gpu_buffer_operations: ResMut<GpuBufferOperations>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
     mut property_bind_groups: ResMut<PropertyBindGroups>,
+    mut sort_fill_dispatch_queue: ResMut<SortFillDispatchQueue>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("batch_effects").entered();
@@ -4462,8 +4600,6 @@ pub(crate) fn batch_effects(
     // For now we re-create that buffer each frame. Since there's no CPU -> GPU
     // transfer, this is pretty cheap in practice.
     sort_bind_groups.clear_indirect_dispatch_buffer();
-
-    let mut sort_queue = GpuBufferOperationQueue::new();
 
     effects_meta.prefix_sum_buffer.clear();
     effects_meta.batch_info_buffer.clear();
@@ -4524,77 +4660,19 @@ pub(crate) fn batch_effects(
         // of the ribbon die (since we can't guarantee a linear lifetime through the
         // ribbon).
         if extracted_effect.layout_flags.contains(LayoutFlags::RIBBONS) {
-            // This buffer is allocated in prepare_effects(), so should always be available
-            let Some(effect_metadata_buffer) = effects_meta.effect_metadata_buffer.buffer() else {
-                error!("Failed to find effect metadata buffer. This is a bug.");
-                continue;
-            };
-
             // Allocate a GpuDispatchIndirect entry
             let sort_fill_indirect_dispatch_index = sort_bind_groups.allocate_indirect_dispatch();
             effect_batch.sort_fill_indirect_dispatch_index =
                 Some(sort_fill_indirect_dispatch_index);
 
-            // Enqueue a fill dispatch operation which reads GpuEffectMetadata::alive_count,
-            // compute a number of workgroups to dispatch based on that particle count, and
-            // store the result into a GpuDispatchIndirect struct which will be used to
-            // dispatch the fill-sort pass.
-            {
-                let src_buffer = effect_metadata_buffer.clone();
-                let src_binding_offset = effects_meta
-                    .effect_metadata_buffer
-                    .dynamic_offset(effect_batch.metadata_table_id);
-                let src_binding_size = effects_meta.gpu_limits.effect_metadata_aligned_size;
-                let Some(dst_buffer) = sort_bind_groups.indirect_buffer() else {
-                    error!("Missing indirect dispatch buffer for sorting, cannot schedule particle sort for ribbon. This is a bug.");
-                    continue;
-                };
-                let dst_buffer = dst_buffer.clone();
-                let dst_binding_offset = 0; // see dst_offset below
-                                            //let dst_binding_size = NonZeroU32::new(12).unwrap();
-                trace!(
-                    "queue_fill_dispatch(): src#{:?}@+{}B ({}B) -> dst#{:?}@+{}B ({}B)",
-                    src_buffer.id(),
-                    src_binding_offset,
-                    src_binding_size.get(),
-                    dst_buffer.id(),
-                    dst_binding_offset,
-                    -1, //dst_binding_size.get(),
-                );
-                let src_offset = std::mem::offset_of!(GpuEffectMetadata, alive_count) as u32 / 4;
-                debug_assert_eq!(
-                    src_offset, 1,
-                    "GpuEffectMetadata changed, update this assert."
-                );
-                // FIXME - This is a quick fix to get 0.15 out. The previous code used the
-                // dynamic binding offset, but the indirect dispatch structs are only 12 bytes,
-                // so are not aligned to min_storage_buffer_offset_alignment. The fix uses a
-                // binding offset of 0 and binds the entire destination buffer,
-                // then use the dst_offset value embedded inside the GpuBufferOperationArgs to
-                // index the proper offset in the buffer. This requires of
-                // course binding the entire buffer, or at least enough to index all operations
-                // (hence the None below). This is not really a general solution, so should be
-                // reviewed.
-                let dst_offset = sort_bind_groups
-                    .get_indirect_dispatch_byte_offset(sort_fill_indirect_dispatch_index)
-                    / 4;
-                sort_queue.enqueue(
-                    GpuBufferOperationType::FillDispatchArgs,
-                    GpuBufferOperationArgs {
-                        src_offset,
-                        src_stride: effects_meta.gpu_limits.effect_metadata_aligned_size.get() / 4,
-                        dst_offset,
-                        dst_stride: GpuDispatchIndirectArgs::SHADER_SIZE.get() as u32 / 4,
-                        count: 1,
-                    },
-                    src_buffer,
-                    src_binding_offset,
-                    Some(src_binding_size),
-                    dst_buffer,
-                    dst_binding_offset,
-                    None, //Some(dst_binding_size),
-                );
-            }
+            // Queue a fill dispatch op which reads GpuEffectMetadata::alive_count and computes the
+            // workgroup count for the fill-sort pass. The op is built later, in
+            // queue_sort_fill_dispatch_ops(), once the metadata buffer is resized; see
+            // SortFillDispatchQueue.
+            sort_fill_dispatch_queue.enqueue(
+                effect_batch.metadata_table_id,
+                sort_fill_indirect_dispatch_index,
+            );
         }
 
         // Append the batch to the (sorted) set of batches to render. If that batch
@@ -4645,11 +4723,11 @@ pub(crate) fn batch_effects(
             .insert(TemporaryRenderEntity);
     }
 
+    // Begin the GpuBufferOperations frame here; the matching submit()s happen in
+    // queue_sort_fill_dispatch_ops() and queue_init_fill_dispatch_ops(), and end_frame() at the
+    // tail of the latter. Render set ordering guarantees this begin precedes all submits.
     gpu_buffer_operations.begin_frame();
     debug_assert!(sorted_effect_batches.dispatch_queue_index.is_none());
-    if !sort_queue.operation_queue.is_empty() {
-        sorted_effect_batches.dispatch_queue_index = Some(gpu_buffer_operations.submit(sort_queue));
-    }
 
     // Write the entire spawner buffer for this frame, for all effects combined
     if effects_meta
@@ -6082,6 +6160,34 @@ pub(crate) fn prepare_effect_metadata(
     }
 }
 
+/// Read the queued ribbon sort fill dispatch operations and enqueue the
+/// corresponding GPU buffer fill dispatch operations.
+///
+/// This system runs after [`prepare_effect_metadata()`] has (re-)allocated the
+/// effect metadata buffer to this frame's effect count, so that it captures the
+/// correctly-sized buffer and computes in-bounds dynamic offsets. It must run
+/// before [`queue_init_fill_dispatch_ops()`], which uploads the shared
+/// [`GpuBufferOperations`] args buffer to the GPU at the end of the frame.
+pub(crate) fn queue_sort_fill_dispatch_ops(
+    effects_meta: Res<EffectsMeta>,
+    sort_bind_groups: Res<SortBindGroups>,
+    sort_fill_dispatch_queue: Res<SortFillDispatchQueue>,
+    mut gpu_buffer_operations: ResMut<GpuBufferOperations>,
+    mut sorted_effect_batches: ResMut<SortedEffectBatches>,
+) {
+    #[cfg(feature = "trace")]
+    let _span = bevy::log::info_span!("queue_sort_fill_dispatch_ops").entered();
+    trace!("queue_sort_fill_dispatch_ops");
+
+    debug_assert!(sorted_effect_batches.dispatch_queue_index.is_none());
+    sorted_effect_batches.dispatch_queue_index = sort_fill_dispatch_queue.submit(
+        &effects_meta.effect_metadata_buffer,
+        effects_meta.gpu_limits.effect_metadata_aligned_size,
+        &sort_bind_groups,
+        &mut gpu_buffer_operations,
+    );
+}
+
 /// Read the queued init fill dispatch operations, batch them together by
 /// contiguous source and destination entries in the buffers, and enqueue
 /// corresponding GPU buffer fill dispatch operations for all batches.
@@ -6112,7 +6218,9 @@ pub(crate) fn queue_init_fill_dispatch_ops(
         }
     }
 
-    // Once all GPU operations for this frame are enqueued, upload them to GPU
+    // End the GpuBufferOperations frame and upload the args buffer to GPU, after every submit() for
+    // the frame (the sort submit in queue_sort_fill_dispatch_ops() is ordered before this system,
+    // the init submit is just above). See begin_frame() in batch_effects() for the full lifecycle.
     gpu_buffer_operations.end_frame(&render_device, &render_queue);
 }
 

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -55,6 +55,9 @@ struct SortFillBindGroupKey {
     particle: BufferId,
     indirect_index: BufferId,
     effect_metadata: BufferId,
+    // Bound at binding 4 with a per-effect dynamic offset; reallocates as
+    // effects grow, so it must be keyed or a stale buffer overruns the offset.
+    spawner: BufferId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -62,6 +65,9 @@ struct SortCopyBindGroupKey {
     indirect_index: BufferId,
     sort: BufferId,
     effect_metadata: BufferId,
+    // Bound at binding 3 with a per-effect dynamic offset; reallocates as
+    // effects grow, so it must be keyed or a stale buffer overruns the offset.
+    spawner: BufferId,
 }
 
 /// GPU representation of a single dual-key value pair, with the added buffer
@@ -410,6 +416,7 @@ impl SortBindGroups {
             particle: particle.id(),
             indirect_index: indirect_index.id(),
             effect_metadata: effect_metadata.id(),
+            spawner: spawner_buffer.id(),
         };
         let entry = self.sort_fill_bind_groups.entry(key);
         let bind_group = match entry {
@@ -473,11 +480,13 @@ impl SortBindGroups {
         particle: BufferId,
         indirect_index: BufferId,
         effect_metadata: BufferId,
+        spawner: BufferId,
     ) -> Option<&BindGroup> {
         let key = SortFillBindGroupKey {
             particle,
             indirect_index,
             effect_metadata,
+            spawner,
         };
         self.sort_fill_bind_groups.get(&key)
     }
@@ -515,6 +524,7 @@ impl SortBindGroups {
             indirect_index: indirect_index_buffer.id(),
             sort: self.sort_buffer.id(),
             effect_metadata: effect_metadata_buffer.id(),
+            spawner: spawner_buffer.id(),
         };
         let entry = self.sort_copy_bind_groups.entry(key);
         let bind_group = match entry {
@@ -564,11 +574,13 @@ impl SortBindGroups {
         &self,
         indirect_index: BufferId,
         effect_metadata: BufferId,
+        spawner: BufferId,
     ) -> Option<&BindGroup> {
         let key = SortCopyBindGroupKey {
             indirect_index,
             sort: self.sort_buffer.id(),
             effect_metadata,
+            spawner,
         };
         self.sort_copy_bind_groups.get(&key)
     }


### PR DESCRIPTION
## Problem

When several effects are alive and at least one uses ribbons (`Attribute::RIBBON_ID`), the app crashes in the render thread on a frame where spawning a new effect grows the effect metadata buffer:

```
wgpu error: Validation Error
  In a set_bind_group command
    Dynamic binding offset index 1 with offset 128 would overrun the buffer
    bound to BindGroup ... Buffer size is 128 bytes ...
```

## Cause

The ribbon particle sort needs a per-effect fill-dispatch that reads `GpuEffectMetadata::alive_count` from the global effect metadata buffer via a dynamic offset. That GPU buffer operation was built in `batch_effects()` (`EffectSystems::PrepareEffectAssets`), where it captured the metadata buffer handle and computed its dynamic offset.

But the metadata buffer is only grown to the current frame's effect count later, in `prepare_effect_metadata()` (`EffectSystems::PrepareEffectGpuResources`). So on a growth frame, `batch_effects()` captured last frame's smaller buffer together with an offset computed for the grown layout. When the cached bind group was validated at dispatch, the dynamic offset overran the (stale) buffer.

## Fix

Defer building the sort fill-dispatch op to a new `queue_sort_fill_dispatch_ops()` system that runs **after** `prepare_effect_metadata()` has (re-)allocated the buffer and **before** the args buffer is uploaded. This mirrors the existing init fill-dispatch path (`InitFillDispatchQueue` / `queue_init_fill_dispatch_ops`):

- `batch_effects()` now only records the intent (metadata table id + indirect dispatch index) into a new `SortFillDispatchQueue`.
- `queue_sort_fill_dispatch_ops()` captures the now-correctly-sized buffer and computes in-bounds offsets, then submits.

Also added a `debug_assert` in `GpuBufferOperations::create_bind_groups` that a dynamic-offset source binding fits its buffer, to surface this class of mistake as an actionable panic rather than a deep wgpu validation error.

## Example / repro

Reworked the `ribbon` example to spawn and despawn several ribbon effects over time (instead of two at startup), so the metadata buffer grows while ribbons are alive. Pre-fix this crashes during the ramp-up; post-fix it runs stably.

## Notes

- The error path in `batch_effects()` previously did a `continue` inside the ribbon block (which also skipped pushing the batch); the batch is now always built and only the sort dispatch is skipped on the (effectively unreachable) missing-buffer path. This is intentional.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test --lib` all pass. Verified the reworked `ribbon` example runs without the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second fix: stale spawner buffer in the sort bind-group cache

After the fill-dispatch fix above, a second instance of the same buffer-staleness family remained — on the `SortBindGroups` path, which the `create_bind_groups` debug_assert does not cover.

Both sort bind groups bind the spawner buffer with a per-effect dynamic offset — `sort_fill` at binding 4, `sort_copy` at binding 3 — but their cache keys omitted it (keying only particle / indirect_index / effect_metadata). The spawner buffer is an `AlignedBufferVec` that is cleared and refilled every frame and reallocates a new GPU buffer when the effect count grows. On a growth frame where the keyed buffers keep their ids but the spawner buffer reallocates, the cached bind group kept a stale, smaller spawner buffer, and the dynamic offset for a newly added effect overran it:

```
set_bind_group: Dynamic binding offset index 1 with offset 3712 would overrun
the buffer bound to BindGroup 'hanabi:bg:sort_fill' binding 4. Buffer size is 3712 bytes ...
```

Fix: add the spawner buffer id to both `SortFillBindGroupKey` and `SortCopyBindGroupKey`, so a reallocated spawner buffer rebuilds the affected bind group.

## Root cause & follow-up

These are three instances of one underlying fragility: a cached bind group's key manually enumerates a subset of the buffers it binds, so any bound buffer whose identity can change must be remembered in the key — and forgetting one yields a stale-buffer overrun. That's easy to get wrong (it happened in `sort_fill`, `sort_copy`, and as a timing variant in the fill-dispatch).

A structural fix would make this class impossible rather than relying on remembering. Options, happy to do as a follow-up PR:
- Recreate the sort bind groups each frame instead of caching them — the spawner/metadata buffers churn every frame anyway, so the cache buys little, and recreating removes the staleness entirely.
- Or derive the cache key from the actual set of bound buffers so it can't drift from what's bound.
- Or extend the `create_bind_groups` dynamic-offset debug_assert to the `SortBindGroups` path so this class surfaces as an actionable panic there too.

Kept out of this PR to keep it focused on the concrete crash fixes.

## Also fixes #511

#511 ("Crash on spawning multiple ribbons") is the same growth-frame staleness reached from a different angle: spawning a second ribbon of an already-in-use effect grows the effect count on a later frame, which reallocates the metadata/spawner buffers and trips the stale fill-dispatch / bind-group buffers fixed here. This matches the reporter's observations exactly — no crash when spawning instances together up front or when using a *different* effect, only when growing into an effect already in use. The reworked `ribbon` example exercises this spawn-over-time pattern and now runs cleanly.

Closes #511