### PR TITLE
Fix two `SimulationSpace::Local` transform bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where some GPU operations queued with a buffer reference could be reused
   after the buffer was reallocated, leading to use-after-free (stale data) on GPU.
 - Fixed a double-free of a GPU buffer when despawning a particle effect with a child effect. (#510)
+- Fixed camera-oriented particles (`OrientMode::FaceCameraPosition`, `OrientMode::AlongVelocity`)
+  in `SimulationSpace::Local` effects not tracking the camera when the emitter is away from
+  the world origin or rotated.
+- Fixed `SimulationSpace::Local` effects applying the emitter transform twice to
+  `SetPositionCone3dModifier`, `SetVelocityCircleModifier`, and `SetVelocityTangentModifier`.
+  Local-space effects with a rotated, scaled, or off-origin emitter may render differently
+  than before; this is the corrected behavior.
 
 ## [0.19.0] 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where some GPU operations queued with a buffer reference could be reused
   after the buffer was reallocated, leading to use-after-free (stale data) on GPU.
 - Fixed a double-free of a GPU buffer when despawning a particle effect with a child effect. (#510)
-- Fixed camera-oriented particles (`OrientMode::FaceCameraPosition`, `OrientMode::AlongVelocity`)
-  in `SimulationSpace::Local` effects not tracking the camera when the emitter is away from
-  the world origin or rotated.
+- Fixed the camera position in effect space used by camera-oriented particles
+  (`OrientMode::FaceCameraPosition`, `OrientMode::AlongVelocity`) in
+  `SimulationSpace::Local` effects: the emitter translation was ignored, most noticeable when emitter is far from origin.
 - Fixed `SimulationSpace::Local` effects applying the emitter transform twice to
   `SetPositionCone3dModifier`, `SetVelocityCircleModifier`, and `SetVelocityTangentModifier`.
   Local-space effects with a rotated, scaled, or off-origin emitter may render differently

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,10 +518,9 @@ pub enum SimulationSpace {
 impl SimulationSpace {
     /// Evaluate the simulation space expression.
     ///
-    /// - In the init context, [`SimulationSpace::Global`] converts the particle
-    ///   from emitter (spawn) space into simulation space. Local is a no-op.
-    /// - In the update context, this expression transforms the particle's
-    ///   position from simulation space to storage space.
+    /// - Init: [`SimulationSpace::Global`] converts emitter space to simulation
+    ///   space; [`SimulationSpace::Local`] is a no-op.
+    /// - Update: no-op. Particles are already in simulation space.
     /// - In the render context, this expression transforms the particle's
     ///   position from simulation space to view space.
     pub fn eval(&self, context: &dyn EvalContext) -> Result<String, ExprError> {
@@ -547,18 +546,7 @@ impl SimulationSpace {
                 }
                 SimulationSpace::Local => Ok("".to_string()),
             },
-            ModifierContext::Update => match *self {
-                SimulationSpace::Global => {
-                    if !context.particle_layout().contains(Attribute::POSITION) {
-                        return Err(ExprError::GraphEvalError(format!("Global-space simulation requires that the particles have a {} attribute.", Attribute::POSITION.name())));
-                    }
-                    Ok(format!(
-                        "particle.{} += transform[3].xyz;", // TODO: get_view_position()
-                        Attribute::POSITION.name()
-                    ))
-                }
-                SimulationSpace::Local => Ok("".to_string()),
-            },
+            ModifierContext::Update => Ok(String::new()),
             ModifierContext::Render => Ok(match *self {
                 // TODO: cast vec3 -> vec4 auomatically
                 SimulationSpace::Global => "vec4<f32>(local_position, 1.0)",
@@ -2423,9 +2411,9 @@ else { return c1; }
         let property_layout = PropertyLayout::default();
         let texture_layout = TextureLayout::default();
         {
-            // Local is always available
+            // Global init requires storing the particle's position
             let ctx = ShaderWriter::new(
-                ModifierContext::Update,
+                ModifierContext::Init,
                 &property_layout,
                 &particle_layout,
                 &texture_layout,
@@ -2433,10 +2421,9 @@ else { return c1; }
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_err());
 
-            // Global requires storing the particle's position
             let particle_layout = ParticleLayout::new().append(Attribute::POSITION).build();
             let ctx = ShaderWriter::new(
-                ModifierContext::Update,
+                ModifierContext::Init,
                 &property_layout,
                 &particle_layout,
                 &texture_layout,
@@ -2445,17 +2432,15 @@ else { return c1; }
             assert!(SimulationSpace::Global.eval(&ctx).is_ok());
         }
         {
-            // Local is always available
             let ctx = ShaderWriter::new(
                 ModifierContext::Update,
                 &property_layout,
                 &particle_layout,
                 &texture_layout,
             );
-            assert!(SimulationSpace::Local.eval(&ctx).is_ok());
-            assert!(SimulationSpace::Global.eval(&ctx).is_err());
+            assert_eq!(SimulationSpace::Local.eval(&ctx).unwrap(), "");
+            assert_eq!(SimulationSpace::Global.eval(&ctx).unwrap(), "");
 
-            // Global requires storing the particle's position
             let particle_layout = ParticleLayout::new().append(Attribute::POSITION).build();
             let ctx = ShaderWriter::new(
                 ModifierContext::Update,
@@ -2463,8 +2448,8 @@ else { return c1; }
                 &particle_layout,
                 &texture_layout,
             );
-            assert!(SimulationSpace::Local.eval(&ctx).is_ok());
-            assert!(SimulationSpace::Global.eval(&ctx).is_ok());
+            assert_eq!(SimulationSpace::Local.eval(&ctx).unwrap(), "");
+            assert_eq!(SimulationSpace::Global.eval(&ctx).unwrap(), "");
         }
         {
             // In the render context, the particle position is always available (either

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,13 +518,36 @@ pub enum SimulationSpace {
 impl SimulationSpace {
     /// Evaluate the simulation space expression.
     ///
-    /// - In the init and udpate contexts, this expression transforms the
-    ///   particle's position from simulation space to storage space.
+    /// - In the init context, [`SimulationSpace::Global`] converts the particle
+    ///   from emitter (spawn) space into simulation space. Local is a no-op.
+    /// - In the update context, this expression transforms the particle's
+    ///   position from simulation space to storage space.
     /// - In the render context, this expression transforms the particle's
     ///   position from simulation space to view space.
     pub fn eval(&self, context: &dyn EvalContext) -> Result<String, ExprError> {
         match context.modifier_context() {
-            ModifierContext::Init | ModifierContext::Update => match *self {
+            ModifierContext::Init => match *self {
+                SimulationSpace::Global => {
+                    if !context.particle_layout().contains(Attribute::POSITION) {
+                        return Err(ExprError::GraphEvalError(format!("Global-space simulation requires that the particles have a {} attribute.", Attribute::POSITION.name())));
+                    }
+                    let pos = Attribute::POSITION.name();
+                    let mut code = format!(
+                        "particle.{0} = (transform * vec4<f32>(particle.{0}, 1.0)).xyz;\n",
+                        pos
+                    );
+                    if context.particle_layout().contains(Attribute::VELOCITY) {
+                        let vel = Attribute::VELOCITY.name();
+                        code.push_str(&format!(
+                            "particle.{0} = (transform * vec4<f32>(particle.{0}, 0.0)).xyz;\n",
+                            vel
+                        ));
+                    }
+                    Ok(code)
+                }
+                SimulationSpace::Local => Ok("".to_string()),
+            },
+            ModifierContext::Update => match *self {
                 SimulationSpace::Global => {
                     if !context.particle_layout().contains(Attribute::POSITION) {
                         return Err(ExprError::GraphEvalError(format!("Global-space simulation requires that the particles have a {} attribute.", Attribute::POSITION.name())));
@@ -2451,6 +2474,30 @@ else { return c1; }
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_ok());
         }
+    }
+
+    #[test]
+    fn test_simulation_space_init_spawn_to_sim() {
+        let property_layout = PropertyLayout::default();
+        let texture_layout = TextureLayout::default();
+        let particle_layout = ParticleLayout::new()
+            .append(Attribute::POSITION)
+            .append(Attribute::VELOCITY)
+            .build();
+        let ctx = ShaderWriter::new(
+            ModifierContext::Init,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
+
+        let global = SimulationSpace::Global.eval(&ctx).unwrap();
+        assert!(global.contains("vec4<f32>(particle.position, 1.0)"));
+        assert!(global.contains("vec4<f32>(particle.velocity, 0.0)"));
+        assert!(!global.contains("transform[3]"));
+
+        let local = SimulationSpace::Local.eval(&ctx).unwrap();
+        assert!(local.is_empty());
     }
 
     fn make_test_app() -> App {

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -1167,7 +1167,6 @@ struct Particle {{
 @compute @workgroup_size(64)
 fn main() {{
     var particle = Particle();
-    var transform: mat4x4<f32> = mat4x4<f32>();
 {main_code}
 }}"##
             );
@@ -1303,7 +1302,6 @@ fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {{
 @compute @workgroup_size(64)
 fn main() {{
     var particle: Particle = particle_buffer.particles[0];
-    var transform: mat4x4<f32> = mat4x4<f32>();
     var is_alive = true;
 {update_code}
 }}"##

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -644,7 +644,8 @@ axis_z = cam_rot[2].xyz;
 let particle_rot_in_cam_space = {};
 let particle_rot_in_cam_space_cos = cos(particle_rot_in_cam_space);
 let particle_rot_in_cam_space_sin = sin(particle_rot_in_cam_space);
-let axis_x0 = normalize(cross(view.world_from_view[1].xyz, axis_z));
+let cam_up = get_camera_rotation_effect_space()[1];
+let axis_x0 = normalize(cross(cam_up, axis_z));
 let axis_y0 = cross(axis_z, axis_x0);
 axis_x = axis_x0 * particle_rot_in_cam_space_cos + axis_y0 * particle_rot_in_cam_space_sin;
 axis_y = axis_x0 * particle_rot_in_cam_space_sin - axis_y0 * particle_rot_in_cam_space_cos;
@@ -653,7 +654,8 @@ axis_y = axis_x0 * particle_rot_in_cam_space_sin - axis_y0 * particle_rot_in_cam
                     );
                 } else {
                     context.vertex_code += r#"axis_z = normalize(get_camera_position_effect_space() - position);
-axis_x = normalize(cross(view.world_from_view[1].xyz, axis_z));
+let cam_up = get_camera_rotation_effect_space()[1];
+axis_x = normalize(cross(cam_up, axis_z));
 axis_y = cross(axis_z, axis_x);
 "#;
                 }
@@ -1131,6 +1133,9 @@ mod tests {
         assert!(context
             .vertex_code
             .contains("get_camera_position_effect_space"));
+        assert!(context
+            .vertex_code
+            .contains("get_camera_rotation_effect_space"));
         assert!(context
             .vertex_code
             .contains("cos(particle_rot_in_cam_space)"));

--- a/src/modifier/position.rs
+++ b/src/modifier/position.rs
@@ -276,7 +276,7 @@ impl SetPositionCone3dModifier {
 
         context.make_fn(
             &func_name,
-            "transform: mat4x4<f32>, particle: ptr<function, Particle>",
+            "particle: ptr<function, Particle>",
             None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
@@ -309,9 +309,7 @@ impl SetPositionCone3dModifier {
     let x = r * cost;
     let y = h;
     let z = r * sint;
-    let p = vec3<f32>(x, y, z);
-    let p2 = transform * vec4<f32>(p, 0.0);
-    (*particle).{3} = p2.xyz;
+    (*particle).{3} = vec3<f32>(x, y, z);
 "##,
                     height,
                     top_radius,
@@ -321,7 +319,7 @@ impl SetPositionCone3dModifier {
             },
         )?;
 
-        let code = format!("{}(transform, &particle);\n", func_name);
+        let code = format!("{}(&particle);\n", func_name);
 
         Ok(code)
     }

--- a/src/modifier/velocity.rs
+++ b/src/modifier/velocity.rs
@@ -52,7 +52,7 @@ impl SetVelocityCircleModifier {
 
         context.make_fn(
             &func_name,
-            "transform: mat4x4<f32>, particle: ptr<function, Particle>",
+            "particle: ptr<function, Particle>",
             None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
@@ -63,8 +63,7 @@ impl SetVelocityCircleModifier {
                 Ok(format!(
                     r##"    let delta = (*particle).{0} - ({1});
     let radial = normalize(delta - dot(delta, {2}) * ({2}));
-    let radial_vec4 = transform * vec4<f32>(radial.xyz, 0.0);
-    (*particle).{3} = radial_vec4.xyz * ({4});
+    (*particle).{3} = radial * ({4});
 "##,
                     Attribute::POSITION.name(),
                     center,
@@ -75,7 +74,7 @@ impl SetVelocityCircleModifier {
             },
         )?;
 
-        let code = format!("{}(transform, &particle);\n", func_name);
+        let code = format!("{}(&particle);\n", func_name);
 
         Ok(code)
     }
@@ -196,7 +195,7 @@ impl SetVelocityTangentModifier {
 
         context.make_fn(
             &func_name,
-            "transform: mat4x4<f32>, particle: ptr<function, Particle>",
+            "particle: ptr<function, Particle>",
             None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
@@ -207,8 +206,7 @@ impl SetVelocityTangentModifier {
                 Ok(format!(
                     r##"    let radial = (*particle).{0} - ({1});
     let tangent = normalize(cross({2}, radial));
-    let tangent_vec4 = transform * vec4<f32>(tangent.xyz, 0.0);
-    (*particle).{3} = tangent_vec4.xyz * ({4});
+    (*particle).{3} = tangent * ({4});
 "##,
                     Attribute::POSITION.name(),
                     origin,
@@ -219,7 +217,7 @@ impl SetVelocityTangentModifier {
             },
         )?;
 
-        let code = format!("{}(transform, &particle);\n", func_name);
+        let code = format!("{}(&particle);\n", func_name);
 
         Ok(code)
     }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -65,14 +65,8 @@ var<private> spawner_index: u32;
 fn get_camera_position_effect_space() -> vec3<f32> {
     let view_pos = view.world_from_view[3].xyz;
 #ifdef LOCAL_SPACE_SIMULATION
-    let inverse_transform = transpose(
-        mat3x3(
-            spawners[spawner_index].inverse_transform[0].xyz,
-            spawners[spawner_index].inverse_transform[1].xyz,
-            spawners[spawner_index].inverse_transform[2].xyz,
-        )
-    );
-    return inverse_transform * view_pos;
+    let inverse_transform = unpack_compressed_transform(spawners[spawner_index].inverse_transform);
+    return (inverse_transform * vec4<f32>(view_pos, 1.0)).xyz;
 #else
     return view_pos;
 #endif


### PR DESCRIPTION
TL;DR: In pursuit of these Elodin features ([new example](https://github.com/elodin-sys/elodin/pull/745), [effects tool](https://github.com/elodin-sys/pyrotechnique)), I discovered 2 transform bugs that manifest with emitters that are very far from the origin. This PR attempts to fix them in a maintainer acceptable manner. Happy to adjust as directed.

## Summary

Two independent bugs in how `SimulationSpace::Local` handles the emitter
transform. Both are invisible when the emitter sits at the world origin without
rotation, which is how every example is set up, and both become obvious as soon
as the emitter moves or turns:

1. The camera is converted into effect space with only the rotation part of the
   inverse emitter transform, so camera-oriented particles stop tracking the
   camera as the emitter moves away from the world origin.
2. The init pass applies the emitter transform to shape modifiers and the render
   pass applies it again, so a rotated local-space emitter spawns its shape
   rotated twice.

I found these building a spacecraft visualization where the emitters are
far from the origin and pitch during flight. Each fix is one commit, with
tests and changelog in their own commits.

## 1. Camera position in effect space ignores the emitter translation

`get_camera_position_effect_space()` reconstructs the inverse emitter transform
from the 3x3 block only:

```wgsl
let inverse_transform = transpose(mat3x3(
    spawners[spawner_index].inverse_transform[0].xyz,
    spawners[spawner_index].inverse_transform[1].xyz,
    spawners[spawner_index].inverse_transform[2].xyz,
));
return inverse_transform * view_pos;
```

An affine inverse is `R^-1 * (cam - T)`; this computes `R^-1 * cam`. In effect
space the camera therefore appears where the *world* camera is, not where it is
relative to the emitter. `OrientMode::FaceCameraPosition` and
`OrientMode::AlongVelocity` end up orienting against `normalize(T + offset)`
instead of `normalize(offset)`, so once `|T|` exceeds the camera distance the
direction barely changes as the camera moves: billboards face a fixed world
direction and can be seen edge-on.

`GpuSpawnerParams::new()` already uploads the full inverse affine, and the
shader already has `unpack_compressed_transform()` for exactly this, so the fix
just uses it.

Repro on top of `main`, putting the stock `billboard` example 10 km from the
origin in local space (camera and ground move with it, so framing is unchanged):

```diff
--- a/examples/billboard.rs
+++ b/examples/billboard.rs
+const FAR: Vec3 = Vec3::new(0.0, 0.0, 10_000.0);
+
 fn setup(
     ...
     commands.spawn((
-        Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Transform::from_translation(FAR + Vec3::new(3.0, 3.0, 3.0)).looking_at(FAR, Vec3::Y),
         Camera3d::default(),
@@
         EffectAsset::new(32768, SpawnerSettings::rate(64.0.into()), module)
             .with_name("billboard")
+            .with_simulation_space(SimulationSpace::Local)
@@
     // The ground
     commands.spawn((
-        Transform::from_xyz(0.0, -0.5, 0.0)
+        Transform::from_translation(FAR + Vec3::new(0.0, -0.5, 0.0))
             * Transform::from_rotation(Quat::from_rotation_x(-FRAC_PI_2)),
@@
     commands.spawn((
         ParticleEffect::new(effect),
+        Transform::from_translation(FAR),
         EffectMaterial {
@@
 fn rotate_camera(...) {
-    **camera_transform =
-        Transform::from_xyz(c * radius_xz, 3.0, s * radius_xz).looking_at(Vec3::ZERO, Vec3::Y)
+    **camera_transform =
+        Transform::from_translation(FAR + Vec3::new(c * radius_xz, 3.0, s * radius_xz))
+            .looking_at(FAR, Vec3::Y)
 }
```

Same patch, same frame, `main` vs this branch:

| before | after |
|---|---|
| <img width="2560" height="1440" alt="billboard-before" src="https://github.com/user-attachments/assets/90401d24-e106-43b9-b7ad-b6339cc11a2c" /> | <img width="2560" height="1440" alt="billboard-after" src="https://github.com/user-attachments/assets/31bc3909-f06d-4a1c-a110-551e5c941cd4" /> |

## 2. `FaceCameraPosition` builds its up axis in world space

Adjacent to the above, and in the same commit. The generated code crossed the
(effect-space) view vector with a world-space up vector:

```rust
axis_x = normalize(cross(view.world_from_view[1].xyz, axis_z));
```

With an unrotated emitter the two frames coincide, so this looks fine; with a
rotated one the billboard basis picks up a roll that grows with the rotation.
`get_camera_rotation_effect_space()` already exists and already handles the
local/global split, so the fix is to use it for the up axis.

Note that `get_camera_rotation_effect_space()` itself is left alone: it returns
a rotation, so the 3x3 block is the correct and complete inverse there.

## 3. Local-space init applies the emitter transform twice

Shape modifiers that need an orientation take the spawner transform as a
parameter and apply it with `w = 0`, contributing rotation and scale:

```wgsl
let p2 = transform * vec4<f32>(p, 0.0);
(*particle).position = p2.xyz;
```

`vfx_init.wgsl` passed the world spawner transform for every simulation space.
For `SimulationSpace::Local` the render pass then applies the same transform
again, so particles are stored at `R*p` and drawn at `R*(R*p)`. With an
unrotated emitter `R` is identity and `R*R == R`, which is why this has gone
unnoticed.

Affected modifiers are the ones that receive the transform:
`SetPositionCone3dModifier`, `SetVelocityCircleModifier`, and
`SetVelocityTangentModifier`. Global space keeps the world transform, since its
shape modifiers place geometry in world orientation and the generated
simulation-space snippet reads `transform[3].xyz` for the translation.

The init shader had no `LOCAL_SPACE_SIMULATION` shader def, so the fix threads
it through `ParticleInitPipelineKeyFlags` to keep local- and global-space
effects on distinct specialized init pipelines.

Repro on top of `main`, giving the stock `init` example a fixed tilt so the
emitter is already rotated when the particles spawn:

```diff
--- a/examples/init.rs
+++ b/examples/init.rs
 fn rotate_effect(time: Res<Time>, mut query: Query<(&RotateSpeed, &mut Transform)>) {
     for (speed, mut transform) in &mut query {
-        let a = (time.elapsed_secs() * 0.1 * speed.0) * PI;
-        *transform = Transform::from_rotation(Quat::from_rotation_y(a));
+        *transform = Transform::from_rotation(Quat::from_rotation_z(PI / 4.0));
     }
 }
```

The emitter is tilted 45 degrees. Before, the cone is drawn at 90 degrees, i.e.
rotated twice; after, it matches the emitter. The circle and sphere shapes do
not take the transform, and are identical in both, which isolates the cause:

| before | after |
|---|---|
| <img width="2560" height="1440" alt="init-before" src="https://github.com/user-attachments/assets/21ffc209-5eaf-47bd-9665-8715fb244f74" /> | <img width="2560" height="1440" alt="init-after" src="https://github.com/user-attachments/assets/ba21504d-e7b9-42a7-92a2-eec6ed374041" /> |

## Behavior change

This changes how existing local-space effects render whenever the emitter is
rotated, scaled, or far from the origin. Content that was authored around the
old behavior (compensating for a doubled rotation, or for billboards facing the
world origin) will look different. Global-space effects and local-space effects
on an unrotated emitter at the origin are unaffected: every change is inside
`#ifdef LOCAL_SPACE_SIMULATION`.

As a check on that, the unmodified `init` example (local space, animated
rotation) was captured on `main` and on this branch: the two differ by fewer
pixels than two runs of the same build differ from each other, because that
example spawns its particles while the emitter is still at rest.

## Tests

Both are CPU-only, so they run in the no-GPU CI job:

- `spawner_inverse_transform_is_full_affine` locks the contract the render
  shader now relies on: unpacking the uploaded inverse as a 4x4 and applying it
  to the emitter position yields the effect-space origin. Reconstructing only
  the 3x3 block silently drops that.
- `init_pipeline_local_space_shader_def` checks `LOCAL_SPACE_SIMULATION` reaches
  the init pipeline specialization, and is absent otherwise.

The existing `OrientModifier` codegen test also now asserts the generated shader
uses `get_camera_rotation_effect_space()`.

I did not add an example: the bugs need a large translation or a rotation to be
visible, both repros above are a few lines on existing examples, and the
`run-examples` job is already long.

## Verification

Ran the CI matrix locally on macOS (Apple M2 Max, Metal), all passing:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`
- `cargo test --lib --no-default-features --features 2d`, `3d`, and `"2d 3d"`
- `WGPU_BACKEND=metal cargo test --no-default-features --features "2d 3d gpu_tests"`
- `cargo check --lib --all-features` on 1.95 (MSRV)
- `cargo check --target wasm32-unknown-unknown --no-default-features --features 2d,3d`

## Notes for review

- The identity matrix in the local-space init branch keeps a single code path
  through the shape modifiers; it is a constant, so the multiply folds away.
- `get_camera_position_effect_space()` calls `unpack_compressed_transform()`,
  which is defined further down the file. That is valid WGSL (module-scope
  declarations are in scope for the whole program) and naga accepts it, so I
  left the helper where it is rather than reordering and adding diff noise. Say
  the word if you would rather have it moved.
- Happy to split this into two PRs if you prefer to take them separately.

_Disclosure: while this work was done with some AI assistance; the analysis, repros, and
verification above are mine and were run locally and against use in Elodin to verify fix robustness._