### PR TITLE
Pack `EffectMetadata` and bind as array

### DIFF
--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -18,6 +18,10 @@ use utils::*;
 
 const DEMO_DESC: &str = include_str!("instancing.txt");
 
+/// Per-effect instance Hue offset, to show that all instances are unique.
+#[derive(Component)]
+struct HueOffset(pub f32);
+
 #[derive(Default, Resource)]
 struct InstanceManager {
     effect: Handle<EffectAsset>,
@@ -75,6 +79,9 @@ impl InstanceManager {
 
         let pos = origin + IVec2::new(index % self.grid_size.x, index / self.grid_size.x);
 
+        let mut thread_rng = rand::rng();
+        let hue_offset = thread_rng.random_range(0..360) as f32;
+
         *entry = Some(
             commands
                 .spawn((
@@ -94,6 +101,12 @@ impl InstanceManager {
                     EffectMaterial {
                         images: vec![self.texture.clone()],
                     },
+                    // Only used if alt_effect, but just simpler to add all the time for this
+                    // example only.
+                    EffectProperties::default(),
+                    // Set a unique random Hue offset per effect instance, so that they don't all
+                    // look the same.
+                    HueOffset(hue_offset),
                 ))
                 .with_children(|p| {
                     // Reference cube to visualize the emit origin
@@ -180,7 +193,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .insert_resource(InstanceManager::new(5, 4))
         .add_systems(Startup, setup)
-        .add_systems(Update, keyboard_input_system)
+        .add_systems(Update, (keyboard_input_system, update_color_via_property))
         //.add_system(stress_test.after(keyboard_input_system))
         .run();
     app_exit.into_result()
@@ -215,10 +228,6 @@ fn setup(
     });
     let mat = materials.add(utils::COLOR_PURPLE);
 
-    let mut gradient = bevy_hanabi::Gradient::new();
-    gradient.add_key(0.0, Vec4::new(0.0, 0.0, 1.0, 1.0));
-    gradient.add_key(1.0, Vec4::splat(0.0));
-
     let writer = ExprWriter::new();
 
     let age = writer.lit(0.).expr();
@@ -238,6 +247,10 @@ fn setup(
         speed: writer.lit(2.).expr(),
     };
 
+    let prop_color = writer.add_property("prop_color", 0xFFFFFFFFu32.into());
+    let prop_color = writer.prop(prop_color);
+    let update_col = SetAttributeModifier::new(Attribute::COLOR, prop_color.expr());
+
     let effect = effects.add(
         EffectAsset::new(512, SpawnerSettings::rate(50.0.into()), writer.finish())
             .with_name("instancing")
@@ -245,13 +258,8 @@ fn setup(
             .init(init_vel)
             .init(init_age)
             .init(init_lifetime)
-            .render(ColorOverLifetimeModifier::new(gradient)),
+            .update(update_col),
     );
-
-    let mut gradient = bevy_hanabi::Gradient::new();
-    gradient.add_key(0.0, Vec4::new(1., 0., 0., 0.));
-    gradient.add_key(0.1, Vec4::new(1., 0., 0., 1.));
-    gradient.add_key(1.0, Vec4::new(1., 0., 0., 0.));
 
     let writer = ExprWriter::new();
 
@@ -275,6 +283,10 @@ fn setup(
 
     let texture_slot = writer.lit(0u32).expr();
 
+    let prop_color = writer.add_property("prop_color", 0xFFFFFFFFu32.into());
+    let prop_color = writer.prop(prop_color);
+    let update_col = SetAttributeModifier::new(Attribute::COLOR, prop_color.expr());
+
     let mut module = writer.finish();
     module.add_texture_slot("color");
 
@@ -286,11 +298,11 @@ fn setup(
             .init(init_vel)
             .init(init_lifetime)
             .update(radial_accel)
+            .update(update_col)
             .render(ParticleTextureModifier {
                 texture_slot,
                 sample_mapping: ImageSampleMapping::Modulate,
-            })
-            .render(ColorOverLifetimeModifier::new(gradient)),
+            }),
     );
 
     // Store the effects for later reference
@@ -320,13 +332,21 @@ fn keyboard_input_system(
     {
         my_effect.despawn_random(&mut commands);
     }
+}
 
-    // #123 - Hanabi 0.5.2 Causes Panic on Unwrap
-    // if my_effect.frame == 5 {
-    //     my_effect.despawn_nth(&mut commands, 3);
-    //     my_effect.despawn_nth(&mut commands, 2);
-    //     my_effect.spawn_random(&mut commands);
-    // }
+fn update_color_via_property(
+    time: Res<Time<EffectSimulation>>,
+    mut q_effects: Query<(&HueOffset, &mut EffectProperties)>,
+) {
+    for (hue_offset, properties) in &mut q_effects {
+        let color = Color::hsv(
+            (time.elapsed_secs() / 10.0 + hue_offset.0 / 360.0).fract() * 360.0,
+            1.0,
+            1.0,
+        )
+        .to_linear();
+        EffectProperties::set_if_changed(properties, "prop_color", color.as_u32().into());
+    }
 }
 
 fn stress_test(mut commands: Commands, mut my_effect: ResMut<InstanceManager>) {

--- a/examples/ribbon.rs
+++ b/examples/ribbon.rs
@@ -245,7 +245,7 @@ fn recycle_ribbons(
 
 fn move_head(
     mut query: Query<(&mut Shape, &mut Transform), With<ParticleEffect>>,
-    timer: Res<Time>,
+    timer: Res<Time<EffectSimulation>>,
 ) {
     for (mut shape, mut transform) in query.iter_mut() {
         let time = timer.elapsed_secs();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -39,17 +39,17 @@ use crate::{
         queue_init_indirect_workgroup_update, queue_sort_fill_dispatch_ops, report_ready_state,
         start_stop_gpu_debug_capture, update_mesh_locations, Batcher, DebugSettings,
         DispatchIndirectPipeline, DrawEffects, EffectAssetEvents, EffectBindGroups, EffectCache,
-        EffectsMeta, EventCache, GpuBatchInfo, GpuBufferOperations, GpuEffectMetadata,
-        GpuSpawnerParams, HanabiRenderPlugin, InitFillDispatchQueue, ParticlesInitPipeline,
-        ParticlesRenderPipeline, ParticlesUpdatePipeline, PrefixSumPipeline, PropertyBindGroups,
-        PropertyCache, RenderDebugSettings, ShaderCache, SimParams, SortBindGroups,
-        SortFillDispatchQueue, StorageType as _, UtilsPipeline,
+        EffectsMeta, EventCache, GpuBatchInfo, GpuBufferOperations, GpuSpawnerParams,
+        HanabiRenderPlugin, InitFillDispatchQueue, ParticlesInitPipeline, ParticlesRenderPipeline,
+        ParticlesUpdatePipeline, PrefixSumPipeline, PropertyBindGroups, PropertyCache,
+        RenderDebugSettings, ShaderCache, SimParams, SortBindGroups, SortFillDispatchQueue,
+        StorageType as _, UtilsPipeline,
     },
     spawn::{self, Random},
     tick_spawners,
     time::effect_simulation_time_system,
     update_properties_from_asset, EffectSimulation, EffectVisibilityClass, ParticleEffect,
-    SpawnerSettings, ToWgslString,
+    SpawnerSettings,
 };
 
 /// Source code for the `vfx_sort` compute shader.
@@ -126,17 +126,9 @@ impl HanabiPlugin {
             GpuSpawnerParams::padding_code(min_storage_buffer_offset_alignment);
         let batch_info_padding_code =
             GpuBatchInfo::padding_code(min_storage_buffer_offset_alignment);
-        let effect_metadata_padding_code =
-            GpuEffectMetadata::padding_code(min_storage_buffer_offset_alignment);
-        let render_effect_indirect_size =
-            GpuEffectMetadata::aligned_size(min_storage_buffer_offset_alignment);
-        let effect_metadata_stride_code =
-            (render_effect_indirect_size.get() as u32).to_wgsl_string();
         let common_code = include_str!("render/vfx_common.wgsl")
             .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
-            .replace("{{BATCH_INFO_PADDING}}", &batch_info_padding_code)
-            .replace("{{EFFECT_METADATA_PADDING}}", &effect_metadata_padding_code)
-            .replace("{{EFFECT_METADATA_STRIDE}}", &effect_metadata_stride_code);
+            .replace("{{BATCH_INFO_PADDING}}", &batch_info_padding_code);
         Shader::from_wgsl(
             common_code,
             std::path::Path::new(file!())
@@ -160,14 +152,7 @@ impl HanabiPlugin {
         min_storage_buffer_offset_alignment: u32,
         has_events: bool,
     ) -> Shader {
-        let render_effect_indirect_size =
-            GpuEffectMetadata::aligned_size(min_storage_buffer_offset_alignment);
-        let render_effect_indirect_stride_code =
-            (render_effect_indirect_size.get() as u32).to_wgsl_string();
-        let indirect_code = include_str!("render/vfx_indirect.wgsl").replace(
-            "{{EFFECT_METADATA_STRIDE}}",
-            &render_effect_indirect_stride_code,
-        );
+        let indirect_code = include_str!("render/vfx_indirect.wgsl");
         Shader::from_wgsl(
             indirect_code,
             std::path::Path::new(file!())
@@ -504,7 +489,7 @@ impl Plugin for HanabiPlugin {
                         .before(prepare_bind_groups),
                     prepare_effect_metadata
                         .in_set(EffectSystems::PrepareEffectGpuResources)
-                        // Need DispatchBufferIndices to be allocated
+                        //
                         .after(allocate_effects)
                         // Need the draw indirect args to be allocated
                         .after(update_mesh_locations)
@@ -521,9 +506,13 @@ impl Plugin for HanabiPlugin {
                     // effect metadata buffer has been (re-)allocated to this frame's size.
                     queue_sort_fill_dispatch_ops
                         .in_set(EffectSystems::PrepareEffectGpuResources)
+                        // The prefix sum buffer is allocated and uploaded while batching.
+                        .after(batch_effects)
                         // Need the metadata buffer (re-)allocated so the captured handle and
                         // dynamic offsets are correct and in-bounds
                         .after(prepare_effect_metadata)
+                        // Keep this aligned with other queue submissions that capture GPU buffers.
+                        .after(prepare_gpu_resources)
                         // Must submit into the shared GpuBufferOperations before
                         // queue_init_fill_dispatch_ops uploads its args buffer (end_frame)
                         .before(queue_init_fill_dispatch_ops)

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -25,12 +25,14 @@ use crate::{
     AlphaMode, EffectAsset, ParticleLayout, TextureLayout,
 };
 
+/// Info about particle spawning for an entire batch of effects.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum BatchSpawnInfo {
     /// Spawn a number of particles uploaded from CPU each frame.
     CpuSpawner {
         /// Total number of particles to spawn for the batch. This is only used
-        /// to calculate the number of compute workgroups to dispatch.
+        /// to calculate the number of compute workgroups to dispatch. This is
+        /// the sum of all spawn counts for all effects in the batch.
         total_spawn_count: u32,
     },
 
@@ -52,15 +54,61 @@ pub(crate) enum BatchSpawnInfo {
 }
 
 impl BatchSpawnInfo {
+    /// Check if this batch uses CPU-based spawning.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if this instance is a `BatchSpawnInfo::CpuSpawner`.
     #[inline]
     #[must_use]
     pub fn is_cpu(&self) -> bool {
         matches!(self, Self::CpuSpawner { .. })
     }
 
+    /// Check if this batch uses GPU-based spawning.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if this instance is a `BatchSpawnInfo::GpuSpawner`.
     #[inline]
     #[must_use]
     #[allow(dead_code)]
+    pub fn is_gpu(&self) -> bool {
+        matches!(self, Self::GpuSpawner { .. })
+    }
+
+    /// Retrieve the CPU spawn count, if this batch is CPU-based.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(count)` with the total spawn count if this instance is a
+    /// `BatchSpawnInfo::CpuSpawner`. Otherwise returns `None`.
+    #[inline]
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn as_cpu(&self) -> Option<&u32> {
+        if let Self::CpuSpawner { total_spawn_count } = self {
+            Some(total_spawn_count)
+        } else {
+            None
+        }
+    }
+
+    /// Retrieve the CPU spawn count or a default value.
+    ///
+    /// This variant is used as a shortcut to
+    /// `.as_cpu().unwrap_or(<unspecified>)` when filling out GPU buffers,
+    /// where we need a value whatever the case, but will ignore it if GPU
+    /// based.
+    ///
+    /// # Returns
+    ///
+    /// Returns the total spawn count if this instance is a
+    /// `BatchSpawnInfo::CpuSpawner`. Otherwise returns an unspecified value,
+    /// which should be ignored.
+    #[inline]
+    #[must_use]
+    #[allow(unused)]
     pub fn cpu_spawn_count(&self) -> u32 {
         if let Self::CpuSpawner { total_spawn_count } = self {
             *total_spawn_count
@@ -92,7 +140,8 @@ pub(crate) struct BatchEffectData {
 pub(crate) struct EffectBatch {
     /// ID of the [`GpuBatchInfo`] in the global shared array for this batch.
     pub batch_info_id: u32,
-    /// Handle of the underlying effect asset describing the effect.
+    /// Handle of the underlying effect asset describing the effect. The batch
+    /// only contains effect instances of the same asset.
     pub handle: Handle<EffectAsset>,
     /// ID of the particle slab in the [`EffectBuffer`] where all the batched
     /// effects are stored.
@@ -201,6 +250,9 @@ pub(crate) struct Batcher {
     /// Index of the dispatch queue used for indirect fill dispatch and
     /// submitted to [`GpuBufferOperations`].
     pub(super) dispatch_queue_index: Option<u32>,
+    /// Index of the queue which copies post-update alive counts into the prefix
+    /// sum buffer before the ribbon sort prefix sum pass.
+    pub(super) sort_fill_prefix_sum_queue_index: Option<u32>,
     /// Global shared GPU buffer storing the various `BatchInfo` structs for the
     /// active batches. This is dynamically updated each frame based on current
     /// batching, with one entry per batch (= one entry per dispatch/draw).
@@ -230,6 +282,7 @@ impl FromWorld for Batcher {
         Self {
             batches: vec![],
             dispatch_queue_index: None,
+            sort_fill_prefix_sum_queue_index: None,
             batch_info_buffer,
             is_batch_open: false,
             prefix_sum_buffer,
@@ -257,6 +310,7 @@ impl Batcher {
     pub fn clear(&mut self) {
         self.batches.clear();
         self.dispatch_queue_index = None;
+        self.sort_fill_prefix_sum_queue_index = None;
         self.prefix_sum_buffer.clear();
         self.batch_info_buffer.clear();
     }
@@ -269,8 +323,8 @@ impl Batcher {
 
         let batch_info_base = self.batch_info_buffer.len() as u32;
         let batch_info = GpuBatchInfo {
-            total_spawn_count: 0,
-            total_update_count: 0,
+            total_spawn_count: 0,  // set in end_batch()
+            total_update_count: 0, // calculated on GPU
             spawner_base,
             base_particle,
             prefix_sum_offset,
@@ -318,13 +372,19 @@ impl Batcher {
             "Call to end_batch() without begin_batch()"
         );
 
+        // Get the open batch
         let batch = self
             .batch_info_buffer
             .last_mut()
             .expect("No open batch. Missing begin_batch() call?");
+
+        // Record prefix sum
         let end = self.prefix_sum_buffer.len() as u32;
         assert!(end >= batch.prefix_sum_offset);
         batch.prefix_sum_count = end - batch.prefix_sum_offset;
+
+        // Record total number of CPU spawn, to clamp the number of GPU threads
+        batch.total_spawn_count = self.cpu_prefix_sum_value;
 
         self.is_batch_open = false;
     }
@@ -345,19 +405,23 @@ impl Batcher {
     /// merged with a previous batch. Otherwise the input batch was merged with
     /// an existing one, and therefore share its index; in that case `None` is
     /// returned.
+    ///
+    /// Also returns the index of that effect batch in the prefix sum buffer.
     pub fn push(
         &mut self,
         effect_batch: EffectBatch,
         instance_spawn_count: u32,
-    ) -> Option<EffectBatchIndex> {
+    ) -> (Option<EffectBatchIndex>, u32) {
         assert!(effect_batch.effect_data.len() == 1);
+
+        let prefix_sum_index = self.prefix_sum_buffer.len() as u32;
 
         let effect_batch = if let Some(batch) = self.batches.last_mut() {
             let Err(effect_batch) = batch.try_merge(effect_batch) else {
                 // Successfully batched
                 self.add_effect_to_batch(self.cpu_prefix_sum_value);
                 self.cpu_prefix_sum_value += instance_spawn_count;
-                return None;
+                return (None, prefix_sum_index);
             };
             // Failed to merge incompatible batches
             effect_batch
@@ -382,15 +446,17 @@ impl Batcher {
         self.add_effect_to_batch(self.cpu_prefix_sum_value);
         self.cpu_prefix_sum_value += instance_spawn_count;
 
-        Some(EffectBatchIndex(index))
+        (Some(EffectBatchIndex(index)), prefix_sum_index)
     }
 
     #[inline]
+    #[must_use]
     pub fn last(&self) -> Option<&EffectBatch> {
         self.batches.last()
     }
 
     #[inline]
+    #[must_use]
     pub fn last_mut(&mut self) -> Option<&mut EffectBatch> {
         self.batches.last_mut()
     }

--- a/src/render/buffer_table.rs
+++ b/src/render/buffer_table.rs
@@ -410,6 +410,7 @@ impl<T: Pod + ShaderSize> BufferTable<T> {
     ///
     /// [`aligned_size()`]: Self::aligned_size
     #[inline]
+    #[allow(dead_code)]
     pub fn dynamic_offset(&self, id: BufferTableId) -> u32 {
         let offset = self.aligned_size * id.0 as usize;
         assert!(offset <= u32::MAX as usize);

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -26,7 +26,7 @@ use crate::{
     asset::EffectAsset,
     render::{
         calc_hash, event::GpuChildInfo, GpuDrawIndexedIndirectArgs, GpuDrawIndirectArgs,
-        GpuEffectMetadata, GpuIndirectIndex, StorageType as _,
+        GpuEffectMetadata, GpuIndirectIndex,
     },
     ParticleLayout,
 };
@@ -986,7 +986,6 @@ impl EffectCache {
             &mut self.metadata_init_bind_group_layout_desc[consume_gpu_spawn_events as usize];
         if layout.is_none() {
             *layout = Some(create_metadata_init_bind_group_layout_desc(
-                &self.render_device,
                 consume_gpu_spawn_events,
             ));
         }
@@ -1006,12 +1005,7 @@ impl EffectCache {
     pub fn ensure_metadata_update_bind_group_layout_desc(&mut self, num_event_buffers: u32) {
         self.metadata_update_bind_group_layout_descs
             .entry(num_event_buffers)
-            .or_insert_with(|| {
-                create_metadata_update_bind_group_layout_desc(
-                    &self.render_device,
-                    num_event_buffers,
-                )
-            });
+            .or_insert_with(|| create_metadata_update_bind_group_layout_desc(num_event_buffers));
     }
 
     /// Get the bind group layout for the metadata@3 bind group of the
@@ -1125,25 +1119,18 @@ fn create_particle_sim_bind_group_layout_desc(
 
 /// Create the bind group layout for the metadata@3 bind group of the init pass.
 fn create_metadata_init_bind_group_layout_desc(
-    render_device: &RenderDevice,
     consume_gpu_spawn_events: bool,
 ) -> BindGroupLayoutDescriptor {
-    let storage_alignment = render_device.limits().min_storage_buffer_offset_alignment;
-    let effect_metadata_size = GpuEffectMetadata::aligned_size(storage_alignment);
-
     let mut entries = Vec::with_capacity(3);
 
-    // @group(3) @binding(0) var<storage, read_write> effect_metadata :
-    // EffectMetadata;
+    // @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>
     entries.push(BindGroupLayoutEntry {
         binding: 0,
         visibility: ShaderStages::COMPUTE,
         ty: BindingType::Buffer {
             ty: BufferBindingType::Storage { read_only: false },
             has_dynamic_offset: false,
-            // This WGSL struct is manually padded, so the Rust type GpuEffectMetadata doesn't
-            // reflect its true min size.
-            min_binding_size: Some(effect_metadata_size),
+            min_binding_size: Some(GpuEffectMetadata::SHADER_SIZE),
         },
         count: None,
     });
@@ -1196,25 +1183,18 @@ fn create_metadata_init_bind_group_layout_desc(
 /// Create the bind group layout for the metadata@3 bind group of the update
 /// pass.
 fn create_metadata_update_bind_group_layout_desc(
-    render_device: &RenderDevice,
     num_event_buffers: u32,
 ) -> BindGroupLayoutDescriptor {
-    let storage_alignment = render_device.limits().min_storage_buffer_offset_alignment;
-    let effect_metadata_size = GpuEffectMetadata::aligned_size(storage_alignment);
-
     let mut entries = Vec::with_capacity(num_event_buffers as usize + 2);
 
-    // @group(3) @binding(0) var<storage, read_write> effect_metadata :
-    // EffectMetadata;
+    // @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>
     entries.push(BindGroupLayoutEntry {
         binding: 0,
         visibility: ShaderStages::COMPUTE,
         ty: BindingType::Buffer {
             ty: BufferBindingType::Storage { read_only: false },
             has_dynamic_offset: false,
-            // This WGSL struct is manually padded, so the Rust type GpuEffectMetadata doesn't
-            // reflect its true min size.
-            min_binding_size: Some(effect_metadata_size),
+            min_binding_size: Some(GpuEffectMetadata::SHADER_SIZE),
         },
         count: None,
     });

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -535,7 +535,13 @@ impl Default for GpuDrawIndexedIndirectArgs {
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Pod, Zeroable, ShaderType)]
 pub struct GpuBatchInfo {
+    /// Total number of CPU particles to spawn. This is the sum of all `spawn`
+    /// counts of all effect instances in this batch which spawn CPU-based
+    /// particles. This is uploaded from CPU each frame.
     pub total_spawn_count: u32,
+    /// Total number of CPU particles to update. This is the sum of all
+    /// `alive_count` of all effect instances in this batch. This is calculated
+    /// on GPU each frame, between the init and update passes.
     pub total_update_count: u32,
     /// Start index of the slice of [`GpuSpawnerInfo`] for this batch, into the
     /// [`EffectsMeta::spawner_buffer`]. The slice length is equal to the number
@@ -775,9 +781,21 @@ pub(super) struct SortFillDispatchItem {
     /// Metadata table entry of the ribbon effect batch to read the
     /// [`GpuEffectMetadata::alive_count`] from.
     pub metadata_table_id: BufferTableId,
+    /// Index into the prefix sum buffer where the post-update alive count is
+    /// copied before calculating the sort prefix sum.
+    pub prefix_sum_index: u32,
     /// Index of the [`GpuDispatchIndirect`] entry to write the workgroup count
     /// to.
     pub sort_fill_indirect_dispatch_index: u32,
+}
+
+/// Indices of the GPU operation queues needed to prepare a ribbon sort.
+#[derive(Debug, Default)]
+pub(super) struct SortFillDispatchQueueIndices {
+    /// Queue which copies post-update alive counts into the prefix sum buffer.
+    pub alive_count_copy: Option<u32>,
+    /// Queue which creates the indirect sort-fill dispatch arguments.
+    pub fill_dispatch: Option<u32>,
 }
 
 /// Queue of fill dispatch operations for the ribbon particle sort pass.
@@ -799,15 +817,23 @@ impl SortFillDispatchQueue {
         self.queue.clear();
     }
 
+    /// Check if no ribbon sort dispatch operations were queued this frame.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
     /// Enqueue a new operation.
     #[inline]
     pub fn enqueue(
         &mut self,
         metadata_table_id: BufferTableId,
+        prefix_sum_index: u32,
         sort_fill_indirect_dispatch_index: u32,
     ) {
         self.queue.push(SortFillDispatchItem {
             metadata_table_id,
+            prefix_sum_index,
             sort_fill_indirect_dispatch_index,
         });
     }
@@ -818,31 +844,32 @@ impl SortFillDispatchQueue {
     pub fn submit(
         &self,
         effect_metadata_buffer: &BufferTable<GpuEffectMetadata>,
-        effect_metadata_aligned_size: NonZeroU32,
+        prefix_sum_buffer: &Buffer,
         sort_bind_groups: &SortBindGroups,
         gpu_buffer_operations: &mut GpuBufferOperations,
-    ) -> Option<u32> {
+    ) -> SortFillDispatchQueueIndices {
         if self.queue.is_empty() {
-            return None;
+            return default();
         }
 
         let Some(src_buffer) = effect_metadata_buffer.buffer() else {
             error!("Failed to find effect metadata buffer. This is a bug.");
-            return None;
+            return default();
         };
-        let Some(dst_buffer) = sort_bind_groups.indirect_buffer() else {
+        let Some(dst_buffer) = sort_bind_groups.indirect_args_buffer() else {
             error!("Missing indirect dispatch buffer for sorting, cannot schedule particle sort for ribbons. This is a bug.");
-            return None;
+            return default();
         };
 
-        let src_offset = std::mem::offset_of!(GpuEffectMetadata, alive_count) as u32 / 4;
+        let alive_count_offset = std::mem::offset_of!(GpuEffectMetadata, alive_count) as u32 / 4;
         debug_assert_eq!(
-            src_offset, 1,
+            alive_count_offset, 1,
             "GpuEffectMetadata changed, update this assert."
         );
-        let src_stride = effect_metadata_aligned_size.get() / 4;
+        let src_stride = GpuEffectMetadata::SHADER_SIZE.get() as u32 / 4;
         let dst_stride = GpuDispatchIndirectArgs::SHADER_SIZE.get() as u32 / 4;
 
+        let mut alive_count_copy_queue = GpuBufferOperationQueue::new();
         let mut fill_queue = GpuBufferOperationQueue::new();
         for item in &self.queue {
             let src_binding_offset = effect_metadata_buffer.dynamic_offset(item.metadata_table_id);
@@ -851,15 +878,36 @@ impl SortFillDispatchQueue {
                 0,
                 "Effect metadata offset must be u32-aligned."
             );
-            let src_offset = src_binding_offset / 4 + src_offset;
+            let src_offset = src_binding_offset / 4 + alive_count_offset;
             let dst_offset = sort_bind_groups
-                .get_indirect_dispatch_byte_offset(item.sort_fill_indirect_dispatch_index)
+                .get_indirect_args_byte_offset(item.sort_fill_indirect_dispatch_index)
                 / 4;
+            trace!(
+                "queue_sort_alive_count_copy(): src#{:?}@+{}B -> dst#{:?}[{}]",
+                src_buffer.id(),
+                src_binding_offset,
+                prefix_sum_buffer.id(),
+                item.prefix_sum_index,
+            );
+            alive_count_copy_queue.enqueue(
+                GpuBufferOperationType::Copy,
+                GpuBufferOperationArgs {
+                    src_offset,
+                    src_stride,
+                    dst_offset: item.prefix_sum_index,
+                    dst_stride: 1,
+                    count: 1,
+                },
+                src_buffer.clone(),
+                None,
+                prefix_sum_buffer.clone(),
+                None,
+            );
             trace!(
                 "queue_sort_fill_dispatch(): src#{:?}@+{}B ({}B) -> dst#{:?}@+{}B (whole)",
                 src_buffer.id(),
                 src_binding_offset,
-                effect_metadata_aligned_size.get(),
+                src_stride,
                 dst_buffer.id(),
                 dst_offset * 4,
             );
@@ -868,21 +916,30 @@ impl SortFillDispatchQueue {
                 GpuBufferOperationArgs {
                     src_offset,
                     src_stride,
-                    dst_offset,
+                    dst_offset: dst_offset as u32,
                     dst_stride,
                     count: 1,
                 },
                 src_buffer.clone(),
-                Some(effect_metadata_aligned_size),
+                None,
                 dst_buffer.clone(),
                 None,
             );
         }
 
-        if fill_queue.operation_queue.is_empty() {
+        let alive_count_copy = if alive_count_copy_queue.operation_queue.is_empty() {
+            None
+        } else {
+            Some(gpu_buffer_operations.submit(alive_count_copy_queue))
+        };
+        let fill_dispatch = if fill_queue.operation_queue.is_empty() {
             None
         } else {
             Some(gpu_buffer_operations.submit(fill_queue))
+        };
+        SortFillDispatchQueueIndices {
+            alive_count_copy,
+            fill_dispatch,
         }
     }
 }
@@ -941,8 +998,8 @@ impl FromWorld for DispatchIndirectPipeline {
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
                 (
-                    // @group(1) @binding(0) var<storage, read_write> effect_metadata_buffer :
-                    // array<u32>;
+                    // @group(1) @binding(0) var<storage, read_write> effect_metadatas :
+                    // array<EffectMetadata>;
                     storage_buffer::<GpuEffectMetadata>(false),
                     // @group(1) @binding(1) var<storage, read_write> draw_indirect_buffer :
                     // array<u32>;
@@ -2102,6 +2159,14 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
             key.spawner_bind_group_layout_desc.clone(),
         ];
         let mut shader_defs = vec![];
+        if !key.texture_layout.layout.is_empty() {
+            shader_defs.push("HAS_MATERIAL".into());
+            if let Some(material_bind_group_layout) = self.get_material(&key.texture_layout) {
+                layout.push(material_bind_group_layout.clone());
+            } else {
+                panic!("Failed to retrieve material bind group layout, cannot specialize render pipeline.");
+            }
+        }
 
         let vertex_buffer_layout = key.mesh_layout.as_ref().and_then(|mesh_layout| {
             mesh_layout
@@ -2113,10 +2178,6 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
                 ])
                 .ok()
         });
-
-        if let Some(material_bind_group_layout) = self.get_material(&key.texture_layout) {
-            layout.push(material_bind_group_layout.clone());
-        }
 
         // Key: LOCAL_SPACE_SIMULATION
         if key.local_space_simulation {
@@ -2827,11 +2888,12 @@ struct GpuLimits {
     /// [`WgpuLimits::min_storage_buffer_offset_alignment`]: bevy::render::settings::WgpuLimits::min_storage_buffer_offset_alignment
     storage_buffer_align: NonZeroU32,
 
-    /// Size of [`GpuEffectMetadata`] aligned to the contraint of
+    /// Size of [`GpuSpawnerParams`] aligned to the contraint of
     /// [`WgpuLimits::min_storage_buffer_offset_alignment`].
     ///
     /// [`WgpuLimits::min_storage_buffer_offset_alignment`]: bevy::render::settings::WgpuLimits::min_storage_buffer_offset_alignment
-    effect_metadata_aligned_size: NonZeroU32,
+    #[allow(dead_code)]
+    spawner_params_aligned_size: NonZeroU32,
 }
 
 impl GpuLimits {
@@ -2839,34 +2901,29 @@ impl GpuLimits {
         let storage_buffer_align =
             render_device.limits().min_storage_buffer_offset_alignment as u64;
 
-        let effect_metadata_aligned_size = NonZeroU32::new(
-            GpuEffectMetadata::min_size()
+        let spawner_params_aligned_size = NonZeroU32::new(
+            GpuSpawnerParams::min_size()
                 .get()
                 .next_multiple_of(storage_buffer_align) as u32,
         )
         .unwrap();
 
         trace!(
-            "GPU-aligned sizes (align: {} B):\n- GpuEffectMetadata: {} B -> {} B",
+            "GPU-aligned sizes (align: {} B):\n- GpuSpawnerParams: {} B -> {} B",
             storage_buffer_align,
-            GpuEffectMetadata::min_size().get(),
-            effect_metadata_aligned_size.get(),
+            GpuSpawnerParams::min_size().get(),
+            spawner_params_aligned_size.get(),
         );
 
         Self {
             storage_buffer_align: NonZeroU32::new(storage_buffer_align as u32).unwrap(),
-            effect_metadata_aligned_size,
+            spawner_params_aligned_size,
         }
     }
 
     /// Byte alignment for any storage buffer binding.
     pub fn storage_buffer_align(&self) -> NonZeroU32 {
         self.storage_buffer_align
-    }
-
-    /// Byte offset of the [`GpuEffectMetadata`] of a given buffer.
-    pub fn effect_metadata_offset(&self, buffer_index: u32) -> u64 {
-        self.effect_metadata_aligned_size.get() as u64 * buffer_index as u64
     }
 }
 
@@ -2914,6 +2971,7 @@ pub struct EffectsMeta {
     effect_metadata_buffer: BufferTable<GpuEffectMetadata>,
     /// Various GPU limits and aligned sizes lazily allocated and cached for
     /// convenience.
+    #[allow(dead_code)]
     gpu_limits: GpuLimits,
     indirect_shader_noevent: Handle<Shader>,
     indirect_shader_events: Handle<Shader>,
@@ -2970,7 +3028,7 @@ impl EffectsMeta {
             ),
             effect_metadata_buffer: BufferTable::new(
                 BufferUsages::STORAGE | BufferUsages::INDIRECT,
-                Some(item_align.into()),
+                None,
                 Some("hanabi:buffer:effect_metadata".to_string()),
             ),
             gpu_limits,
@@ -3736,7 +3794,7 @@ pub fn prepare_init_update_pipelines(
         let property_layout_min_binding_size =
             maybe_cached_properties.map(|cp| cp.property_layout.min_binding_size());
         let spawner_bind_group_layout_desc = property_cache
-            .bind_group_layout_desc(property_layout_min_binding_size)
+            .bind_group_layout_desc(property_layout_min_binding_size, true)
             .unwrap_or_else(|| {
                 panic!(
                     "Failed to find spawner@2 bind group layout for property binding size {:?}",
@@ -3857,11 +3915,15 @@ pub fn prepare_init_update_pipelines(
             .get_compute_pipeline(init_pipeline_id)
             .is_none()
         {
-            trace!(
-                "Skipping effect from render entity {:?} due to missing or not ready init pipeline (status: {:?})",
-                entity,
-                pipeline_cache.get_compute_pipeline_state(init_pipeline_id)
-            );
+            match pipeline_cache.get_compute_pipeline_state(init_pipeline_id)
+            {
+                CachedPipelineState::Err(err) => error!("Skipping effect from render entity {:?} due to missing or not ready init pipeline (error: {:?})", entity, err),
+                other => trace!(
+                    "Skipping effect from render entity {:?} due to missing or not ready init pipeline (status: {:?})",
+                    entity,
+                    other
+                ),
+            }
             cached_pipelines
                 .flags
                 .remove(CachedPipelineFlags::INIT_PIPELINE_READY);
@@ -4542,7 +4604,7 @@ pub(crate) fn batch_effects(
 
     // For now we re-create that buffer each frame. Since there's no CPU -> GPU
     // transfer, this is pretty cheap in practice.
-    sort_bind_groups.clear_indirect_dispatch_buffer();
+    sort_bind_groups.clear_indirect_args_buffer();
 
     // Loop on all extracted effects in sorted order, and batch compatible
     // effects together.
@@ -4600,24 +4662,22 @@ pub(crate) fn batch_effects(
         // for ribbon meshing, in order to avoid gaps when some particles in the middle
         // of the ribbon die (since we can't guarantee a linear lifetime through the
         // ribbon).
-        if extracted_effect.layout_flags.contains(LayoutFlags::RIBBONS) {
-            // Allocate a GpuDispatchIndirect entry
-            let sort_fill_indirect_dispatch_index = sort_bind_groups.allocate_indirect_dispatch();
-            effect_batch.effect_data[0].sort_fill_indirect_dispatch_index =
-                Some(sort_fill_indirect_dispatch_index);
+        let sort_fill_indirect_dispatch_index =
+            if extracted_effect.layout_flags.contains(LayoutFlags::RIBBONS) {
+                // Allocate a GpuDispatchIndirect entry
+                let sort_fill_indirect_dispatch_index = sort_bind_groups.allocate_indirect_args();
+                effect_batch.effect_data[0].sort_fill_indirect_dispatch_index =
+                    Some(sort_fill_indirect_dispatch_index);
 
-            // Queue a fill dispatch op which reads GpuEffectMetadata::alive_count and
-            // computes the workgroup count for the fill-sort pass. The op is
-            // built later, in queue_sort_fill_dispatch_ops(), once the metadata
-            // buffer is resized; see SortFillDispatchQueue.
-            sort_fill_dispatch_queue.enqueue(
-                effect_batch.effect_data[0].metadata_table_id,
-                sort_fill_indirect_dispatch_index,
-            );
-        }
+                Some(sort_fill_indirect_dispatch_index)
+            } else {
+                None
+            };
 
         // Append to sorted compute batches; this may merge with the previous one.
-        if let Some(new_effect_batch_index) = batcher.push(effect_batch, instance_spawn_count) {
+        let (new_effect_batch_index, sort_prefix_sum_index) =
+            batcher.push(effect_batch, instance_spawn_count);
+        if let Some(new_effect_batch_index) = new_effect_batch_index {
             trace!(
                 "Spawned new effect batch #{:?} from cached instance on entity {:?}.",
                 new_effect_batch_index,
@@ -4635,6 +4695,13 @@ pub(crate) fn batch_effects(
                     main_entity: *main_entity,
                 })
                 .insert(TemporaryRenderEntity);
+        }
+        if let Some(sort_fill_indirect_dispatch_index) = sort_fill_indirect_dispatch_index {
+            sort_fill_dispatch_queue.enqueue(
+                cached_effect_metadata.table_id,
+                sort_prefix_sum_index,
+                sort_fill_indirect_dispatch_index,
+            );
         }
 
         // Ensure first_instance remains zero (required without INDIRECT_FIRST_INSTANCE
@@ -5112,9 +5179,8 @@ impl EffectBindGroups {
             );
 
             trace!(
-                "Created new metadata@3 bind group for update pass and slab ID {}: effect_metadata={}",
+                "Created new metadata@3 bind group for update pass and slab ID {}",
                 effect_batch.slab_id.index(),
-                effect_batch.effect_data[0].metadata_table_id.0,
             );
 
             bind_group
@@ -5308,11 +5374,12 @@ fn emit_sorted_draw<T, F>(
             // This should always exist by the time we reach this point, because we should
             // have inserted any property in the cache, which would have allocated the
             // proper bind group layout (or the default no-property one).
+            let has_multi_draw = false; // TODO?
             let property_layout_min_binding_size = effect_batch
                 .property_key
                 .map(|key| NonZeroU64::new(key.binding_size as u64).unwrap());
             let spawner_bind_group_layout_desc = property_cache
-                .bind_group_layout_desc(property_layout_min_binding_size)
+                .bind_group_layout_desc(property_layout_min_binding_size, has_multi_draw)
                 .unwrap_or_else(|| {
                     panic!(
                         "Failed to find spawner@2 bind group layout for property binding size {:?}",
@@ -5513,11 +5580,12 @@ fn emit_binned_draw<T, F, G>(
             // This should always exist by the time we reach this point, because we should
             // have inserted any property in the cache, which would have allocated the
             // proper bind group layout (or the default no-property one).
+            let has_multi_draw = false; // TODO?
             let property_layout_min_binding_size = effect_batch
                 .property_key
                 .map(|key| NonZeroU64::new(key.binding_size as u64).unwrap());
             let spawner_bind_group_layout_desc = property_cache
-                .bind_group_layout_desc(property_layout_min_binding_size)
+                .bind_group_layout_desc(property_layout_min_binding_size, has_multi_draw)
                 .unwrap_or_else(|| {
                     panic!(
                         "Failed to find spawner@2 bind group layout for property binding size {:?}",
@@ -6120,13 +6188,24 @@ pub(crate) fn queue_sort_fill_dispatch_ops(
     let _span = bevy::log::info_span!("queue_sort_fill_dispatch_ops").entered();
     trace!("queue_sort_fill_dispatch_ops");
 
+    if sort_fill_dispatch_queue.is_empty() {
+        return;
+    }
+
+    debug_assert!(batcher.sort_fill_prefix_sum_queue_index.is_none());
     debug_assert!(batcher.dispatch_queue_index.is_none());
-    batcher.dispatch_queue_index = sort_fill_dispatch_queue.submit(
+    let Some(prefix_sum_buffer) = batcher.prefix_sum_buffer() else {
+        error!("Missing prefix sum buffer for ribbon sort. This is a bug.");
+        return;
+    };
+    let queue_indices = sort_fill_dispatch_queue.submit(
         &effects_meta.effect_metadata_buffer,
-        effects_meta.gpu_limits.effect_metadata_aligned_size,
+        prefix_sum_buffer,
         &sort_bind_groups,
         &mut gpu_buffer_operations,
     );
+    batcher.sort_fill_prefix_sum_queue_index = queue_indices.alive_count_copy;
+    batcher.dispatch_queue_index = queue_indices.fill_dispatch;
 }
 
 /// Read the queued init fill dispatch operations, batch them together by
@@ -6280,8 +6359,8 @@ pub(crate) fn prepare_bind_groups(
                         &dispatch_indirect_pipeline.effect_metadata_bind_group_layout_desc,
                     ),
                     &BindGroupEntries::sequential((
-                        // @group(1) @binding(0) var<storage, read_write> effect_metadata_buffer :
-                        // array<u32>;
+                        // @group(1) @binding(0) var<storage, read_write> effect_metadatas :
+                        // array<EffectMetadata>;
                         effect_metadata_buffer.as_entire_binding(),
                         // @group(1) @binding(1) var<storage, read_write> draw_indirect_buffer :
                         // array<u32>;
@@ -6648,6 +6727,7 @@ fn draw<'w>(
     let effect_batch = batcher.get(effect_draw_batch.effect_batch_index).unwrap();
 
     let Some(pipeline) = pipeline_cache.into_inner().get_render_pipeline(pipeline_id) else {
+        trace!("ERROR: Failed to find render pipeline ID {:?}", pipeline_id);
         return;
     };
 
@@ -6656,9 +6736,11 @@ fn draw<'w>(
     pass.set_render_pipeline(pipeline);
 
     let Some(render_mesh): Option<&RenderMesh> = meshes.get(effect_batch.mesh) else {
+        trace!("Missing render mesh; can't draw. Skipped.");
         return;
     };
     let Some(vertex_buffer_slice) = mesh_allocator.mesh_vertex_slice(&effect_batch.mesh) else {
+        trace!("Missing vertex buffer slice; can't draw. Skipped.");
         return;
     };
 
@@ -6689,7 +6771,8 @@ fn draw<'w>(
         layout: effect_batch.texture_layout.clone(),
         textures: effect_batch.textures.iter().map(|h| h.id()).collect(),
     };
-    if !effect_batch.texture_layout.layout.is_empty() {
+    let has_material = !effect_batch.texture_layout.layout.is_empty();
+    if has_material {
         if let Some(bind_group) = effect_bind_groups.material_bind_groups.get(&material) {
             pass.set_bind_group(3, bind_group, &[]);
         } else {
@@ -6710,6 +6793,9 @@ fn draw<'w>(
         return;
     };
 
+    let spawner_size = effects_meta.spawner_buffer.aligned_size() as u32;
+    assert!(spawner_size >= GpuSpawnerParams::min_size().get() as u32);
+
     match render_mesh.buffer_info {
         RenderMeshBufferInfo::Indexed { index_format, .. } => {
             let Some(index_buffer_slice) = mesh_allocator.mesh_index_slice(&effect_batch.mesh)
@@ -6722,11 +6808,25 @@ fn draw<'w>(
             };
 
             pass.set_index_buffer(index_buffer_slice.buffer.slice(..), index_format);
+            // Note: multi_draw_indexed_indirect() only works if first_instance is
+            // available, which doesn't work without validation in wgpu. This is due to a
+            // limitation in DX12. We could have multidraw in Vulkan only though, but that
+            // requires dynamically switching.
+            // pass.multi_draw_indexed_indirect(
+            //     indirect_buffer,
+            //     draw_indirect_offset,
+            //     effect_batch.effect_count,
+            // );
+            let with_prefix_sum = false; // per-effect, no draw batching
+            trace!(
+                "Emit non-batched draw_indexed_indirect() for {} effect instances...",
+                effect_batch.effect_data.len()
+            );
             for effect_data in &effect_batch.effect_data {
                 pass.set_bind_group(
                     2,
                     property_bind_groups
-                        .get(effect_batch.property_key.as_ref())
+                        .get(effect_batch.property_key.as_ref(), with_prefix_sum)
                         .unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
@@ -6734,15 +6834,36 @@ fn draw<'w>(
                 assert_eq!(GpuDrawIndexedIndirectArgs::SHADER_SIZE.get(), 20);
                 let draw_indirect_offset =
                     draw_indirect_index as u64 * GpuDrawIndexedIndirectArgs::SHADER_SIZE.get();
+                trace!(
+                    "+ batch-info @+{}B (row #{}), draw_indirect_offset=+{}B (row #{})",
+                    effect_data.render_batch_info_offset,
+                    effect_data.render_batch_info_offset / GpuBatchInfo::SHADER_SIZE.get() as u32,
+                    draw_indirect_offset,
+                    draw_indirect_index,
+                );
                 pass.draw_indexed_indirect(indirect_buffer, draw_indirect_offset);
             }
         }
         RenderMeshBufferInfo::NonIndexed => {
+            // Note: multi_draw_indexed_indirect() only works if first_instance is
+            // available, which doesn't work without validation in wgpu. This is due to a
+            // limitation in DX12. We could have multidraw in Vulkan only though, but that
+            // requires dynamically switching.
+            // pass.multi_draw_indirect(
+            //     indirect_buffer,
+            //     draw_indirect_offset,
+            //     effect_batch.effect_count,
+            // );
+            let with_prefix_sum = false; // per-effect, no draw batching
+            trace!(
+                "Emit non-batched draw_indirect() for {} effect instances...",
+                effect_batch.effect_data.len()
+            );
             for effect_data in &effect_batch.effect_data {
                 pass.set_bind_group(
                     2,
                     property_bind_groups
-                        .get(effect_batch.property_key.as_ref())
+                        .get(effect_batch.property_key.as_ref(), with_prefix_sum)
                         .unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
@@ -7103,7 +7224,7 @@ fn simulate(
             compute_pass.set_bind_group(
                 2,
                 property_bind_groups
-                    .get(effect_batch.property_key.as_ref())
+                    .get(effect_batch.property_key.as_ref(), true)
                     .unwrap(),
                 &[batch_info_offset],
             );
@@ -7129,14 +7250,10 @@ fn simulate(
                         "record commands for indirect init pipeline of effect {:?} \
                                 init_indirect_dispatch_index={} \
                                 indirect_offset={} \
-                                spawner_base={} \
-                                spawner_offset={} \
                                 property_key={:?}...",
                         effect_batch.handle,
                         init_indirect_dispatch_index,
                         indirect_offset,
-                        spawner_base,
-                        spawner_offset,
                         effect_batch.property_key,
                     );
 
@@ -7348,7 +7465,7 @@ fn simulate(
             compute_pass.set_bind_group(
                 2,
                 property_bind_groups
-                    .get(effect_batch.property_key.as_ref())
+                    .get(effect_batch.property_key.as_ref(), true)
                     .unwrap(),
                 &[batch_info_offset],
             );
@@ -7376,17 +7493,16 @@ fn simulate(
         // After the update pass (atomically) updated the particle alive count per
         // effect instance, copy that number into the prefix sum buffer, so that
         // the prefix sum pass can calculate the prefix sum for sorting.
-        // if let Some(queue_index) = sorted_effect_batches
-        //     .sort_fill_prefix_sum_queue_index
-        //     .as_ref()
-        // {
-        //     gpu_buffer_operations.dispatch(
-        //         *queue_index,
-        //         render_context,
-        //         utils_pipeline,
-        //         Some("hanabi:sort_fill_prefix_sum"),
-        //     );
-        // }
+        let Some(queue_index) = batcher.sort_fill_prefix_sum_queue_index else {
+            warn!("Missing alive count copy queue for ribbon sorting.");
+            return;
+        };
+        gpu_buffer_operations.dispatch(
+            queue_index,
+            &mut render_context,
+            &utils_pipeline,
+            Some("hanabi:sort_fill_prefix_sum"),
+        );
 
         // Sort prefix sum compute pass
         //
@@ -7432,29 +7548,28 @@ fn simulate(
         // particles in the batch after their update in the compute update pass. Since
         // particles may die during update, this may be different from the number of
         // particles updated.
-        if let Some(queue_index) = batcher.dispatch_queue_index.as_ref() {
-            gpu_buffer_operations.dispatch(
-                *queue_index,
-                &mut render_context,
-                &utils_pipeline,
-                Some("hanabi:sort_fill_dispatch"),
-            );
-        }
+        let Some(queue_index) = batcher.dispatch_queue_index else {
+            warn!("Missing indirect dispatch queue for ribbon sorting.");
+            return;
+        };
+        gpu_buffer_operations.dispatch(
+            queue_index,
+            &mut render_context,
+            &utils_pipeline,
+            Some("hanabi:sort_fill_dispatch"),
+        );
 
         // Compute sort pass
         {
-            let mut compute_pass =
-                HanabiComputePass::new("hanabi:sort", &pipeline_cache, &mut render_context);
-
             let effect_metadata_buffer = effects_meta.effect_metadata_buffer.buffer().unwrap();
-            let indirect_buffer = sort_bind_groups.indirect_buffer().unwrap();
+            let indirect_args_buffer = sort_bind_groups.indirect_args_buffer().unwrap();
 
             // Loop on batches and find those which need sorting
             for effect_batch in batcher.iter() {
-                trace!("Processing effect batch for sorting...");
                 if !effect_batch.layout_flags.contains(LayoutFlags::RIBBONS) {
                     continue;
                 }
+                trace!("Processing RIBBONS effect batch for sorting...");
                 assert!(effect_batch.particle_layout.contains(Attribute::RIBBON_ID));
                 assert!(effect_batch.particle_layout.contains(Attribute::AGE)); // or is that optional?
 
@@ -7470,10 +7585,15 @@ fn simulate(
                         continue;
                     };
                     let indirect_offset =
-                        sort_bind_groups.get_indirect_dispatch_byte_offset(indirect_dispatch_index);
+                        sort_bind_groups.get_indirect_args_byte_offset(indirect_dispatch_index);
 
                     // Fill the sort buffer with the key-value pairs to sort
                     {
+                        let mut compute_pass = HanabiComputePass::new(
+                            "hanabi:sort_fill",
+                            &pipeline_cache,
+                            &mut render_context,
+                        );
                         compute_pass.push_debug_group("hanabi:sort_fill");
 
                         let Some(pipeline_id) = sort_bind_groups
@@ -7516,23 +7636,20 @@ fn simulate(
                             compute_pass.insert_debug_marker("ERROR:MissingSortFillBindGroup");
                             continue;
                         };
-                        let effect_metadata_offset = effects_meta
-                            .gpu_limits
-                            .effect_metadata_offset(effect_data.metadata_table_id.0)
-                            as u32;
-                        compute_pass.set_bind_group(
-                            0,
-                            bind_group,
-                            &[effect_metadata_offset, spawner_offset],
-                        );
+                        compute_pass.set_bind_group(0, bind_group, &[spawner_offset]);
 
                         compute_pass
-                            .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
+                            .dispatch_workgroups_indirect(indirect_args_buffer, indirect_offset);
                         compute_pass.pop_debug_group();
                     }
 
                     // Do the actual sort
                     {
+                        let mut compute_pass = HanabiComputePass::new(
+                            "hanabi:sort",
+                            &pipeline_cache,
+                            &mut render_context,
+                        );
                         compute_pass.push_debug_group("hanabi:sort");
 
                         if compute_pass
@@ -7551,13 +7668,18 @@ fn simulate(
                         };
                         compute_pass.set_bind_group(0, bind_group, &[]);
                         compute_pass
-                            .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
+                            .dispatch_workgroups_indirect(indirect_args_buffer, indirect_offset);
 
                         compute_pass.pop_debug_group();
                     }
 
                     // Copy the sorted indices back into the indirect index buffer.
                     {
+                        let mut compute_pass = HanabiComputePass::new(
+                            "hanabi:sort_copy",
+                            &pipeline_cache,
+                            &mut render_context,
+                        );
                         compute_pass.push_debug_group("hanabi:copy_sorted_indices");
 
                         let pipeline_id = sort_bind_groups.get_sort_copy_pipeline_id();
@@ -7592,17 +7714,10 @@ fn simulate(
                             compute_pass.insert_debug_marker("ERROR:MissingSortCopyBindGroup");
                             continue;
                         };
-                        let effect_metadata_offset = effects_meta
-                            .effect_metadata_buffer
-                            .dynamic_offset(effect_data.metadata_table_id);
-                        compute_pass.set_bind_group(
-                            0,
-                            bind_group,
-                            &[effect_metadata_offset, spawner_offset],
-                        );
+                        compute_pass.set_bind_group(0, bind_group, &[spawner_offset]);
 
                         compute_pass
-                            .dispatch_workgroups_indirect(indirect_buffer, indirect_offset as u64);
+                            .dispatch_workgroups_indirect(indirect_args_buffer, indirect_offset);
 
                         compute_pass.pop_debug_group();
                     }
@@ -7632,19 +7747,6 @@ mod tests {
     fn layout_flags() {
         let flags = LayoutFlags::default();
         assert_eq!(flags, LayoutFlags::NONE);
-    }
-
-    #[cfg(feature = "gpu_tests")]
-    #[test]
-    fn gpu_limits() {
-        use crate::test_utils::MockRenderer;
-
-        let renderer = MockRenderer::new();
-        let device = renderer.device();
-        let limits = GpuLimits::from_device(&device);
-
-        // assert!(limits.storage_buffer_align().get() >= 1);
-        assert!(limits.effect_metadata_offset(256) >= 256 * GpuEffectMetadata::min_size().get());
     }
 
     #[cfg(feature = "gpu_tests")]

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -6,7 +6,7 @@ use std::{
 use bevy::{
     ecs::{lifecycle::Remove, observer::On, system::Commands, world::Mut},
     log::{error, trace},
-    platform::collections::HashMap,
+    platform::collections::{hash_map::Entry, HashMap},
     prelude::{Component, Entity, Query, Res, ResMut, Resource},
     render::{
         render_resource::{
@@ -24,7 +24,7 @@ use wgpu::{
 
 use super::effect_cache::SlabState;
 use crate::{
-    render::{ExtractedProperties, GpuBatchInfo, GpuSpawnerParams, StorageType},
+    render::{ExtractedProperties, GpuBatchInfo, GpuSpawnerParams, StorageType as _},
     PropertyLayout,
 };
 
@@ -509,6 +509,14 @@ impl PropertyBuffer {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct BindGroupLayoutKey {
+    /// Binding size, in bytes, of the property block.
+    pub binding_byte_size: u32,
+    /// Is this binding using the prefix sum buffer?
+    pub with_prefix_sum: bool,
+}
+
 /// Cache for effect properties.
 #[derive(Resource)]
 pub struct PropertyCache {
@@ -520,37 +528,79 @@ pub struct PropertyCache {
     /// size zero is valid, and corresponds to the variant without properties,
     /// which by abuse is stored here even though it's not related to properties
     /// (contains only the spawner binding).
-    bind_group_layout_descs: HashMap<u32, BindGroupLayoutDescriptor>,
+    bind_group_layout_descs: HashMap<BindGroupLayoutKey, BindGroupLayoutDescriptor>,
 }
 
 impl PropertyCache {
     pub fn new(device: &RenderDevice) -> Self {
         let align = device.limits().min_storage_buffer_offset_alignment;
         let spawner_min_binding_size = GpuSpawnerParams::aligned_size(align);
+        let batch_info_min_binding_size = GpuBatchInfo::aligned_size(align);
+
+        // HAS_BATCHED_DRAW
+        // let has_multi_draw = false;
+        // TODO
+        //  device
+        //     .features()
+        //     .features_webgpu
+        //     .contains(FeaturesWebGPU::INDIRECT_FIRST_INSTANCE)
+        //     && (instance.has(VALIDATION_INDIRECT_CALL) || (backend != DX12));
+        //
+        // Anyway we create both with/without prefix sum variants, because init/update
+        // unconditionally use the "with" variant, and render conditionally use one or
+        // the other depending on multi-draw availability. Technically we could skip the
+        // no-prefix-sum variant if we're sure we always use multi-draw though.
 
         // Create the default bind group layout when no properties are present
-        let bgl = BindGroupLayoutDescriptor::new(
+        let bgl_prefix = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:no_property",
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE | ShaderStages::VERTEX,
                 (
                     // @group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
-                    //storage_buffer_read_only::<GpuSpawnerParams>(false), // TODO - vfx_sort_fill
-                    // still needs align
                     storage_buffer_read_only_sized(false, Some(spawner_min_binding_size)),
                     // @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
                     storage_buffer_read_only::<u32>(false),
                     // @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
-                    storage_buffer_read_only_sized(true, Some(GpuBatchInfo::aligned_size(align))),
+                    storage_buffer_read_only_sized(true, Some(batch_info_min_binding_size)),
                 ),
             ),
         );
         trace!(
             "-> created bind group layout desc for no-property variant: {:?}",
-            bgl
+            bgl_prefix
         );
-        let mut bind_group_layout_descs = HashMap::with_capacity_and_hasher(1, Default::default());
-        bind_group_layout_descs.insert(0, bgl);
+        let bgl_noprefix = BindGroupLayoutDescriptor::new(
+            "hanabi:bgl:no_property",
+            &BindGroupLayoutEntries::sequential(
+                ShaderStages::COMPUTE | ShaderStages::VERTEX,
+                (
+                    // @group(2) @binding(0) var<storage, read> spawner : Spawner;
+                    storage_buffer_read_only_sized(false, Some(spawner_min_binding_size)),
+                    // @group(2) @binding(1) var<storage, read> batch_info : BatchInfo;
+                    storage_buffer_read_only_sized(true, Some(batch_info_min_binding_size)),
+                ),
+            ),
+        );
+        trace!(
+            "-> created bind group layout desc for no-property variant: {:?}",
+            bgl_noprefix
+        );
+        let mut bind_group_layout_descs = HashMap::with_capacity_and_hasher(16, Default::default());
+        bind_group_layout_descs.insert(
+            BindGroupLayoutKey {
+                binding_byte_size: 0,
+                with_prefix_sum: true,
+            },
+            bgl_prefix,
+        );
+        bind_group_layout_descs.insert(
+            BindGroupLayoutKey {
+                binding_byte_size: 0,
+                with_prefix_sum: false,
+            },
+            bgl_noprefix,
+        );
 
         Self {
             buffers: vec![],
@@ -573,25 +623,33 @@ impl PropertyCache {
     pub fn bind_group_layout_desc(
         &self,
         min_binding_size: Option<NonZeroU64>,
+        with_prefix_sum: bool,
     ) -> Option<&BindGroupLayoutDescriptor> {
-        let key = min_binding_size.map(NonZeroU64::get).unwrap_or(0) as u32;
+        let binding_byte_size = min_binding_size.map(NonZeroU64::get).unwrap_or(0) as u32;
+        let key = BindGroupLayoutKey {
+            binding_byte_size,
+            with_prefix_sum,
+        };
         self.bind_group_layout_descs.get(&key)
     }
 
     pub fn allocate(&mut self, property_layout: &PropertyLayout) -> CachedEffectProperties {
         assert!(!property_layout.is_empty());
 
-        // Use the no-property layout descriptor as the base, that we'll customize. It's
-        // always available. But since it's stored inside the hash map, we need to
-        // eagerly clone in advance, for the borrow checker.
-        let mut bgl = self.bind_group_layout_descs.get(&0).unwrap().clone();
-
         // Ensure there's a bind group layout for the property variant with that binding
         // size.
         let properties_min_binding_size = property_layout.min_binding_size();
-        self.bind_group_layout_descs
-            .entry(properties_min_binding_size.get() as u32)
-            .or_insert_with(|| {
+        for with_prefix_sum in [false, true] {
+            // Get base layout that we will clone and modify
+            let mut key = BindGroupLayoutKey {
+                binding_byte_size: 0,
+                with_prefix_sum,
+            };
+            let mut bgl = self.bind_group_layout_descs.get(&key).unwrap().clone();
+
+            // Make a layout for the given binding size if needed
+            key.binding_byte_size = properties_min_binding_size.get() as u32;
+            self.bind_group_layout_descs.entry(key).or_insert_with(|| {
                 let label = format!(
                     "hanabi:bgl:property_size{}",
                     properties_min_binding_size.get()
@@ -614,6 +672,7 @@ impl PropertyCache {
                 );
                 bgl
             });
+        }
 
         self.buffers
             .iter_mut()
@@ -710,9 +769,10 @@ impl From<&CachedEffectProperties> for PropertyBindGroupKey {
 pub struct PropertyBindGroups {
     /// Map from a [`PropertyBuffer`] index and a binding size to the
     /// corresponding bind group.
-    property_bind_groups: HashMap<PropertyBindGroupKey, BindGroup>,
-    /// Bind group for the variant without any property.
-    no_property_bind_group: Option<BindGroup>,
+    property_bind_groups: HashMap<PropertyBindGroupKey, [BindGroup; 2]>,
+    /// Bind group for the variant without any property (without and with prefix
+    /// sum).
+    no_property_bind_groups: Option<[BindGroup; 2]>,
 }
 
 impl PropertyBindGroups {
@@ -723,8 +783,86 @@ impl PropertyBindGroups {
     pub fn clear(&mut self, with_no_property: bool) {
         self.property_bind_groups.clear();
         if with_no_property {
-            self.no_property_bind_group = None;
+            self.no_property_bind_groups = None;
         }
+    }
+
+    fn make_bind_group(
+        property_key: &PropertyBindGroupKey,
+        property_cache: &PropertyCache,
+        with_prefix_sum: bool,
+        spawner_buffer: &Buffer,
+        prefix_sum_buffer: &Buffer,
+        batch_info_buffer: &Buffer,
+        property_buffer: &Buffer,
+        render_device: &RenderDevice,
+        pipeline_cache: &PipelineCache,
+    ) -> Result<BindGroup, ()> {
+        trace!(
+            "Creating new spawner@2 bind group for property buffer #{} and binding size {} (w/ prefix sum: {})",
+            property_key.buffer_index,
+            property_key.binding_size,
+            with_prefix_sum
+        );
+
+        // This should always be non-zero if the property key is Some().
+        let property_binding_size = NonZeroU64::new(property_key.binding_size as u64).unwrap();
+        let Some(layout_desc) =
+            property_cache.bind_group_layout_desc(Some(property_binding_size), with_prefix_sum)
+        else {
+            error!(
+                "Missing property bind group layout for binding size {}, referenced by effect batch.",
+                property_binding_size.get(),
+            );
+            return Err(());
+        };
+
+        let align = render_device.limits().min_storage_buffer_offset_alignment;
+
+        let bind_group = if with_prefix_sum {
+            render_device.create_bind_group(
+                Some(
+                    &format!(
+                        "hanabi:bg:spawner@2:property{}_size{}_md",
+                        property_key.buffer_index, property_key.binding_size
+                    )[..],
+                ),
+                &pipeline_cache.get_bind_group_layout(layout_desc),
+                &BindGroupEntries::sequential((
+                    spawner_buffer.as_entire_binding(),
+                    prefix_sum_buffer.as_entire_binding(),
+                    BufferBinding {
+                        buffer: batch_info_buffer,
+                        offset: 0,
+                        size: Some(GpuBatchInfo::aligned_size(align)),
+                    },
+                    property_buffer.as_entire_binding(),
+                )),
+            )
+        } else {
+            render_device.create_bind_group(
+                Some(
+                    &format!(
+                        "hanabi:bg:spawner@2:property{}_size{}",
+                        property_key.buffer_index, property_key.binding_size
+                    )[..],
+                ),
+                &pipeline_cache.get_bind_group_layout(layout_desc),
+                &BindGroupEntries::with_indices((
+                    (0, spawner_buffer.as_entire_binding()),
+                    (
+                        1,
+                        BufferBinding {
+                            buffer: batch_info_buffer,
+                            offset: 0,
+                            size: Some(GpuBatchInfo::aligned_size(align)),
+                        },
+                    ),
+                    (3, property_buffer.as_entire_binding()),
+                )),
+            )
+        };
+        Ok(bind_group)
     }
 
     /// Ensure the bind group for the given key exists, creating it if needed.
@@ -746,46 +884,34 @@ impl PropertyBindGroups {
             return Err(());
         };
 
-        // This should always be non-zero if the property key is Some().
-        let property_binding_size = NonZeroU64::new(property_key.binding_size as u64).unwrap();
-        let Some(layout_desc) = property_cache.bind_group_layout_desc(Some(property_binding_size))
-        else {
-            error!(
-                "Missing property bind group layout for binding size {}, referenced by effect batch.",
-                property_binding_size.get(),
-            );
-            return Err(());
+        match self.property_bind_groups.entry(*property_key) {
+            Entry::Vacant(entry) => {
+                let without = Self::make_bind_group(
+                    property_key,
+                    property_cache,
+                    false,
+                    spawner_buffer,
+                    prefix_sum_buffer,
+                    batch_info_buffer,
+                    property_buffer,
+                    render_device,
+                    pipeline_cache,
+                )?;
+                let with = Self::make_bind_group(
+                    property_key,
+                    property_cache,
+                    true,
+                    spawner_buffer,
+                    prefix_sum_buffer,
+                    batch_info_buffer,
+                    property_buffer,
+                    render_device,
+                    pipeline_cache,
+                )?;
+                entry.insert([without, with]);
+            }
+            Entry::Occupied(_) => (),
         };
-
-        let align = render_device.limits().min_storage_buffer_offset_alignment;
-        self.property_bind_groups
-            .entry(*property_key)
-            .or_insert_with(|| {
-                trace!(
-                    "Creating new spawner@2 bind group for property buffer #{} and binding size {}",
-                    property_key.buffer_index,
-                    property_key.binding_size
-                );
-                render_device.create_bind_group(
-                    Some(
-                        &format!(
-                            "hanabi:bg:spawner@2:property{}_size{}",
-                            property_key.buffer_index, property_key.binding_size
-                        )[..],
-                    ),
-                    &pipeline_cache.get_bind_group_layout(layout_desc),
-                    &BindGroupEntries::sequential((
-                        spawner_buffer.as_entire_binding(),
-                        prefix_sum_buffer.as_entire_binding(),
-                        BufferBinding {
-                            buffer: batch_info_buffer,
-                            offset: 0,
-                            size: Some(GpuBatchInfo::aligned_size(align)),
-                        },
-                        property_buffer.as_entire_binding(),
-                    )),
-                )
-            });
         Ok(())
     }
 
@@ -799,40 +925,73 @@ impl PropertyBindGroups {
         render_device: &RenderDevice,
         pipeline_cache: &PipelineCache,
     ) -> Result<(), ()> {
-        let Some(layout_desc) = property_cache.bind_group_layout_desc(None) else {
+        if self.no_property_bind_groups.is_some() {
+            return Ok(());
+        }
+
+        let align = render_device.limits().min_storage_buffer_offset_alignment;
+        trace!("Creating new spawner@2 bind group for no-property variant");
+
+        // Variant with prefix sum (for init/update batched passes, and multi-draw
+        // rendering)
+        let Some(layout_desc) = property_cache.bind_group_layout_desc(None, true) else {
             error!(
-                "Missing property bind group layout for no-property variant, referenced by effect batch.",
+                "Missing property bind group layout for no-property variant (w/ prefix), referenced by effect batch.",
             );
             return Err(());
         };
+        let with = render_device.create_bind_group(
+            Some("hanabi:bg:spawner@2:no-property_md"),
+            &pipeline_cache.get_bind_group_layout(layout_desc),
+            &BindGroupEntries::sequential((
+                spawner_buffer.as_entire_binding(),
+                prefix_sum_buffer.as_entire_binding(),
+                BufferBinding {
+                    buffer: batch_info_buffer,
+                    offset: 0,
+                    size: Some(GpuBatchInfo::aligned_size(align)),
+                },
+            )),
+        );
 
-        if self.no_property_bind_group.is_none() {
-            let align = render_device.limits().min_storage_buffer_offset_alignment;
-            trace!("Creating new spawner@2 bind group for no-property variant");
-            self.no_property_bind_group = Some(render_device.create_bind_group(
-                Some("hanabi:bg:spawner@2:no-property"),
-                &pipeline_cache.get_bind_group_layout(layout_desc),
-                &BindGroupEntries::sequential((
-                    spawner_buffer.as_entire_binding(),
-                    prefix_sum_buffer.as_entire_binding(),
-                    BufferBinding {
-                        buffer: batch_info_buffer,
-                        offset: 0,
-                        size: Some(GpuBatchInfo::aligned_size(align)),
-                    },
-                )),
-            ));
-        }
+        // Variant without prefix sum (for single-draw rendering)
+        let Some(layout_desc) = property_cache.bind_group_layout_desc(None, false) else {
+            error!(
+                "Missing property bind group layout for no-property variant (w/o prefix), referenced by effect batch.",
+            );
+            return Err(());
+        };
+        let without = render_device.create_bind_group(
+            Some("hanabi:bg:spawner@2:no-property"),
+            &pipeline_cache.get_bind_group_layout(layout_desc),
+            &BindGroupEntries::sequential((
+                spawner_buffer.as_entire_binding(),
+                BufferBinding {
+                    buffer: batch_info_buffer,
+                    offset: 0,
+                    size: Some(GpuBatchInfo::aligned_size(align)),
+                },
+            )),
+        );
 
+        self.no_property_bind_groups = Some([without, with]);
         Ok(())
     }
 
     /// Get the bind group for the given key.
-    pub fn get(&self, key: Option<&PropertyBindGroupKey>) -> Option<&BindGroup> {
+    pub fn get(
+        &self,
+        key: Option<&PropertyBindGroupKey>,
+        with_prefix_sum: bool,
+    ) -> Option<&BindGroup> {
         if let Some(key) = key {
-            self.property_bind_groups.get(key)
+            self.property_bind_groups
+                .get(key)
+                .map(|arr| &arr[with_prefix_sum as usize])
         } else {
-            self.no_property_bind_group.as_ref()
+            self.no_property_bind_groups
+                .as_ref()
+                .map(|arr| &arr[with_prefix_sum as usize])
         }
     }
 }

--- a/src/render/shader_contract_tests.rs
+++ b/src/render/shader_contract_tests.rs
@@ -11,8 +11,8 @@ use wgpu::util::DeviceExt;
 
 use super::*;
 use crate::{
-    test_utils::MockRenderer, Attribute, EffectAsset, EffectShaderSources, ExprWriter,
-    SetAttributeModifier, SpawnerSettings,
+    plugin::VFX_SORT_WGSL, test_utils::MockRenderer, Attribute, EffectAsset, EffectShaderSources,
+    ExprWriter, SetAttributeModifier, SpawnerSettings,
 };
 
 #[repr(C)]
@@ -98,15 +98,9 @@ fn create_composed_shader_module(
 ) -> Result<wgpu::ShaderModule, Box<dyn std::error::Error>> {
     let spawner_padding_code = GpuSpawnerParams::padding_code(storage_alignment);
     let batch_info_padding_code = GpuBatchInfo::padding_code(storage_alignment);
-    let effect_metadata_padding_code = GpuEffectMetadata::padding_code(storage_alignment);
-    let effect_metadata_stride_code = GpuEffectMetadata::aligned_size(storage_alignment)
-        .get()
-        .to_string();
     let common_code = include_str!("vfx_common.wgsl")
         .replace("{{SPAWNER_PADDING}}", &spawner_padding_code)
-        .replace("{{BATCH_INFO_PADDING}}", &batch_info_padding_code)
-        .replace("{{EFFECT_METADATA_PADDING}}", &effect_metadata_padding_code)
-        .replace("{{EFFECT_METADATA_STRIDE}}", &effect_metadata_stride_code);
+        .replace("{{BATCH_INFO_PADDING}}", &batch_info_padding_code);
 
     let mut composer = Composer::default();
     composer.add_composable_module(ComposableModuleDescriptor {
@@ -126,18 +120,6 @@ fn create_composed_shader_module(
             label: Some(file_path),
             source: wgpu::ShaderSource::Naga(Cow::Owned(module)),
         }))
-}
-
-fn pack_effect_metadata_rows(rows: &[GpuEffectMetadata], storage_alignment: u32) -> Vec<u32> {
-    let stride_u32 = (GpuEffectMetadata::aligned_size(storage_alignment).get() / 4) as usize;
-    let row_u32 = std::mem::size_of::<GpuEffectMetadata>() / 4;
-    let mut packed = vec![0_u32; rows.len() * stride_u32];
-    for (i, row) in rows.iter().enumerate() {
-        let src: &[u32] = cast_slice(std::slice::from_ref(row));
-        let dst = &mut packed[i * stride_u32..i * stride_u32 + row_u32];
-        dst.copy_from_slice(src);
-    }
-    packed
 }
 
 fn write_aligned_spawners(
@@ -168,7 +150,8 @@ fn write_aligned_spawners(
     buffer
 }
 
-/// Create an array containing the input slice content padded to the given alignment.
+/// Create an array containing the input slice content padded to the given
+/// alignment.
 fn padded_slice_content<T: ShaderType + Pod>(arr: &[T], align: u32) -> Vec<u8> {
     let aligned_size = (T::min_size().get() as usize).next_multiple_of(align as usize);
     let total_size = arr.len() * aligned_size;
@@ -180,6 +163,395 @@ fn padded_slice_content<T: ShaderType + Pod>(arr: &[T], align: u32) -> Vec<u8> {
         data[offset..offset + cpu_size].copy_from_slice(item_bytes);
     }
     data
+}
+
+fn create_sort_pipeline(
+    wgpu_device: &wgpu::Device,
+    sort_buffer: &wgpu::Buffer,
+) -> (wgpu::ComputePipeline, wgpu::BindGroup) {
+    let bgl = wgpu_device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("hanabi:test:sort:bgl"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }],
+    });
+    let bg = wgpu_device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("hanabi:test:sort:bg"),
+        layout: &bgl,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: sort_buffer.as_entire_binding(),
+        }],
+    });
+    let pl = wgpu_device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("hanabi:test:sort:pl"),
+        bind_group_layouts: &[Some(&bgl)],
+        immediate_size: 0,
+    });
+    let source = VFX_SORT_WGSL
+        .replace("#ifdef HAS_DUAL_KEY", "")
+        .replace("#ifdef TEST", "")
+        .replace("#endif", "");
+    let shader = wgpu_device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("hanabi:test:vfx_sort"),
+        source: wgpu::ShaderSource::Wgsl(source.into()),
+    });
+    let pipeline = wgpu_device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("hanabi:test:sort:pipe"),
+        layout: Some(&pl),
+        module: &shader,
+        entry_point: Some("main"),
+        cache: None,
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+    });
+    (pipeline, bg)
+}
+
+#[test]
+fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::error::Error>> {
+    let renderer = MockRenderer::new();
+    let device = renderer.device();
+    let queue = renderer.queue();
+    let wgpu_device = device.wgpu_device();
+    let storage_alignment = device.limits().min_storage_buffer_offset_alignment;
+
+    let fill_shader = create_composed_shader_module(
+        &device,
+        storage_alignment,
+        include_str!("vfx_sort_fill.wgsl"),
+        "bevy_hanabi::vfx_sort_fill",
+    )?;
+    let copy_shader = create_composed_shader_module(
+        &device,
+        storage_alignment,
+        include_str!("vfx_sort_copy.wgsl"),
+        "bevy_hanabi::vfx_sort_copy",
+    )?;
+
+    let metadatas = [
+        GpuEffectMetadata {
+            capacity: 4,
+            alive_count: 4,
+            indirect_write_index: 0,
+            particle_stride: 2,
+            sort_key_offset: 0,
+            sort_key2_offset: 1,
+            ..default()
+        },
+        GpuEffectMetadata {
+            capacity: 4,
+            alive_count: 4,
+            indirect_write_index: 0,
+            particle_stride: 2,
+            sort_key_offset: 0,
+            sort_key2_offset: 1,
+            ..default()
+        },
+    ];
+    let spawners = [
+        GpuSpawnerParams {
+            effect_metadata_index: 0,
+            slab_offset: 0,
+            ..default()
+        },
+        GpuSpawnerParams {
+            effect_metadata_index: 1,
+            slab_offset: 4,
+            ..default()
+        },
+    ];
+    let particles = [
+        1_u32,
+        3.0_f32.to_bits(),
+        0,
+        1.0_f32.to_bits(),
+        1,
+        2.0_f32.to_bits(),
+        0,
+        4.0_f32.to_bits(), // Instance 0
+        2,
+        1.0_f32.to_bits(),
+        1,
+        4.0_f32.to_bits(),
+        2,
+        3.0_f32.to_bits(),
+        1,
+        2.0_f32.to_bits(), // Instance 1
+    ];
+    let indirect_indices = [
+        3_u32,
+        0,
+        u32::MAX,
+        2,
+        0,
+        u32::MAX,
+        1,
+        0,
+        u32::MAX,
+        0,
+        0,
+        u32::MAX,
+        2,
+        0,
+        u32::MAX,
+        0,
+        0,
+        u32::MAX,
+        3,
+        0,
+        u32::MAX,
+        1,
+        0,
+        u32::MAX,
+    ];
+    let particle_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("hanabi:test:ribbon:particles"),
+        contents: cast_slice(&particles),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+    let indirect_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("hanabi:test:ribbon:indirect"),
+        contents: cast_slice(&indirect_indices),
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+    });
+    let metadata_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("hanabi:test:ribbon:metadata"),
+        contents: cast_slice(&metadatas),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+    let spawner_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("hanabi:test:ribbon:spawners"),
+        contents: &padded_slice_content(&spawners, storage_alignment),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+    let sort_buffer = wgpu_device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("hanabi:test:ribbon:sort"),
+        size: 4 + 4 * 12,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let dispatch_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("hanabi:test:ribbon:dispatch"),
+        contents: cast_slice(&[
+            GpuDispatchIndirectArgs { x: 1, y: 1, z: 1 },
+            GpuDispatchIndirectArgs { x: 1, y: 1, z: 1 },
+        ]),
+        usage: wgpu::BufferUsages::INDIRECT,
+    });
+
+    let storage = |binding, read_only, dynamic| wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only },
+            has_dynamic_offset: dynamic,
+            min_binding_size: None,
+        },
+        count: None,
+    };
+    let fill_bgl = wgpu_device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("hanabi:test:ribbon:fill:bgl"),
+        entries: &[
+            storage(0, false, false),
+            storage(1, true, false),
+            storage(2, true, false),
+            storage(3, false, false),
+            storage(4, true, true),
+        ],
+    });
+    let copy_bgl = wgpu_device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("hanabi:test:ribbon:copy:bgl"),
+        entries: &[
+            storage(0, false, false),
+            storage(1, true, false),
+            storage(2, false, false),
+            storage(3, true, true),
+        ],
+    });
+    let fill_bg = wgpu_device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("hanabi:test:ribbon:fill:bg"),
+        layout: &fill_bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: sort_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: particle_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: indirect_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: metadata_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &spawner_buffer,
+                    offset: 0,
+                    size: NonZeroU64::new(storage_alignment as u64),
+                }),
+            },
+        ],
+    });
+    let copy_bg = wgpu_device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("hanabi:test:ribbon:copy:bg"),
+        layout: &copy_bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: indirect_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: sort_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: metadata_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &spawner_buffer,
+                    offset: 0,
+                    size: NonZeroU64::new(storage_alignment as u64),
+                }),
+            },
+        ],
+    });
+    let fill_pl = wgpu_device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("hanabi:test:ribbon:fill:pl"),
+        bind_group_layouts: &[Some(&fill_bgl)],
+        immediate_size: 0,
+    });
+    let copy_pl = wgpu_device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("hanabi:test:ribbon:copy:pl"),
+        bind_group_layouts: &[Some(&copy_bgl)],
+        immediate_size: 0,
+    });
+    let fill_pipeline = wgpu_device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("hanabi:test:ribbon:fill"),
+        layout: Some(&fill_pl),
+        module: &fill_shader,
+        entry_point: Some("main"),
+        cache: None,
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+    });
+    let copy_pipeline = wgpu_device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("hanabi:test:ribbon:copy"),
+        layout: Some(&copy_pl),
+        module: &copy_shader,
+        entry_point: Some("main"),
+        cache: None,
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+    });
+    let (sort_pipeline, sort_bg) = create_sort_pipeline(wgpu_device, &sort_buffer);
+
+    let mut encoder = wgpu_device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("hanabi:test:ribbon:chain"),
+    });
+    for instance in 0..2 {
+        encoder.clear_buffer(&sort_buffer, 0, Some(4));
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("hanabi:test:ribbon:fill"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&fill_pipeline);
+            pass.set_bind_group(
+                0,
+                &fill_bg,
+                &[(instance * storage_alignment as usize) as u32],
+            );
+            pass.dispatch_workgroups_indirect(
+                &dispatch_buffer,
+                instance as u64 * std::mem::size_of::<GpuDispatchIndirectArgs>() as u64,
+            );
+        }
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("hanabi:test:ribbon:sort"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&sort_pipeline);
+            pass.set_bind_group(0, &sort_bg, &[]);
+            pass.dispatch_workgroups_indirect(
+                &dispatch_buffer,
+                instance as u64 * std::mem::size_of::<GpuDispatchIndirectArgs>() as u64,
+            );
+        }
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("hanabi:test:ribbon:copy"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&copy_pipeline);
+            pass.set_bind_group(
+                0,
+                &copy_bg,
+                &[(instance * storage_alignment as usize) as u32],
+            );
+            pass.dispatch_workgroups_indirect(
+                &dispatch_buffer,
+                instance as u64 * std::mem::size_of::<GpuDispatchIndirectArgs>() as u64,
+            );
+        }
+    }
+    submit_and_wait(&device, &queue, encoder.finish());
+
+    let indirect_out = readback_vec::<u32>(
+        &device,
+        &queue,
+        &indirect_buffer,
+        (indirect_indices.len() * std::mem::size_of::<u32>()) as u64,
+    );
+    assert_eq!(
+        &indirect_out[0..12],
+        &[
+            1,
+            0,
+            u32::MAX,
+            3,
+            0,
+            u32::MAX,
+            2,
+            0,
+            u32::MAX,
+            0,
+            0,
+            u32::MAX
+        ]
+    );
+    assert_eq!(
+        &indirect_out[12..24],
+        &[
+            3,
+            0,
+            u32::MAX,
+            1,
+            0,
+            u32::MAX,
+            0,
+            0,
+            u32::MAX,
+            2,
+            0,
+            u32::MAX
+        ]
+    );
+    Ok(())
 }
 
 #[test]
@@ -976,7 +1348,6 @@ fn real_vfx_update_contracts() -> Result<(), Box<dyn std::error::Error>> {
             ..default()
         },
     ];
-    let metadata_packed = pack_effect_metadata_rows(&metadata_rows, storage_alignment);
 
     let sim_params_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("hanabi:test:update:sim_params"),
@@ -1018,7 +1389,7 @@ fn real_vfx_update_contracts() -> Result<(), Box<dyn std::error::Error>> {
     });
     let metadata_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("hanabi:test:update:metadata"),
-        contents: cast_slice(&metadata_packed),
+        contents: cast_slice(&metadata_rows),
         usage: wgpu::BufferUsages::STORAGE,
     });
 
@@ -1231,13 +1602,6 @@ fn real_vfx_update_contracts() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn real_vfx_indirect_contracts() -> Result<(), Box<dyn std::error::Error>> {
-    const EM_OFFSET_CAPACITY: usize = 0;
-    const EM_OFFSET_ALIVE_COUNT: usize = 1;
-    const EM_OFFSET_MAX_UPDATE: usize = 2;
-    const EM_OFFSET_MAX_SPAWN: usize = 3;
-    const EM_OFFSET_INDIRECT_WRITE_INDEX: usize = 4;
-    const EM_OFFSET_INDIRECT_DRAW_INDEX: usize = 5;
-
     let renderer = MockRenderer::new();
     let device = renderer.device();
     let queue = renderer.queue();
@@ -1266,20 +1630,29 @@ fn real_vfx_indirect_contracts() -> Result<(), Box<dyn std::error::Error>> {
         usage: wgpu::BufferUsages::UNIFORM,
     });
 
-    let effect_stride_u32 = (GpuEffectMetadata::aligned_size(storage_alignment).get() / 4) as usize;
-    let mut metadata_u32 = vec![0_u32; 2 * effect_stride_u32];
-    metadata_u32[EM_OFFSET_CAPACITY] = 200;
-    metadata_u32[EM_OFFSET_ALIVE_COUNT] = 130;
-    metadata_u32[EM_OFFSET_INDIRECT_WRITE_INDEX] = 0;
-    metadata_u32[EM_OFFSET_INDIRECT_DRAW_INDEX] = 0;
-    let em1 = effect_stride_u32;
-    metadata_u32[em1 + EM_OFFSET_CAPACITY] = 5;
-    metadata_u32[em1 + EM_OFFSET_ALIVE_COUNT] = 1;
-    metadata_u32[em1 + EM_OFFSET_INDIRECT_WRITE_INDEX] = 1;
-    metadata_u32[em1 + EM_OFFSET_INDIRECT_DRAW_INDEX] = 1;
+    let metadata_rows = [
+        GpuEffectMetadata {
+            capacity: 200,
+            alive_count: 130,
+            max_update: u32::MAX,
+            max_spawn: u32::MAX,
+            indirect_draw_index: 0,
+            indirect_write_index: 0,
+            ..default()
+        },
+        GpuEffectMetadata {
+            capacity: 5,
+            alive_count: 1,
+            max_update: u32::MAX,
+            max_spawn: u32::MAX,
+            indirect_draw_index: 1,
+            indirect_write_index: 1,
+            ..default()
+        },
+    ];
     let metadata_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("hanabi:test:indirect:metadata"),
-        contents: cast_slice(&metadata_u32),
+        contents: cast_slice(&metadata_rows),
         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
     });
 
@@ -1454,16 +1827,17 @@ fn real_vfx_indirect_contracts() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_out = readback_vec::<u32>(&device, &queue, &prefix_buffer, 8);
     assert_eq!(prefix_out, vec![130, 1]);
 
-    let metadata_out = readback_vec::<u32>(
+    let metadata_raw_out = readback_vec::<u32>(
         &device,
         &queue,
         &metadata_buffer,
-        (metadata_u32.len() * 4) as u64,
+        (metadata_rows.len() * size_of::<GpuEffectMetadata>()) as u64,
     );
-    assert_eq!(metadata_out[EM_OFFSET_MAX_UPDATE], 130);
-    assert_eq!(metadata_out[EM_OFFSET_MAX_SPAWN], 70);
-    assert_eq!(metadata_out[em1 + EM_OFFSET_MAX_UPDATE], 1);
-    assert_eq!(metadata_out[em1 + EM_OFFSET_MAX_SPAWN], 4);
+    let metadata_out: &[GpuEffectMetadata] = cast_slice(&metadata_raw_out);
+    assert_eq!(metadata_out[0].max_update, 130);
+    assert_eq!(metadata_out[0].max_spawn, 70);
+    assert_eq!(metadata_out[1].max_update, 1);
+    assert_eq!(metadata_out[1].max_spawn, 4);
 
     let draw_out = readback_vec::<GpuDrawIndexedIndirectArgs>(
         &device,

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -20,7 +20,9 @@ use bevy::{
     utils::default,
 };
 use bytemuck::{Pod, Zeroable};
-use wgpu::{BufferBinding, BufferDescriptor, BufferUsages, CommandEncoder, ShaderStages};
+use wgpu::{
+    BufferAddress, BufferBinding, BufferDescriptor, BufferUsages, CommandEncoder, ShaderStages,
+};
 
 use super::{gpu_buffer::GpuBuffer, GpuDispatchIndirectArgs, GpuEffectMetadata, StorageType};
 use crate::{
@@ -95,7 +97,7 @@ pub struct SortBindGroups {
     sort_buffer: Buffer,
     /// GPU buffer containing the [`GpuDispatchIndirect`] structs for the
     /// sort-fill and sort passes.
-    indirect_buffer: GpuBuffer<GpuDispatchIndirectArgs>,
+    indirect_args_buffer: GpuBuffer<GpuDispatchIndirectArgs>,
     /// Bind group layouts for group #0 of the sort-fill compute pass.
     sort_fill_bind_group_layout_descs:
         HashMap<SortFillBindGroupLayoutKey, (BindGroupLayoutDescriptor, CachedComputePipelineId)>,
@@ -177,9 +179,9 @@ impl SortBindGroups {
                     storage_buffer::<GpuIndirectIndex>(false),
                     // @group(0) @binding(1) var<storage, read> sort_buffer : SortBuffer;
                     storage_buffer_read_only::<GpuSortBufferSingleEntry>(false),
-                    // @group(0) @binding(2) var<storage, read_write> effect_metadata :
-                    // EffectMetadata;
-                    storage_buffer_sized(true, Some(GpuEffectMetadata::aligned_size(alignment))),
+                    // @group(0) @binding(2) var<storage, read_write> effect_metadatas :
+                    // array<EffectMetadata>;
+                    storage_buffer::<GpuEffectMetadata>(false),
                     // @group(0) @binding(3) var<storage, read> spawner : Spawner;
                     storage_buffer_read_only_sized(
                         true,
@@ -203,7 +205,7 @@ impl SortBindGroups {
         Self {
             sort_fill_shader,
             sort_buffer,
-            indirect_buffer,
+            indirect_args_buffer: indirect_buffer,
             sort_fill_bind_group_layout_descs: default(),
             sort_fill_bind_groups: default(),
             sort_bind_group_layout_desc,
@@ -222,18 +224,19 @@ impl SortBindGroups {
     }
 
     #[inline]
-    pub fn clear_indirect_dispatch_buffer(&mut self) {
-        self.indirect_buffer.clear();
+    pub fn clear_indirect_args_buffer(&mut self) {
+        self.indirect_args_buffer.clear();
+    }
+
+    /// Allocate a [`GpuDispatchIndirectArgs`] slot in the global shared buffer.
+    #[inline]
+    pub fn allocate_indirect_args(&mut self) -> u32 {
+        self.indirect_args_buffer.allocate()
     }
 
     #[inline]
-    pub fn allocate_indirect_dispatch(&mut self) -> u32 {
-        self.indirect_buffer.allocate()
-    }
-
-    #[inline]
-    pub fn get_indirect_dispatch_byte_offset(&self, index: u32) -> u32 {
-        self.indirect_buffer.item_size() as u32 * index
+    pub fn get_indirect_args_byte_offset(&self, index: u32) -> BufferAddress {
+        self.indirect_args_buffer.item_size() as BufferAddress * index as BufferAddress
     }
 
     #[inline]
@@ -243,8 +246,8 @@ impl SortBindGroups {
     }
 
     #[inline]
-    pub fn indirect_buffer(&self) -> Option<&Buffer> {
-        self.indirect_buffer.buffer()
+    pub fn indirect_args_buffer(&self) -> Option<&Buffer> {
+        self.indirect_args_buffer.buffer()
     }
 
     #[inline]
@@ -300,17 +303,17 @@ impl SortBindGroups {
 
     #[inline]
     pub fn prepare_buffers(&mut self, render_device: &RenderDevice) {
-        self.indirect_buffer.prepare_buffers(render_device);
+        self.indirect_args_buffer.prepare_buffers(render_device);
     }
 
     #[inline]
     pub fn write_buffers(&self, command_encoder: &mut CommandEncoder) {
-        self.indirect_buffer.write_buffers(command_encoder);
+        self.indirect_args_buffer.write_buffers(command_encoder);
     }
 
     #[inline]
     pub fn clear_previous_frame_resizes(&mut self) {
-        self.indirect_buffer.clear_previous_frame_resizes();
+        self.indirect_args_buffer.clear_previous_frame_resizes();
     }
 
     pub fn ensure_sort_fill_bind_group_layout_desc(
@@ -342,12 +345,9 @@ impl SortBindGroups {
                             // @group(0) @binding(2) var<storage, read> indirect_index_buffer :
                             // array<u32>;
                             storage_buffer_read_only::<GpuIndirectIndex>(false),
-                            // @group(0) @binding(3) var<storage, read_write> effect_metadata :
-                            // EffectMetadata;
-                            storage_buffer_sized(
-                                true,
-                                Some(GpuEffectMetadata::aligned_size(alignment)),
-                            ),
+                            // @group(0) @binding(3) var<storage, read_write> effect_metadatas :
+                            // array<EffectMetadata>;
+                            storage_buffer::<GpuEffectMetadata>(false),
                             // @group(0) @binding(4) var<storage, read> spawner : Spawner;
                             storage_buffer_read_only_sized(
                                 true,
@@ -428,7 +428,6 @@ impl SortBindGroups {
                     .get(&key)
                     .ok_or(())?
                     .0;
-                let align = render_device.limits().min_storage_buffer_offset_alignment;
                 entry.insert(render_device.create_bind_group(
                     "hanabi:bg:sort_fill",
                     &pipeline_cache.get_bind_group_layout(layout_desc),
@@ -442,18 +441,16 @@ impl SortBindGroups {
                         // @group(0) @binding(2) var<storage, read> indirect_index_buffer :
                         // array<u32>;
                         indirect_index.as_entire_binding(),
-                        // @group(0) @binding(3) var<storage, read> effect_metadata :
-                        // EffectMetadata;
-                        BufferBinding {
-                            buffer: effect_metadata,
-                            offset: 0,
-                            size: Some(GpuEffectMetadata::aligned_size(align)),
-                        },
+                        // @group(0) @binding(3) var<storage, read_write> effect_metadatas :
+                        // array<EffectMetadata>;
+                        effect_metadata.as_entire_binding(),
                         // @group(0) @binding(4) var<storage, read> spawner : Spawner;
                         BufferBinding {
                             buffer: spawner_buffer,
                             offset: 0,
-                            size: Some(GpuSpawnerParams::aligned_size(align)),
+                            size: Some(GpuSpawnerParams::aligned_size(
+                                render_device.limits().min_storage_buffer_offset_alignment,
+                            )),
                         },
                     )),
                 ))
@@ -519,7 +516,6 @@ impl SortBindGroups {
         let bind_group = match entry {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let align = render_device.limits().min_storage_buffer_offset_alignment;
                 entry.insert(render_device.create_bind_group(
                     "hanabi:bg:sort_copy",
                     &pipeline_cache.get_bind_group_layout(&self.sort_copy_bind_group_layout_desc),
@@ -529,18 +525,16 @@ impl SortBindGroups {
                         indirect_index_buffer.as_entire_binding(),
                         // @group(0) @binding(1) var<storage, read> sort_buffer : SortBuffer;
                         self.sort_buffer.as_entire_binding(),
-                        // @group(0) @binding(2) var<storage, read> effect_metadata :
-                        // EffectMetadata;
-                        BufferBinding {
-                            buffer: effect_metadata_buffer,
-                            offset: 0,
-                            size: Some(GpuEffectMetadata::aligned_size(align)),
-                        },
+                        // @group(0) @binding(2) var<storage, read_write> effect_metadatas :
+                        // array<EffectMetadata>;
+                        effect_metadata_buffer.as_entire_binding(),
                         // @group(0) @binding(3) var<storage, read> spawner : Spawner;
                         BufferBinding {
                             buffer: spawner_buffer,
                             offset: 0,
-                            size: Some(GpuSpawnerParams::aligned_size(align)),
+                            size: Some(GpuSpawnerParams::aligned_size(
+                                render_device.limits().min_storage_buffer_offset_alignment,
+                            )),
                         },
                     )),
                 ))
@@ -562,5 +556,329 @@ impl SortBindGroups {
             spawner,
         };
         self.sort_copy_bind_groups.get(&key)
+    }
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod gpu_tests {
+    use bevy::{
+        math::FloatOrd,
+        render::render_resource::{
+            binding_types::storage_buffer_sized, BindGroupEntries, BindGroupLayoutEntries,
+            ShaderSize, ShaderType,
+        },
+    };
+    #[allow(unused_imports)]
+    use bytemuck::{cast_slice, Pod, Zeroable};
+    use wgpu::{
+        BufferDescriptor, BufferUsages, ComputePassDescriptor, ComputePipelineDescriptor,
+        PipelineCompilationOptions, PipelineLayoutDescriptor, ShaderModuleDescriptor, ShaderSource,
+        ShaderStages,
+    };
+
+    use crate::{plugin::VFX_SORT_WGSL, test_utils::*};
+
+    #[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable, ShaderType)]
+    #[repr(C)]
+    struct DualKeyValuePair {
+        pub key: u32,
+        pub key2: f32,
+        pub value: u32,
+    }
+
+    // Ignore weirdnesses with f32 NaN etc. here, we should never have a key with
+    // such values.
+    impl std::cmp::Eq for DualKeyValuePair {}
+
+    impl std::cmp::PartialOrd for DualKeyValuePair {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl std::cmp::Ord for DualKeyValuePair {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            if self.key != other.key {
+                return self.key.cmp(&other.key);
+            }
+            FloatOrd(self.key2).cmp(&FloatOrd(other.key2))
+        }
+    }
+
+    #[test]
+    fn test_serial_insertion_sort() {
+        let renderer = MockRenderer::new();
+        let device = renderer.device();
+        let queue = renderer.queue();
+        let num_kv = 257u32;
+        let byte_size = 4 + num_kv as u64 * DualKeyValuePair::SHADER_SIZE.get();
+        let sort_buffer = device.create_buffer(&BufferDescriptor {
+            label: Some("sort_buffer"),
+            size: byte_size,
+            usage: BufferUsages::STORAGE | BufferUsages::MAP_READ,
+            mapped_at_creation: true,
+        });
+
+        let mut expected = Vec::with_capacity(num_kv as usize);
+        for i in 0..num_kv {
+            expected.push(DualKeyValuePair {
+                key: i % 4,
+                key2: ((i / 4) % 3) as f32,
+                value: i,
+            });
+        }
+        {
+            let mut mapped = sort_buffer.slice(..).get_mapped_range_mut();
+            mapped.slice(..4).copy_from_slice(cast_slice(&[num_kv]));
+            mapped
+                .slice(4..)
+                .copy_from_slice(cast_slice(expected.as_slice()));
+        }
+        sort_buffer.unmap();
+        expected.sort();
+
+        let bind_group_layout = device.create_bind_group_layout(
+            "bind_group_layout",
+            &BindGroupLayoutEntries::single(
+                ShaderStages::COMPUTE,
+                storage_buffer_sized(false, None),
+            ),
+        );
+        let bind_group = device.create_bind_group(
+            None,
+            &bind_group_layout,
+            &BindGroupEntries::single(sort_buffer.as_entire_binding()),
+        );
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("pipeline_layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let src = VFX_SORT_WGSL
+            .replace("#ifdef HAS_DUAL_KEY", "")
+            .replace("#ifdef TEST", "")
+            .replace("#endif", "");
+        let shader_module = device.create_and_validate_shader_module(ShaderModuleDescriptor {
+            label: Some("vfx_sort"),
+            source: ShaderSource::Wgsl(src.into()),
+        });
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some("test_serial_insertion_sort"),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("main"),
+            compilation_options: PipelineCompilationOptions {
+                constants: &[],
+                zero_initialize_workgroup_memory: false,
+            },
+            cache: None,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("test"),
+        });
+        {
+            let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some("test_serial_insertion_sort"),
+                timestamp_writes: None,
+            });
+            compute_pass.set_pipeline(&pipeline);
+            compute_pass.set_bind_group(0, &bind_group, &[]);
+            compute_pass.dispatch_workgroups(1, 1, 1);
+        }
+        queue.submit([encoder.finish()]);
+        let (tx, rx) = futures::channel::oneshot::channel();
+        queue.on_submitted_work_done(move || {
+            tx.send(()).unwrap();
+        });
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+        let _ = futures::executor::block_on(rx);
+
+        let buffer_slice = sort_buffer.slice(..);
+        let (tx, rx) = futures::channel::oneshot::channel();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).unwrap();
+        });
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+        let _ = futures::executor::block_on(rx);
+        let view = buffer_slice.get_mapped_range();
+        assert_eq!(view.len(), byte_size as usize);
+        assert_eq!(cast_slice::<_, u32>(&view[..4]), &[0]);
+        assert_eq!(
+            cast_slice::<_, DualKeyValuePair>(&view[4..]),
+            expected.as_slice()
+        );
+    }
+
+    /// Calculate the effect index from a particle index using a binary search
+    /// of the base particle prefix sum.
+    #[test]
+    fn test_binary_search_prefix_sum() {
+        let renderer = MockRenderer::new();
+        let device = renderer.device();
+        let queue = renderer.queue();
+
+        println!(
+            "max_compute_workgroup_storage_size = {}",
+            device.limits().max_compute_workgroup_storage_size
+        );
+
+        // SAFETY : for debugging only
+        #[allow(unsafe_code)]
+        unsafe {
+            device.wgpu_device().start_graphics_debugger_capture()
+        };
+
+        // Clamp max block size to the device's reported storage
+        let max_block_size = device.limits().max_compute_workgroup_storage_size
+            / (2 * DualKeyValuePair::SHADER_SIZE.get() as u32);
+        println!("max_block_size = {}", max_block_size);
+        let num_particle = 1024.min(max_block_size);
+
+        let byte_size = 4 + num_particle as u64 * DualKeyValuePair::SHADER_SIZE.get();
+        let sort_buffer = device.create_buffer(&BufferDescriptor {
+            label: Some("sort_buffer"),
+            size: byte_size,
+            usage: BufferUsages::STORAGE | BufferUsages::MAP_READ,
+            mapped_at_creation: true,
+        });
+        let effects = [0, 35, 399, 1000];
+        assert!((effects.len() as u32) < num_particle);
+        let values: Vec<_> = (0..num_particle as usize)
+            .map(|i| DualKeyValuePair {
+                key: effects.get(i).copied().unwrap_or(0xDEAD0000),
+                key2: i as f32 * 0.1,
+                value: i as u32,
+            })
+            .collect();
+        {
+            // Scope get_mapped_range_mut() to force a drop before unmap()
+            {
+                let mut mapped = sort_buffer.slice(..).get_mapped_range_mut();
+                mapped
+                    .slice(..4)
+                    .copy_from_slice(cast_slice(&[effects.len() as u32]));
+                mapped
+                    .slice(4..)
+                    .copy_from_slice(cast_slice(values.as_slice()));
+            }
+            sort_buffer.unmap();
+        }
+
+        // Create GPU resources
+        let bind_group_layout = device.create_bind_group_layout(
+            "bind_group_layout",
+            &BindGroupLayoutEntries::single(
+                ShaderStages::COMPUTE,
+                storage_buffer_sized(false, None),
+            ),
+        );
+        let bind_group = device.create_bind_group(
+            None,
+            &bind_group_layout,
+            &BindGroupEntries::single(sort_buffer.as_entire_binding()),
+        );
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("pipeline_layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let src = VFX_SORT_WGSL
+            .replace("#ifdef HAS_DUAL_KEY", "")
+            .replace("#ifdef TEST", "")
+            .replace("#endif", "");
+        let shader_module = device.create_and_validate_shader_module(ShaderModuleDescriptor {
+            label: Some("vfx_sort"),
+            source: ShaderSource::Wgsl(src.into()),
+        });
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some("test_binary_search_prefix_sum"),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("test_find_effect_from_particle"),
+            compilation_options: PipelineCompilationOptions {
+                constants: &[],
+                // Ensure the shader behaves even if memory is not zero-initialized
+                zero_initialize_workgroup_memory: false,
+            },
+            cache: None,
+        });
+
+        // Dispatch test
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("test"),
+        });
+        {
+            let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some("test_binary_search_prefix_sum"),
+                timestamp_writes: None,
+            });
+            compute_pass.set_pipeline(&pipeline);
+            compute_pass.set_bind_group(0, &bind_group, &[]);
+            compute_pass.dispatch_workgroups(1, 1, 1);
+        }
+
+        // Submit command queue and wait for execution
+        println!("Executing pipeline...");
+        let command_buffer = encoder.finish();
+        queue.submit([command_buffer]);
+        let (tx, rx) = futures::channel::oneshot::channel();
+        queue.on_submitted_work_done(move || {
+            tx.send(()).unwrap();
+        });
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+        let _ = futures::executor::block_on(rx);
+        println!("Pipeline executed");
+
+        // SAFETY : for debugging only
+        #[allow(unsafe_code)]
+        unsafe {
+            device.wgpu_device().stop_graphics_debugger_capture()
+        };
+
+        // Read back (GPU -> CPU)
+        println!("Downloading result buffer from GPU to CPU...");
+        let buffer_slice = sort_buffer.slice(..);
+        let (tx, rx) = futures::channel::oneshot::channel();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).unwrap();
+        });
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+        let _result = futures::executor::block_on(rx);
+        let view = buffer_slice.get_mapped_range();
+        println!("Result buffer downloaded to CPU");
+
+        // Validate content
+        assert_eq!(view.len(), byte_size as usize);
+        let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
+        for (i, kv) in view_slice.iter().enumerate() {
+            //println!("[#{}] k={} k2={} v={}", i, kv.key, kv.key2, kv.value);
+
+            let mut effect_index = usize::MAX;
+            for (idx, base_particle) in effects.iter().enumerate().rev() {
+                if i as u32 >= *base_particle {
+                    effect_index = idx;
+                    break;
+                }
+            }
+            assert!(effect_index <= effects.len());
+            assert_eq!(
+                effect_index as u32, kv.value,
+                "Test failed for particle {} : expected effect index {}, got {}",
+                i, effect_index, kv.value
+            );
+        }
     }
 }

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -147,8 +147,17 @@ const DRAW_INDEXED_INDIRECT_STRIDE: u32 = 5u;
 
 /// Shared info for a single batch (single shader invocation).
 struct BatchInfo {
+    /// Total number of CPU particles to spawn. This is the sum of all `spawn`
+    /// counts of all effect instances in this batch which spawn CPU-based
+    /// particles. This is uploaded from CPU each frame.
     total_spawn_count: u32,
+    /// Total number of CPU particles to update. This is the sum of all
+    /// `alive_count` of all effect instances in this batch. This is calculated
+    /// on GPU each frame, between the init and update passes.
     total_update_count: u32,
+    /// Start index of the slice of [`GpuSpawnerInfo`] for this batch, into the
+    /// [`EffectsMeta::spawner_buffer`]. The slice length is equal to the number
+    /// of effects instances batched together.
     spawner_base: u32,
     /// Offset to apply to the workgroup thread index to determine the global
     /// particle index in the currently bound slab. This is often (and ideally)
@@ -169,16 +178,6 @@ struct BatchInfo {
     {{BATCH_INFO_PADDING}}
 }
 
-// Effect metadata offsets. Used when accessing a tightly packed array of EffectMetadata
-// as a raw array<u32>, so that we can avoid WGSL struct padding and keep data more compact
-// in the GPU buffer. Each offset corresponds to a field in the EffectMetadata struct.
-// Note that all fields are 4 bytes, so we can index by "number of 4-byte field".
-const EM_OFFSET_CAPACITY: u32 = 0u;
-const EM_OFFSET_ALIVE_COUNT: u32 = 1u;
-const EM_OFFSET_MAX_UPDATE: u32 = 2u;
-const EM_OFFSET_MAX_SPAWN: u32 = 3u;
-const EM_OFFSET_INDIRECT_WRITE_INDEX: u32 = 4u;
-
 /// Metadata describing a single effect instance.
 ///
 /// The metadata describes various effect settings, as well we the location in
@@ -194,7 +193,8 @@ struct EffectMetadata {
     /// when off-screen, in theory this could be greater than instance_count. Currently
     /// we don't have GPU culling, so in practice this remains strictly equal. But we
     /// store it separately 1) because this could change in the future, and 2) because
-    /// the indirect render fields above should really be in their own buffer, not here.
+    /// the indirect render fields above (FIXME: not there anymore) should really be in
+    /// their own buffer, not here.
     alive_count: atomic<u32>,
     /// Maximum number of update threads to run. This is cached from `alive_count`
     /// during the indirect dispatch, so that the update compute pass can cap its
@@ -218,8 +218,6 @@ struct EffectMetadata {
     /// buffer. This avoids having to align those 16-byte structs to the GPU
     /// alignment (at least 32 bytes, even 256 bytes on some).
     init_indirect_dispatch_index: u32,
-    /// Index inside the global array of the spawner struct for this effect instance.
-    //spawner_index: u32,
     /// Offset (in u32 count) of the start of the property block for this
     /// effect. This is ignored if the effect doesn't use properties.
     properties_array_index: u32,
@@ -246,16 +244,7 @@ struct EffectMetadata {
     /// The value loops back after some time, but unless some particle lives
     /// forever there's little chance of repetition.
     particle_counter: atomic<u32>,
-
-    /// Padding for storage buffer alignment. This struct is sometimes bound as part
-    /// of an array, or sometimes individually as a single unit. In the later case,
-    /// we need it to be aligned to the GPU limits of the device. That limit is only
-    /// known at runtime when initializing the WebGPU device.
-    {{EFFECT_METADATA_PADDING}}
 }
-
-/// Stride, in u32 count, between elements of an array<EffectMetadata>.
-const EFFECT_METADATA_STRIDE: u32 = {{EFFECT_METADATA_STRIDE}} / 4u;
 
 var<private> seed : u32 = 0u;
 

--- a/src/render/vfx_indirect.wgsl
+++ b/src/render/vfx_indirect.wgsl
@@ -1,14 +1,11 @@
 #import bevy_hanabi::vfx_common::{
-    ChildInfo, ChildInfoBuffer, DispatchIndirectArgs, SimParams, Spawner,
-    EM_OFFSET_ALIVE_COUNT, EM_OFFSET_MAX_UPDATE, EM_OFFSET_CAPACITY,
-    EM_OFFSET_MAX_SPAWN, DRAW_INDEXED_INDIRECT_STRIDE,
-    EM_OFFSET_INDIRECT_WRITE_INDEX, EFFECT_METADATA_STRIDE
+    ChildInfo, ChildInfoBuffer, DispatchIndirectArgs, EffectMetadata, SimParams, Spawner,
+    DRAW_INDEXED_INDIRECT_STRIDE,
 }
 
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 
-// Tightly packed array of EffectMetadata[], accessed as u32 array.
-@group(1) @binding(0) var<storage, read_write> effect_metadata_buffer : array<u32>;
+@group(1) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>;
 // Tightly packed array of DrawIndexedIndirectArgs[], accessed as u32 array. This can contain
 // some DrawIndirectArgs[] instead, but in that case the stride is adjusted so all rows have
 // the same size. Since we access the instance_count, which is at the same position in both,
@@ -46,9 +43,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 #endif
 
     let spawner = &spawner_buffer[global_effect_index];
-
     let effect_metadata_index = (*spawner).effect_metadata_index;
-    let em_base = EFFECT_METADATA_STRIDE * effect_metadata_index;
 
     // Clear the rendering instance count, which will be upgraded by the update pass
     // with the particles actually alive at the end of their update (after aged).
@@ -56,8 +51,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let dri_base = DRAW_INDEXED_INDIRECT_STRIDE * draw_indirect_index;
     draw_indirect_buffer[dri_base + 1u] = 0u;
 
-    let capacity = effect_metadata_buffer[em_base + EM_OFFSET_CAPACITY];
-    let alive_count = effect_metadata_buffer[em_base + EM_OFFSET_ALIVE_COUNT];
+    let capacity = effect_metadatas[effect_metadata_index].capacity;
+    let alive_count = atomicLoad(&effect_metadatas[effect_metadata_index].alive_count); // atomic not needed
     let dead_count = capacity - alive_count;
 
     // Prepare to rebuild the prefix sum of active instances by storing in the prefix sum array
@@ -69,20 +64,20 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Update max_update from current value of alive_count, so that the
     // update pass coming next can cap its threads to this value, while also
     // atomically modifying alive_count itself for next frame.
-    effect_metadata_buffer[em_base + EM_OFFSET_MAX_UPDATE] = alive_count;
+    effect_metadatas[effect_metadata_index].max_update = alive_count;
 
     // Copy the number of dead particles to a constant location, so that the
     // init pass on next frame can atomically modify alive_count in parallel
     // yet still read its initial value at the beginning of the init pass,
     // and limit the number of particles spawned to the number of dead
     // particles to recycle.
-    effect_metadata_buffer[em_base + EM_OFFSET_MAX_SPAWN] = dead_count;
+    atomicStore(&effect_metadatas[effect_metadata_index].max_spawn, dead_count);  // atomic not needed
 
     // Swap ping/pong buffers. The update pass always writes into ping, and both the update
     // pass and the render pass always read from pong.
-    let ping = effect_metadata_buffer[em_base + EM_OFFSET_INDIRECT_WRITE_INDEX];
+    let ping = effect_metadatas[effect_metadata_index].indirect_write_index;
     let pong = 1u - ping;
-    effect_metadata_buffer[em_base + EM_OFFSET_INDIRECT_WRITE_INDEX] = pong;
+    effect_metadatas[effect_metadata_index].indirect_write_index = pong;
 
     // Copy the new pong into the spawner buffer, which will be used during rendering
     // to determine where to read particle indices.

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -65,9 +65,10 @@ fn find_location_from_particle(update_particle_index: u32) -> EffectLocation {
             return EffectLocation(0xDEADBEEFu, 0xDEADBEEFu, 0xDEADBEEFu);
         }
     }
-    let base_particle = prefix_sum[lo - 1u];
+    let base_index = prefix_sum[lo - 1u];
+    let update_index = update_particle_index - base_index;
     let effect_index = lo - 1u - batch_info.prefix_sum_offset;
-    let update_index = update_particle_index - base_particle;
+    let base_particle = spawners[batch_info.spawner_base + effect_index].slab_offset;
     return EffectLocation(effect_index, base_particle, update_index);
 }
 
@@ -102,6 +103,11 @@ var<private> properties_array_index: u32;
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Particle index in the packed init space of this batch.
     let update_particle_index = global_invocation_id.x;
+#ifndef CONSUME_GPU_SPAWN_EVENTS
+    if (update_particle_index >= batch_info.total_spawn_count) {
+        return;
+    }
+#endif
 
     // Find the index of the effect this particle is part of.
     let location = find_location_from_particle(update_particle_index);
@@ -111,8 +117,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Cap to max number of dead particles, copied from (capacity - alive_count) at the end
     // of the previous iteration, and constant during this pass (unlike alive_count).
-    let effect_metadata = &effect_metadatas[(*spawner).effect_metadata_index];
-    let max_spawn = atomicLoad(&(*effect_metadata).max_spawn);
+    let effect_metadata = &effect_metadatas[effect_metadata_index];
+    let max_spawn = atomicLoad(&(*effect_metadata).max_spawn);  // Not atomic
     if (location.update_index >= max_spawn) {
         return;
     }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -30,19 +30,31 @@ struct VertexOutput {
 #endif
 }
 
+// Global bindings
 @group(0) @binding(0) var<uniform> view: View;
 @group(0) @binding(1) var<uniform> sim_params : SimParams;
 
+// Per-batch bindings
 @group(1) @binding(0) var<storage, read> particle_buffer : ParticleBuffer;
 @group(1) @binding(1) var<storage, read> indirect_buffer : IndirectBuffer;
 
+#ifdef HAS_BATCHED_DRAW
+// Per-batch bindings
 // "spawner" group @2
 @group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
 @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
 @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
+#else
+// Per-effect bindings
+@group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
+@group(2) @binding(1) var<storage, read> batch_info : BatchInfo;
+#endif
 {{PROPERTIES_BINDING}}
 
+// Per-effect bindings
+#ifdef HAS_MATERIAL
 {{MATERIAL_BINDINGS}}
+#endif
 
 /// The resolved effect and particle location.
 ///
@@ -51,20 +63,17 @@ struct VertexOutput {
 var<private> effect_location : EffectLocation;
 
 var<private> effect_metadata_index: u32;
-// var<private> properties_array_index: u32;
-
-fn get_spawner_index() -> u32 {
-    return batch_info.spawner_base + effect_location.effect_index;
-}
+var<private> spawner_index: u32;
+// var<private> properties_offset: u32;
 
 fn get_camera_position_effect_space() -> vec3<f32> {
     let view_pos = view.world_from_view[3].xyz;
 #ifdef LOCAL_SPACE_SIMULATION
     let inverse_transform = transpose(
         mat3x3(
-            spawners[get_spawner_index()].inverse_transform[0].xyz,
-            spawners[get_spawner_index()].inverse_transform[1].xyz,
-            spawners[get_spawner_index()].inverse_transform[2].xyz,
+            spawners[spawner_index].inverse_transform[0].xyz,
+            spawners[spawner_index].inverse_transform[1].xyz,
+            spawners[spawner_index].inverse_transform[2].xyz,
         )
     );
     return inverse_transform * view_pos;
@@ -78,9 +87,9 @@ fn get_camera_rotation_effect_space() -> mat3x3<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
     let inverse_transform = transpose(
         mat3x3(
-            spawners[get_spawner_index()].inverse_transform[0].xyz,
-            spawners[get_spawner_index()].inverse_transform[1].xyz,
-            spawners[get_spawner_index()].inverse_transform[2].xyz,
+            spawners[spawner_index].inverse_transform[0].xyz,
+            spawners[spawner_index].inverse_transform[1].xyz,
+            spawners[spawner_index].inverse_transform[2].xyz,
         )
     );
     return inverse_transform * view_rot;
@@ -116,7 +125,7 @@ fn unpack_compressed_transform_3x3_transpose(compressed_transform: mat3x4<f32>) 
 /// the effect space (SimulationSpace::Local) or the world space (SimulationSpace::Global).
 fn transform_position_simulation_to_world(sim_position: vec3<f32>) -> vec4<f32> {
 #ifdef LOCAL_SPACE_SIMULATION
-    let transform = unpack_compressed_transform(spawners[get_spawner_index()].transform);
+    let transform = unpack_compressed_transform(spawners[spawner_index].transform);
     return transform * vec4<f32>(sim_position, 1.0);
 #else
     return vec4<f32>(sim_position, 1.0);
@@ -128,7 +137,7 @@ fn transform_normal_simulation_to_world(sim_normal: vec3<f32>) -> vec3<f32> {
     // We use the inverse transpose transform to transform normals.
     // The inverse transpose is the same as the transposed inverse, so we can
     // safely use the inverse transform.
-    let transform = unpack_compressed_transform_3x3_transpose(spawners[get_spawner_index()].inverse_transform);
+    let transform = unpack_compressed_transform_3x3_transpose(spawners[spawner_index].inverse_transform);
     return transform * sim_normal;
 #else
     return sim_normal;
@@ -166,6 +175,7 @@ struct EffectLocation {
     update_index: u32,
 }
 
+#ifdef HAS_BATCHED_DRAW
 /// Find the index of an effect from the index of a particle.
 ///
 /// This uses a binary search on the slab_offset field of the spawners array, which
@@ -192,11 +202,12 @@ fn find_location_from_particle(slab_particle_index: u32) -> EffectLocation {
             return EffectLocation(0xDEADBEEFu, 0xDEADBEEFu, 0xDEADBEEFu);
         }
     }
-    let base_particle = batch_info.base_particle + prefix_sum[lo - 1u];
     let effect_index = lo - 1u - batch_info.prefix_sum_offset;
-    let update_index = slab_particle_index - base_particle;
+    let update_index = slab_particle_index - prefix_sum[lo - 1u];
+    let base_particle = spawners[batch_info.spawner_base + effect_offset + effect_index].slab_offset;
     return EffectLocation(effect_index, base_particle, update_index);
 }
+#endif
 
 @vertex
 fn vertex(
@@ -211,17 +222,20 @@ fn vertex(
     // @location(1) vertex_color: u32,
     // @location(1) vertex_velocity: vec3<f32>,
 ) -> VertexOutput {
-    // Global particle index into the slab, including those particles from other
-    // effect instances in the same batch, as well as possibly from other batches.
-    // This is rarely useful on its own.
-    let slab_particle_index = batch_info.base_particle + instance_index;
-
     // Find the index of the effect this particle is part of. Note that currently
     // rendering is not yet batched, so this really derives into (effect_index = 0,
     // base_particle = batch_info.base_particle), and the binary search is a bit useless
     // until an actual batching is set up.
-    effect_location = find_location_from_particle(slab_particle_index);
-    let spawner = &spawners[get_spawner_index()];
+#ifdef HAS_BATCHED_DRAW
+    effect_location = find_location_from_particle(instance_index);
+    spawner_index = batch_info.spawner_base + effect_offset + effect_index;
+#else
+    effect_location.effect_index = 0u;
+    effect_location.base_particle = batch_info.base_particle;
+    effect_location.update_index = instance_index;
+    spawner_index = batch_info.spawner_base;
+#endif
+    let spawner = &spawners[spawner_index];
     effect_metadata_index = (*spawner).effect_metadata_index;
     let base_particle = effect_location.base_particle;
 

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -1,8 +1,13 @@
+/// Key-value pair to sort, with optional secondary key.
+///
+/// Sorting operates on the key (and the secondary key as discriminant, if present,
+/// and if the primary keys are equal). The value is carried over alongside the key(s),
+/// unmodified. It generally represents or indexes the payload associated with the key(s).
 struct KeyValuePair {
     /// Sorting key.
     key: u32,
 #ifdef HAS_DUAL_KEY
-    /// Secondary sorting key. Sorts value with the same primary key.
+    /// Secondary sorting key. Used for values with equal primary key.
     key2: u32,
 #endif
     /// Value associated with the sort key(s), generally an index to some other data.
@@ -10,8 +15,11 @@ struct KeyValuePair {
     value: u32,
 }
 
+/// Buffer of key-value pairs to sort.
 struct SortBuffer {
+    /// Number of items in the buffer.
     count: i32,
+    /// Pairs to sort. On output, contains the pairs in sorted order.
     pairs: array<KeyValuePair>,
 }
 
@@ -29,6 +37,69 @@ fn compare_greater(kv1: KeyValuePair, kv2: KeyValuePair) -> bool {
 }
 
 @group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
+
+/// Size of a block of KeyValuePair in workgroup memory.
+const blockSize: u32 = 512u;
+
+// Workgroup has at least 16kB memory (max_compute_workgroup_storage_size).
+// Note that Vulkan on Windows 11 report 16352, not 16384 (so, lower than
+// the default in the wgpu docs).
+var<workgroup> arr0 : array<KeyValuePair, blockSize>;
+var<workgroup> arr1 : array<KeyValuePair, blockSize>;
+
+/// Find the index of an effect from the index of a particle.
+///
+/// This uses a binary search on the slab_offset field of the spawners array, which
+/// represents a prefix sum of the particle count per effect (for previous effects;
+/// the value is actually the base particle so the first entry is always 0).
+fn find_effect_from_particle(num_effects: u32, particle_index: u32) -> u32 {
+    var lo = 0u;
+    var hi = num_effects;
+    var nnn = 0;
+    while (lo < hi) {
+        let mid = (hi + lo) >> 1u;
+        let base_particle = arr0[mid].key;
+        if (particle_index >= base_particle) {
+            lo = mid + 1u;
+        } else if (particle_index < base_particle) {
+            hi = mid;
+        }
+        nnn += 1;
+        if (nnn >= 100) {
+            return 0xDEADBEEFu;
+        }
+    }
+    return lo - 1u;
+}
+
+#ifdef TEST
+
+@compute @workgroup_size(64)
+fn test_find_effect_from_particle(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let tid = global_invocation_id.x;
+    if (tid >= 64) {
+        return;
+    }
+    
+    let num_particles = arrayLength(&sort_buffer.pairs);
+    let num_effects = u32(sort_buffer.count);
+
+    // Copy prefix sum into arr0[]
+    if (tid < num_effects) {
+        arr0[tid] = sort_buffer.pairs[tid];
+    }
+
+    workgroupBarrier();
+
+    let particle_per_thread = (num_particles + 63u) >> 6u;
+    let first_particle = particle_per_thread * tid;
+    let last_particle = min(first_particle + particle_per_thread, num_particles);
+    for (var i = first_particle; i < last_particle; i += 1u) {
+        sort_buffer.pairs[i].value = find_effect_from_particle(num_effects, i);
+    }
+}
+
+#endif
 
 /// Naive insertion sort. TODO: replace with something faster.
 @compute @workgroup_size(64)

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -77,9 +77,6 @@ fn find_effect_from_particle(num_effects: u32, particle_index: u32) -> u32 {
 @compute @workgroup_size(64)
 fn test_find_effect_from_particle(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let tid = global_invocation_id.x;
-    if (tid >= 64) {
-        return;
-    }
     
     let num_particles = arrayLength(&sort_buffer.pairs);
     let num_effects = u32(sort_buffer.count);
@@ -90,6 +87,11 @@ fn test_find_effect_from_particle(@builtin(global_invocation_id) global_invocati
     }
 
     workgroupBarrier();
+    
+    // Only branch after sync
+    if (tid >= 64) {
+        return;
+    }
 
     let particle_per_thread = (num_particles + 63u) >> 6u;
     let first_particle = particle_per_thread * tid;

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -23,14 +23,15 @@ struct IndirectIndexBuffer {
 @group(0) @binding(0) var<storage, read_write> indirect_index_buffer : IndirectIndexBuffer;
 @group(0) @binding(1) var<storage, read> sort_buffer : SortBuffer;
 // Technically read-only, but the type contains atomic<> fields and wasm is strict about it
-@group(0) @binding(2) var<storage, read_write> effect_metadata : EffectMetadata;
+@group(0) @binding(2) var<storage, read_write> effect_metadatas : array<EffectMetadata>;
 @group(0) @binding(3) var<storage, read> spawner : Spawner;
 
 /// Copy the sorted particle indices back into the effect index buffer.
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let row_index = global_invocation_id.x;
-    let count = atomicLoad(&effect_metadata.alive_count); // TODO - atomic not needed
+    let effect_metadata_index = spawner.effect_metadata_index;
+    let count = atomicLoad(&effect_metadatas[effect_metadata_index].alive_count); // TODO - atomic not needed
     if (row_index >= count) {
         return;
     }
@@ -39,7 +40,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Write the particle index back into the same ping-pong column index we read it from
     // in vfx_sort_fill. Sorting is optional and shouldn't influence that ping-pong logic.
-    let write_index = effect_metadata.indirect_write_index;
+    let write_index = effect_metadatas[effect_metadata_index].indirect_write_index;
 
     let particle_index = sort_buffer.pairs[row_index].value;
     indirect_index_buffer.data[(base_particle + row_index) * 3u + write_index] = particle_index;

--- a/src/render/vfx_sort_fill.wgsl
+++ b/src/render/vfx_sort_fill.wgsl
@@ -26,14 +26,15 @@ struct RawParticleBuffer {
 @group(0) @binding(1) var<storage, read> particle_buffer : RawParticleBuffer;
 @group(0) @binding(2) var<storage, read> indirect_index_buffer : array<u32>;
 // Technically read-only, but the type contains atomic<> fields and wasm is strict about it
-@group(0) @binding(3) var<storage, read_write> effect_metadata : EffectMetadata;
+@group(0) @binding(3) var<storage, read_write> effect_metadatas : array<EffectMetadata>;
 @group(0) @binding(4) var<storage, read> spawner : Spawner;
 
 /// Fill the sorting key-value pair buffer with data to prepare for actual sorting.
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let thread_index = global_invocation_id.x;
-    let count = atomicLoad(&effect_metadata.alive_count); // TODO - atomic not needed
+    let effect_metadata_index = spawner.effect_metadata_index;
+    let count = atomicLoad(&effect_metadatas[effect_metadata_index].alive_count); // TODO - atomic not needed
     if (thread_index >= count) {
         return;
     }
@@ -43,12 +44,12 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Read the particle index from the ping-pong column index written this frame by vfx_update.
     // After sorting we will write back into that same column, so that the sorting effectively
     // sorted the column in-place (no ping-pong column swap here).
-    let read_index = effect_metadata.indirect_write_index;
+    let read_index = effect_metadatas[effect_metadata_index].indirect_write_index;
     let particle_index = indirect_index_buffer[(base_particle + thread_index) * 3u + read_index];
 
-    let particle_offset = (base_particle + particle_index) * effect_metadata.particle_stride;
-    let key_offset = particle_offset + effect_metadata.sort_key_offset;
-    let key2_offset = particle_offset + effect_metadata.sort_key2_offset;
+    let particle_offset = (base_particle + particle_index) * effect_metadatas[effect_metadata_index].particle_stride;
+    let key_offset = particle_offset + effect_metadatas[effect_metadata_index].sort_key_offset;
+    let key2_offset = particle_offset + effect_metadatas[effect_metadata_index].sort_key2_offset;
 
     let pair_index = atomicAdd(&sort_buffer.count, 1);
     sort_buffer.pairs[pair_index].key = particle_buffer.data[key_offset];

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -65,9 +65,10 @@ fn find_location_from_particle(update_particle_index: u32) -> EffectLocation {
             return EffectLocation(0xDEADBEEFu, 0xDEADBEEFu, 0xDEADBEEFu);
         }
     }
-    let base_particle = prefix_sum[lo - 1u];
+    let base_index = prefix_sum[lo - 1u];
+    let update_index = update_particle_index - base_index;
     let effect_index = lo - 1u - batch_info.prefix_sum_offset;
-    let update_index = update_particle_index - base_particle;
+    let base_particle = spawners[batch_info.spawner_base + effect_index].slab_offset;
     return EffectLocation(effect_index, base_particle, update_index);
 }
 
@@ -106,13 +107,15 @@ var<private> properties_array_index: u32;
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Particle index in the packed update space of this batch.
     let update_particle_index = global_invocation_id.x;
+    if (update_particle_index >= batch_info.total_update_count) {
+        return;
+    }
 
     // Find the index of the effect this particle is part of.
     let location = find_location_from_particle(update_particle_index);
     let spawner = &spawners[batch_info.spawner_base + location.effect_index];
     effect_metadata_index = (*spawner).effect_metadata_index;
     let base_particle = (*spawner).slab_offset;
-    let slab_particle_index = base_particle + location.update_index;
 
     // Cap at maximum number of alive particles for the current effect
     let effect_metadata = &effect_metadatas[effect_metadata_index];
@@ -127,7 +130,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // This is the actual particle index, from the indirection buffer, addressing an
     // actually alive particle.
     let particle_index = indirect_buffer
-        .rows[slab_particle_index]
+        .rows[base_particle + location.update_index]
         .particle_index[read_index];
 
 #ifdef READ_PARENT_PARTICLE


### PR DESCRIPTION
Bind the `EffectMetadata` struct describing the per-effect-instance data as an array. This allows compacting the struct and avoiding device-mandated padding. This also greatly simplifies the `vfx_indirect` shader which know can use the typed struct instead of manipulating type-erased `u32`/`f32` values.

Fix missing GPU thread capping in CPU-based init and in update passes, to early out when the thread has no particle to process, instead of doing a useless binary search. GPU-based init continues to do the binary search, which is anyway currently operating on a single-element array (no GPU event batching).

Update the `instancing` example to use properties per effect, to prove property batching works.