### PR TITLE
Add `Modifier::into_boxed_render()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,7 @@ _This version is compatible with Bevy 0.12_
 - Added the `ImageSampleMapping` enum to determine how samples of the image of a `ParticleTextureModifier` are mapped to and modulated with the particle's base color. The new default behavior is `ImageSampleMapping::Modulate`, corresponding to a full modulate of all RGBA components. To restore the previous behavior, and use the Red channel of the texture as an opacity mask, set `ParticleTextureModifier::sample_mapping` to `ImageSampleMapping::ModulateOpacityFromR`.
 - Added new `FlipbookModifier` to treat the image of a `ParticleTextureModifier` as a grid sprite sheet, and allow rendering a sprite from that sheet. By animating the selected sprite, this creates a flipbook animation for the particle.
 - Added new `Attribute::SPRITE_INDEX` holding the `i32` index of a sprite inside a sprite sheet texture. This is used with the `FlipbookModifier` to render sprite-based animated particles.
+- Added `Modifier::into_boxed_render()` to cast `Box<dyn Modifier>` to `Box<dyn RenderModifier>` without cloning.
 
 ### Changed
 

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -165,6 +165,11 @@ pub trait Modifier: Reflect + Send + Sync + 'static {
         None
     }
 
+    /// Try to convert this modifier to a [`RenderModifier`].
+    fn into_boxed_render(self: Box<Self>) -> Option<Box<dyn RenderModifier>> {
+        None
+    }
+
     /// Get the list of attributes required for this modifier to be used.
     fn attributes(&self) -> &[Attribute];
 
@@ -587,6 +592,10 @@ macro_rules! impl_mod_render {
                 Some(self)
             }
 
+            fn into_boxed_render(self: Box<Self>) -> Option<Box<dyn RenderModifier>> {
+                Some(self)
+            }
+
             fn attributes(&self) -> &[$crate::Attribute] {
                 $attrs
             }
@@ -928,6 +937,28 @@ mod tests {
             radius: m.lit(1.),
             dimension: ShapeDimension::Surface,
         }
+    }
+
+    #[test]
+    fn modifier_into_render() {
+        let original = SetSizeModifier {
+            size: Vec3::ONE.into(),
+        };
+        let original = Box::new(original);
+        let before: *const dyn RenderModifier = &*original;
+        let modifier: Box<dyn Modifier> = original;
+
+        // into_boxed_render() casts the same object
+        let modifier = modifier.into_boxed_render();
+        assert!(modifier.is_some());
+        let modifier = modifier.unwrap();
+        let after: *const dyn RenderModifier = &*modifier;
+        assert_eq!(before.addr(), after.addr());
+
+        // boxed_render_clone() creates a different object
+        let modifier = modifier.boxed_render_clone();
+        let after: *const dyn RenderModifier = &*modifier;
+        assert_ne!(before.addr(), after.addr());
     }
 
     #[test]


### PR DESCRIPTION
Add a function to convert a boxed `Modifier` into a boxed `RenderModifier` (if possible). This avoids having to clone with `boxed_render_clone()` to convert a boxed modifier.