### PR TITLE
Grow the sort indirect-dispatch buffer instead of overrunning a fixed 256 (closes #493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `typetag` dependency.
 - Removed the `serde` feature. Serialization is always available.
 
+### Fixed
+
+- Fixed the sort indirect-dispatch buffer never growing past its initial 256 entries,
+  which caused an indirect buffer overrun and a render-thread crash in scenes with
+  many sorted (e.g. ribbon) effects alive at once (#493).
+
 ## [0.18.0] 2026-02-01
 
 _This version is compatible with Bevy 0.18_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the sort indirect-dispatch buffer never growing past its initial 256 entries,
-  which caused an indirect buffer overrun and a render-thread crash in scenes with
-  many sorted (e.g. ribbon) effects alive at once (#493).
+- Fixed the sort indirect-dispatch buffer never growing past its initial 256 entries, causing
+  an indirect buffer overrun and crash with many sorted (e.g. ribbon) effects alive at once. (#493)
 
 ## [0.18.0] 2026-02-01
 

--- a/src/render/gpu_buffer.rs
+++ b/src/render/gpu_buffer.rs
@@ -114,9 +114,9 @@ impl<T: Pod + ShaderType + ShaderSize> GpuBuffer<T> {
     /// [`ShaderType::assert_uniform_compat()`].
     ///
     /// [`BufferUsages::UNIFORM`]: bevy::render::render_resource::BufferUsages::UNIFORM
-    pub fn new_allocated(buffer: Buffer, size: u32, label: Option<String>) -> Self {
-        // GPU-aligned item size, compatible with WGSL rules
-        let item_size = <T as ShaderSize>::SHADER_SIZE.get() as u32;
+    pub fn new_allocated(buffer: Buffer, label: Option<String>) -> Self {
+        // GPU-aligned item size, compatible with WGSL rules.
+        let item_size = <T as ShaderSize>::SHADER_SIZE.get();
         let buffer_usage = buffer.usage();
         assert!(
             buffer_usage.contains(BufferUsages::COPY_SRC | BufferUsages::COPY_DST),
@@ -125,7 +125,16 @@ impl<T: Pod + ShaderType + ShaderSize> GpuBuffer<T> {
         if buffer_usage.contains(BufferUsages::UNIFORM) {
             <T as ShaderType>::assert_uniform_compat();
         }
-        trace!("GpuBuffer: item_size={}", item_size);
+        // Capacity is derived from the physical buffer so the two can't disagree.
+        debug_assert_eq!(
+            buffer.size() % item_size,
+            0,
+            "GpuBuffer physical size ({} bytes) is not a multiple of the element size ({} bytes)",
+            buffer.size(),
+            item_size,
+        );
+        let size = (buffer.size() / item_size) as u32;
+        trace!("GpuBuffer: item_size={item_size} capacity={size}");
         Self {
             buffer: Some(BufferAndSize { buffer, size }),
             buffer_usage,

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -12,7 +12,7 @@ use bevy::{
             },
             BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries, Buffer,
             BufferId, CachedComputePipelineId, CachedPipelineState, ComputePipelineDescriptor,
-            PipelineCache, ShaderType,
+            PipelineCache, ShaderSize, ShaderType,
         },
         renderer::RenderDevice,
     },
@@ -127,10 +127,11 @@ impl SortBindGroups {
             mapped_at_creation: false,
         });
 
-        let indirect_buffer_size = 3 * 1024;
+        // Initial room for 256 ribbon sort dispatches; the GpuBuffer grows on demand.
+        let indirect_item_size = GpuDispatchIndirectArgs::SHADER_SIZE.get();
         let indirect_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("hanabi:buffer:sort:indirect"),
-            size: indirect_buffer_size,
+            size: 256 * indirect_item_size,
             usage: BufferUsages::COPY_SRC
                 | BufferUsages::COPY_DST
                 | BufferUsages::STORAGE
@@ -139,7 +140,6 @@ impl SortBindGroups {
         });
         let indirect_buffer = GpuBuffer::new_allocated(
             indirect_buffer,
-            indirect_buffer_size as u32,
             Some("hanabi:buffer:sort:indirect".to_string()),
         );
 


### PR DESCRIPTION
## Problem

With many ribbon effects alive (~260 trailed projectiles), the render thread crashes:

```
dispatch indirect: buffer uses bytes 3072..3084 which overruns indirect buffer of size 3072
```

(The crash reported in #493.)

## Cause

The sort indirect-dispatch buffer is a growable `GpuBuffer` whose capacity is tracked in **elements**: `allocate()` may hand out an index past the current capacity, and `prepare_buffers()` then grows the GPU buffer to fit.

`GpuBuffer::new_allocated` took the element capacity as a separate argument, and `SortBindGroups::new` passed the buffer's **byte** size (3072) there instead of its element count. With 12-byte `GpuDispatchIndirectArgs` the physical buffer holds 256 elements, while `GpuBuffer` believed it had 3072 elements of headroom — so `prepare_buffers()` never grew it. The 257th sort dispatch then read past the end of the physical buffer (byte 3072 in a 3072-byte buffer), exactly the reported numbers.

## Fix

Remove the separate capacity argument from `new_allocated` and derive the element capacity from the physical buffer (`buffer.size() / item_size`), so the recorded and physical capacities can't disagree. `new_allocated` has a single caller, which now just sizes the buffer; a `debug_assert` guards a non-multiple size.

## Testing

Verified in a ribbon-heavy app (every projectile carries a ribbon trail): pre-fix it crashes reliably once ~256 ribbon sort dispatches are concurrently active; post-fix it runs well past that as the buffer grows. `cargo build` passes.

Independent of #537 (stale-buffer overruns in the sort bind-group *cache*); this is the buffer *growth* bug, #493.

Closes #493
