### PR TITLE
Parallelize GPU sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   taking full advantage of all GPU threads to process the init/update of all particles in parallel.
   Batching is still limited to same-effect instances (same `EffectAsset`), and is currently not
   available for GPU particle spawning.
+- Parallelized most of the GPU sort. This dramatically improves performance when using ribbon effects.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.19.0"
+version = "0.19.1-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 rust-version = "1.95.0"

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -90,7 +90,7 @@ fn create_head_effect() -> EffectAsset {
     // Spawn a trail of child body particles into the other effect
     let update_spawn_trail = EmitSpawnEventModifier {
         condition: EventEmitCondition::Always,
-        count: writer.lit(5u32).expr(),
+        count: writer.lit(1u32).expr(),
         // We use channel #0; see EffectParent
         child_index: 0,
     };
@@ -170,7 +170,8 @@ fn create_body_effect() -> EffectAsset {
     let module = writer.finish();
 
     // Allocate room for 500 trail particles
-    EffectAsset::new(5000, SpawnerSettings::rate(0.5.into()), module)
+    let dummy = SpawnerSettings::default(); // unused; uses GPU spawn events
+    EffectAsset::new(5000, dummy, module)
         .with_name("worms_bodies")
         // Body particles don't move. No need to integrate anything (particles don't have any
         // VELOCITY attribute anyway, so that would generate a warning).

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -56,6 +56,10 @@ use crate::{
 pub(crate) const VFX_SORT_WGSL: Cow<'static, str> =
     Cow::Borrowed(include_str!("render/vfx_sort.wgsl"));
 
+/// Source code for the `vfx_sort_merge` compute shader.
+pub(crate) const VFX_SORT_MERGE_WGSL: Cow<'static, str> =
+    Cow::Borrowed(include_str!("render/vfx_sort_merge.wgsl"));
+
 /// Labels for the Hanabi systems.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub enum EffectSystems {
@@ -283,6 +287,7 @@ impl Plugin for HanabiPlugin {
             prefix_sum_shader,
             sort_fill_shader,
             sort_shader,
+            sort_merge_shader,
             sort_copy_shader,
         ) = {
             let align = render_device.limits().min_storage_buffer_offset_alignment;
@@ -305,6 +310,14 @@ impl Plugin for HanabiPlugin {
                     .join("render/vfx_sort.wgsl")
                     .to_string_lossy(),
             );
+            let sort_merge_shader = Shader::from_wgsl(
+                VFX_SORT_MERGE_WGSL,
+                std::path::Path::new(file!())
+                    .parent()
+                    .unwrap()
+                    .join("render/vfx_sort_merge.wgsl")
+                    .to_string_lossy(),
+            );
             let sort_copy_shader = Shader::from_wgsl(
                 include_str!("render/vfx_sort_copy.wgsl"),
                 std::path::Path::new(file!())
@@ -320,6 +333,7 @@ impl Plugin for HanabiPlugin {
             let prefix_sum_shader = assets.add(prefix_sum_shader);
             let sort_fill_shader = assets.add(sort_fill_shader);
             let sort_shader = assets.add(sort_shader);
+            let sort_merge_shader = assets.add(sort_merge_shader);
             let sort_copy_shader = assets.add(sort_copy_shader);
 
             (
@@ -328,6 +342,7 @@ impl Plugin for HanabiPlugin {
                 prefix_sum_shader,
                 sort_fill_shader,
                 sort_shader,
+                sort_merge_shader,
                 sort_copy_shader,
             )
         };
@@ -348,6 +363,7 @@ impl Plugin for HanabiPlugin {
             render_app.world_mut(),
             sort_fill_shader,
             sort_shader,
+            sort_merge_shader,
             sort_copy_shader,
         );
 

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -128,6 +128,7 @@ pub(crate) struct BatchEffectData {
     pub draw_indirect_buffer_row_index: BufferTableId,
     pub metadata_table_id: BufferTableId,
     pub sort_fill_indirect_dispatch_index: Option<u32>,
+    pub sort_indirect_dispatch_index: Option<u32>,
     /// Offset in bytes of the [`GpuBatchInfo`] into the
     /// [`Batcher::batch_info_buffer`], which contains the location of the
     /// particles to render for this effect instance. Ready for bind group
@@ -143,6 +144,8 @@ pub(crate) struct EffectBatch {
     /// Handle of the underlying effect asset describing the effect. The batch
     /// only contains effect instances of the same asset.
     pub handle: Handle<EffectAsset>,
+    /// Effect instance capacity, in number of particles.
+    pub capacity: u32,
     /// ID of the particle slab in the [`EffectBuffer`] where all the batched
     /// effects are stored.
     ///
@@ -249,10 +252,13 @@ pub(crate) struct Batcher {
     batches: Vec<EffectBatch>,
     /// Index of the dispatch queue used for indirect fill dispatch and
     /// submitted to [`GpuBufferOperations`].
-    pub(super) dispatch_queue_index: Option<u32>,
+    pub(super) fill_dispatch_queue_index: Option<u32>,
     /// Index of the queue which copies post-update alive counts into the prefix
     /// sum buffer before the ribbon sort prefix sum pass.
     pub(super) sort_fill_prefix_sum_queue_index: Option<u32>,
+    /// Index of the dispatch queue used for indirect fill dispatch of the sort
+    /// pass, and submitted to [`GpuBufferOperations`].
+    pub(super) sort_dispatch_queue_index: Option<u32>,
     /// Global shared GPU buffer storing the various `BatchInfo` structs for the
     /// active batches. This is dynamically updated each frame based on current
     /// batching, with one entry per batch (= one entry per dispatch/draw).
@@ -281,8 +287,9 @@ impl FromWorld for Batcher {
         prefix_sum_buffer.set_label(Some("prefix_sum_buffer"));
         Self {
             batches: vec![],
-            dispatch_queue_index: None,
+            fill_dispatch_queue_index: None,
             sort_fill_prefix_sum_queue_index: None,
+            sort_dispatch_queue_index: None,
             batch_info_buffer,
             is_batch_open: false,
             prefix_sum_buffer,
@@ -309,8 +316,9 @@ impl Batcher {
 
     pub fn clear(&mut self) {
         self.batches.clear();
-        self.dispatch_queue_index = None;
+        self.fill_dispatch_queue_index = None;
         self.sort_fill_prefix_sum_queue_index = None;
+        self.sort_dispatch_queue_index = None;
         self.prefix_sum_buffer.clear();
         self.batch_info_buffer.clear();
     }
@@ -758,6 +766,7 @@ impl EffectBatch {
         EffectBatch {
             batch_info_id: u32::MAX, // allocated later once the batch is completed
             handle: extracted_effect.handle.clone(),
+            capacity: extracted_effect.capacity,
             slab_id: input.effect_slice.slab_id,
             spawn_info,
             init_and_update_pipeline_ids: input.init_and_update_pipeline_ids,
@@ -776,6 +785,7 @@ impl EffectBatch {
                 draw_indirect_buffer_row_index,
                 metadata_table_id,
                 sort_fill_indirect_dispatch_index: None,
+                sort_indirect_dispatch_index: None,
                 render_batch_info_offset: u32::MAX,
             }],
             particle_layout: input.effect_slice.particle_layout.clone(),

--- a/src/render/effect_cache.rs
+++ b/src/render/effect_cache.rs
@@ -1123,7 +1123,8 @@ fn create_metadata_init_bind_group_layout_desc(
 ) -> BindGroupLayoutDescriptor {
     let mut entries = Vec::with_capacity(3);
 
-    // @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>
+    // @group(3) @binding(0) var<storage, read_write> effect_metadatas :
+    // array<EffectMetadata>
     entries.push(BindGroupLayoutEntry {
         binding: 0,
         visibility: ShaderStages::COMPUTE,
@@ -1187,7 +1188,8 @@ fn create_metadata_update_bind_group_layout_desc(
 ) -> BindGroupLayoutDescriptor {
     let mut entries = Vec::with_capacity(num_event_buffers as usize + 2);
 
-    // @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>
+    // @group(3) @binding(0) var<storage, read_write> effect_metadatas :
+    // array<EffectMetadata>
     entries.push(BindGroupLayoutEntry {
         binding: 0,
         visibility: ShaderStages::COMPUTE,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -7843,50 +7843,54 @@ fn simulate(
                     // sorted. Since we don't know (from CPU) the number of particles, and so the
                     // number of required passes, we over-estimate from the total effect capacity.
                     let block_size = 1024; // see shader
-                    if effect_batch.capacity > block_size {
-                        let num_blocks = effect_batch.capacity.div_ceil(block_size);
-                        let num_passes = 32 - (num_blocks - 1).leading_zeros(); // log2(n-1) rounded up
-
-                        let mut compute_pass = HanabiComputePass::new(
-                            "hanabi:sort_merge",
-                            &pipeline_cache,
-                            &mut render_context,
-                        );
-                        compute_pass.push_debug_group("hanabi:sort_merge");
-
+                    let num_blocks = effect_batch.capacity.div_ceil(block_size);
+                    let num_passes = if num_blocks > 1 {
+                        32 - (num_blocks - 1).leading_zeros() // log2(n-1) rounded up
+                    } else {
+                        0
+                    };
+                    if num_passes > 0 {
                         let pipeline_id = sort_bind_groups.sort_merge_pipeline_id();
-                        if compute_pass
-                            .set_cached_compute_pipeline(pipeline_id)
-                            .is_err()
-                        {
-                            compute_pass.insert_debug_marker("ERROR:FailedToSetSortMergePipeline");
-                            compute_pass.pop_debug_group();
-                            return;
-                        }
-
                         let Some(bind_group) = sort_bind_groups.sort_merge_bind_group() else {
                             warn!("Missing sort bind group.");
-                            compute_pass.insert_debug_marker("ERROR:MissingSortMergeBindGroup");
                             return;
                         };
 
                         let mut num_lists = num_blocks;
                         for ipass in 0..num_passes {
-                            let offset = sort_bind_groups
-                                .merge_params_buffer()
-                                .dynamic_offset(ipass as usize);
+                            // A separate compute pass provides the storage-buffer visibility
+                            // guarantee required before the next ping-pong merge stage reads
+                            // this stage's output.
+                            let mut compute_pass = HanabiComputePass::new(
+                                "hanabi:sort_merge",
+                                &pipeline_cache,
+                                &mut render_context,
+                            );
+                            compute_pass.push_debug_group("hanabi:sort_merge");
+                            if compute_pass
+                                .set_cached_compute_pipeline(pipeline_id)
+                                .is_err()
+                            {
+                                compute_pass
+                                    .insert_debug_marker("ERROR:FailedToSetSortMergePipeline");
+                                compute_pass.pop_debug_group();
+                                return;
+                            }
+
+                            let offset = sort_bind_groups.merge_params_buffer().dynamic_offset(
+                                SortBindGroups::COPY_SOURCE_PARAM_COUNT + ipass as usize,
+                            );
                             compute_pass.set_bind_group(0, bind_group, &[offset]);
 
-                            // For now, we use a naive serial mergesort, so we merge each pair of
-                            // lists serially in a single thread.
-                            let num_threads = num_lists / 2;
+                            // For now, each thread serially merges a pair of lists. A final
+                            // unpaired list is copied to the other ping-pong half.
+                            let num_threads = num_lists.div_ceil(2);
                             let num_workgroups = num_threads.div_ceil(64);
                             compute_pass.dispatch_workgroups(num_workgroups, 1, 1);
 
+                            compute_pass.pop_debug_group();
                             num_lists = num_lists.div_ceil(2);
                         }
-
-                        compute_pass.pop_debug_group();
                     }
 
                     // Copy the sorted indices back into the indirect index buffer.
@@ -7930,7 +7934,14 @@ fn simulate(
                             compute_pass.insert_debug_marker("ERROR:MissingSortCopyBindGroup");
                             continue;
                         };
-                        compute_pass.set_bind_group(0, bind_group, &[spawner_offset]);
+                        let copy_source_offset = sort_bind_groups
+                            .merge_params_buffer()
+                            .dynamic_offset(num_passes as usize % 2);
+                        compute_pass.set_bind_group(
+                            0,
+                            bind_group,
+                            &[spawner_offset, copy_source_offset],
+                        );
 
                         compute_pass.dispatch_workgroups_indirect(
                             indirect_args_buffer,
@@ -7939,6 +7950,15 @@ fn simulate(
 
                         compute_pass.pop_debug_group();
                     }
+
+                    // The sort-fill pass uses this counter as an atomic append index. It must
+                    // remain valid through the block-sort, merge, and copy passes, then be
+                    // cleared before sorting the next effect instance.
+                    render_context.command_encoder().clear_buffer(
+                        sort_bind_groups.sort_buffer(),
+                        0,
+                        Some(4),
+                    );
                 }
             }
         }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6834,21 +6834,6 @@ fn draw<'w>(
         &[],
     );
 
-    // // Bind group @2 -- multi-draw variant (set once for all draw calls)
-    // let has_multi_draw = false;
-    // if has_multi_draw {
-    //     let batch_info_aligned_size =
-    // effects_meta.batch_info_buffer.aligned_size();     let batch_info_offset
-    // = effect_batch.batch_info_id * batch_info_aligned_size as u32;
-    //     pass.set_bind_group(
-    //         2,
-    //         property_bind_groups
-    //             .get(effect_batch.property_key.as_ref(), true)
-    //             .unwrap(),
-    //         &[batch_info_offset],
-    //     );
-    // }
-
     // Effect materials (textures and samplers)
     // TODO = move
     let material = Material {
@@ -7225,56 +7210,6 @@ fn simulate(
         // FIXME - Bevy doesn't allow returning custom errors here...
         return;
     };
-
-    // FIXME - need here (or end of last frame) to copy the number of GPU spawn
-    // events into the prefix_sum buffer, before we do the prefix sum pass below.
-    // Currently without this, GPU events are broken.
-
-    // Init prefix sum compute pass
-    //
-    // Calculate the prefix sum of the number of particles to spawn in the init
-    // pass, which is equal to the number of compute threads dispatched.
-    //
-    // FIXME - vfx_prefix_sum updates BatchInfo::total_update_count, and for CPU
-    // init we already upload the prefix sum values calculated from CPU each
-    // frame. The only prefix sum left we don't currently do would be if we
-    // batched GPU spawning, but we don't currently.
-    //
-    // {
-    //     let mut compute_pass = HanabiComputePass::new(
-    //         "hanabi:init_prefix_sum",
-    //         &pipeline_cache,
-    //         &mut render_context,
-    //     );
-
-    //     trace!("record commands for init prefix sum pass...");
-
-    //     if compute_pass
-    //         .set_cached_compute_pipeline(effects_meta.prefix_sum_pipeline_id)
-    //         .is_err()
-    //     {
-    //         // FIXME - Bevy doesn't allow returning custom errors here...
-    //         trace!("ERROR - Failed to set prefix sum compute pipeline. Simulation
-    // aborted.");         return;
-    //     }
-
-    //     // Dispatch one thread per init effect batch.
-    //     const WORKGROUP_SIZE: u32 = 64;
-    //     // Note: This only works because we use the same batches for the init and
-    // update     // passes. A priori there's no reason why we couldn't split
-    // them, since likely     // the batches would be different.
-    //     let total_batch_count = batcher.len() as u32;
-    //     let workgroup_count = total_batch_count.div_ceil(WORKGROUP_SIZE);
-
-    //     // Setup vfx_prefix_sum pass
-    //     compute_pass.set_bind_group(0, prefix_sum_bind_group, &[]);
-    //     compute_pass.dispatch_workgroups(workgroup_count, 1, 1);
-    //     trace!(
-    //         "prefix sum dispatched: total_batch_count={} workgroup_count={}",
-    //         total_batch_count,
-    //         workgroup_count
-    //     );
-    // }
 
     // Compute init pass
     {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -717,6 +717,7 @@ impl InitFillDispatchQueue {
                     dst_offset: dst_start * dst_stride,
                     dst_stride,
                     count,
+                    thread_group_size: 1,
                 };
                 trace!(
                 "enqueue_init_fill(): src:global_child_index={} dst:init_indirect_dispatch_index={} args={:?} src_buffer={:?} dst_buffer={:?}",
@@ -749,6 +750,7 @@ impl InitFillDispatchQueue {
                 dst_offset: dst_start * dst_stride,
                 dst_stride,
                 count,
+                thread_group_size: 1,
             };
             trace!(
             "IFDA::submit(): src:global_child_index={} dst:init_indirect_dispatch_index={} args={:?} src_buffer={:?} dst_buffer={:?}",
@@ -785,8 +787,11 @@ pub(super) struct SortFillDispatchItem {
     /// copied before calculating the sort prefix sum.
     pub prefix_sum_index: u32,
     /// Index of the [`GpuDispatchIndirect`] entry to write the workgroup count
-    /// to.
+    /// to, for the sort-fill pass (1 thread per particle).
     pub sort_fill_indirect_dispatch_index: u32,
+    /// Index of the [`GpuDispatchIndirect`] entry to write the workgroup count
+    /// to, for the sort pass (1 thread per 16-particle group).
+    pub sort_indirect_dispatch_index: u32,
 }
 
 /// Indices of the GPU operation queues needed to prepare a ribbon sort.
@@ -794,8 +799,12 @@ pub(super) struct SortFillDispatchItem {
 pub(super) struct SortFillDispatchQueueIndices {
     /// Queue which copies post-update alive counts into the prefix sum buffer.
     pub alive_count_copy: Option<u32>,
-    /// Queue which creates the indirect sort-fill dispatch arguments.
+    /// Queue which creates the indirect sort-fill dispatch arguments. This uses
+    /// 1 thread per particle, total alive_count threads.
     pub fill_dispatch: Option<u32>,
+    /// Queue which creates the indirect sort dispatch arguments. This uses 1
+    /// thread per 16 particles, total alive_count.div_ceil(16) threads.
+    pub sort_dispatch: Option<u32>,
 }
 
 /// Queue of fill dispatch operations for the ribbon particle sort pass.
@@ -830,11 +839,13 @@ impl SortFillDispatchQueue {
         metadata_table_id: BufferTableId,
         prefix_sum_index: u32,
         sort_fill_indirect_dispatch_index: u32,
+        sort_indirect_dispatch_index: u32,
     ) {
         self.queue.push(SortFillDispatchItem {
             metadata_table_id,
             prefix_sum_index,
             sort_fill_indirect_dispatch_index,
+            sort_indirect_dispatch_index,
         });
     }
 
@@ -871,6 +882,7 @@ impl SortFillDispatchQueue {
 
         let mut alive_count_copy_queue = GpuBufferOperationQueue::new();
         let mut fill_queue = GpuBufferOperationQueue::new();
+        let mut sort_queue = GpuBufferOperationQueue::new();
         for item in &self.queue {
             let src_binding_offset = effect_metadata_buffer.dynamic_offset(item.metadata_table_id);
             debug_assert_eq!(
@@ -879,9 +891,6 @@ impl SortFillDispatchQueue {
                 "Effect metadata offset must be u32-aligned."
             );
             let src_offset = src_binding_offset / 4 + alive_count_offset;
-            let dst_offset = sort_bind_groups
-                .get_indirect_args_byte_offset(item.sort_fill_indirect_dispatch_index)
-                / 4;
             trace!(
                 "queue_sort_alive_count_copy(): src#{:?}@+{}B -> dst#{:?}[{}]",
                 src_buffer.id(),
@@ -889,6 +898,8 @@ impl SortFillDispatchQueue {
                 prefix_sum_buffer.id(),
                 item.prefix_sum_index,
             );
+
+            // Enqueue an op to copy alive_count into the prefix sum buffer
             alive_count_copy_queue.enqueue(
                 GpuBufferOperationType::Copy,
                 GpuBufferOperationArgs {
@@ -897,20 +908,19 @@ impl SortFillDispatchQueue {
                     dst_offset: item.prefix_sum_index,
                     dst_stride: 1,
                     count: 1,
+                    thread_group_size: 1,
                 },
                 src_buffer.clone(),
                 None,
                 prefix_sum_buffer.clone(),
                 None,
             );
-            trace!(
-                "queue_sort_fill_dispatch(): src#{:?}@+{}B ({}B) -> dst#{:?}@+{}B (whole)",
-                src_buffer.id(),
-                src_binding_offset,
-                src_stride,
-                dst_buffer.id(),
-                dst_offset * 4,
-            );
+
+            // Enqueue an op to calculate from alive_count the number of workgroups for the
+            // sort-fill pass
+            let dst_offset = sort_bind_groups
+                .get_indirect_args_byte_offset(item.sort_fill_indirect_dispatch_index)
+                / 4;
             fill_queue.enqueue(
                 GpuBufferOperationType::FillDispatchArgs,
                 GpuBufferOperationArgs {
@@ -919,11 +929,42 @@ impl SortFillDispatchQueue {
                     dst_offset: dst_offset as u32,
                     dst_stride,
                     count: 1,
+                    thread_group_size: 1,
                 },
                 src_buffer.clone(),
                 None,
                 dst_buffer.clone(),
                 None,
+            );
+
+            // Enqueue an op to calculate from alive_count the number of workgroups for the
+            // sort pass
+            let dst_offset = sort_bind_groups
+                .get_indirect_args_byte_offset(item.sort_indirect_dispatch_index)
+                / 4;
+            sort_queue.enqueue(
+                GpuBufferOperationType::FillDispatchArgs,
+                GpuBufferOperationArgs {
+                    src_offset,
+                    src_stride,
+                    dst_offset: dst_offset as u32,
+                    dst_stride,
+                    count: 1,
+                    thread_group_size: 16, // numItemPerThread=16; see shader
+                },
+                src_buffer.clone(),
+                None,
+                dst_buffer.clone(),
+                None,
+            );
+
+            trace!(
+                "queue_sort_fill_dispatch(): src#{:?}@+{}B ({}B) -> dst#{:?}@+{}B (whole)",
+                src_buffer.id(),
+                src_binding_offset,
+                src_stride,
+                dst_buffer.id(),
+                dst_offset * 4,
             );
         }
 
@@ -937,9 +978,15 @@ impl SortFillDispatchQueue {
         } else {
             Some(gpu_buffer_operations.submit(fill_queue))
         };
+        let sort_dispatch = if sort_queue.operation_queue.is_empty() {
+            None
+        } else {
+            Some(gpu_buffer_operations.submit(sort_queue))
+        };
         SortFillDispatchQueueIndices {
             alive_count_copy,
             fill_dispatch,
+            sort_dispatch,
         }
     }
 }
@@ -1223,6 +1270,8 @@ pub(super) struct GpuBufferOperationArgs {
     dst_stride: u32,
     /// Number of u32 elements to process for this operation.
     count: u32,
+    /// Thread group size.
+    thread_group_size: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1320,6 +1369,7 @@ impl GpuBufferOperationQueue {
         dst_buffer: Buffer,
         dst_binding_size: Option<NonZeroU32>,
     ) -> u32 {
+        assert!(args.thread_group_size > 0);
         trace!(
             "Queue {:?} op: args={:?} src_buffer={:?} src_binding_size={:?} dst_buffer={:?} dst_binding_size={:?}",
             op,
@@ -4662,14 +4712,24 @@ pub(crate) fn batch_effects(
         // for ribbon meshing, in order to avoid gaps when some particles in the middle
         // of the ribbon die (since we can't guarantee a linear lifetime through the
         // ribbon).
-        let sort_fill_indirect_dispatch_index =
+        let sort_indirect_dispatch_indices =
             if extracted_effect.layout_flags.contains(LayoutFlags::RIBBONS) {
                 // Allocate a GpuDispatchIndirect entry
                 let sort_fill_indirect_dispatch_index = sort_bind_groups.allocate_indirect_args();
                 effect_batch.effect_data[0].sort_fill_indirect_dispatch_index =
                     Some(sort_fill_indirect_dispatch_index);
 
-                Some(sort_fill_indirect_dispatch_index)
+                let sort_indirect_dispatch_index = sort_bind_groups.allocate_indirect_args();
+                effect_batch.effect_data[0].sort_indirect_dispatch_index =
+                    Some(sort_indirect_dispatch_index);
+
+                // Ensure sort merge passes are allocated, if needed
+                sort_bind_groups.ensure_mergesort_passes(extracted_effect.capacity);
+
+                Some((
+                    sort_fill_indirect_dispatch_index,
+                    sort_indirect_dispatch_index,
+                ))
             } else {
                 None
             };
@@ -4696,11 +4756,14 @@ pub(crate) fn batch_effects(
                 })
                 .insert(TemporaryRenderEntity);
         }
-        if let Some(sort_fill_indirect_dispatch_index) = sort_fill_indirect_dispatch_index {
+        if let Some((sort_fill_indirect_dispatch_index, sort_indirect_dispatch_index)) =
+            sort_indirect_dispatch_indices
+        {
             sort_fill_dispatch_queue.enqueue(
                 cached_effect_metadata.table_id,
                 sort_prefix_sum_index,
                 sort_fill_indirect_dispatch_index,
+                sort_indirect_dispatch_index,
             );
         }
 
@@ -4740,7 +4803,8 @@ pub(crate) fn batch_effects(
     // end_frame() at the tail of the latter. Render set ordering guarantees
     // this begin precedes all submits.
     gpu_buffer_operations.begin_frame();
-    debug_assert!(batcher.dispatch_queue_index.is_none());
+    debug_assert!(batcher.fill_dispatch_queue_index.is_none());
+    debug_assert!(batcher.sort_dispatch_queue_index.is_none());
 
     // Write the entire spawner buffer for this frame, for all effects combined
     if effects_meta
@@ -4770,6 +4834,8 @@ pub(crate) fn batch_effects(
         effects_meta.indirect_spawner_bind_group = None;
         effects_meta.prefix_sum_bind_group = None;
     }
+
+    let _ = sort_bind_groups.write_merge_params(&render_device, &render_queue);
 }
 
 /// Per-buffer bind groups for a GPU effect buffer.
@@ -6193,7 +6259,8 @@ pub(crate) fn queue_sort_fill_dispatch_ops(
     }
 
     debug_assert!(batcher.sort_fill_prefix_sum_queue_index.is_none());
-    debug_assert!(batcher.dispatch_queue_index.is_none());
+    debug_assert!(batcher.fill_dispatch_queue_index.is_none());
+    debug_assert!(batcher.sort_dispatch_queue_index.is_none());
     let Some(prefix_sum_buffer) = batcher.prefix_sum_buffer() else {
         error!("Missing prefix sum buffer for ribbon sort. This is a bug.");
         return;
@@ -6205,7 +6272,8 @@ pub(crate) fn queue_sort_fill_dispatch_ops(
         &mut gpu_buffer_operations,
     );
     batcher.sort_fill_prefix_sum_queue_index = queue_indices.alive_count_copy;
-    batcher.dispatch_queue_index = queue_indices.fill_dispatch;
+    batcher.fill_dispatch_queue_index = queue_indices.fill_dispatch;
+    batcher.sort_dispatch_queue_index = queue_indices.sort_dispatch;
 }
 
 /// Read the queued init fill dispatch operations, batch them together by
@@ -6599,6 +6667,7 @@ pub(crate) fn prepare_bind_groups(
 
             // Bind group @0 of sort pass
             sort_bind_groups.ensure_sort_bind_group(&render_device, &pipeline_cache);
+            sort_bind_groups.ensure_sort_merge_bind_group(&render_device, &pipeline_cache);
 
             // Bind group @0 of sort-copy pass
             let indirect_index_buffer = effect_buffer.indirect_index_buffer();
@@ -6764,6 +6833,21 @@ fn draw<'w>(
             .unwrap(),
         &[],
     );
+
+    // // Bind group @2 -- multi-draw variant (set once for all draw calls)
+    // let has_multi_draw = false;
+    // if has_multi_draw {
+    //     let batch_info_aligned_size =
+    // effects_meta.batch_info_buffer.aligned_size();     let batch_info_offset
+    // = effect_batch.batch_info_id * batch_info_aligned_size as u32;
+    //     pass.set_bind_group(
+    //         2,
+    //         property_bind_groups
+    //             .get(effect_batch.property_key.as_ref(), true)
+    //             .unwrap(),
+    //         &[batch_info_offset],
+    //     );
+    // }
 
     // Effect materials (textures and samplers)
     // TODO = move
@@ -7141,6 +7225,56 @@ fn simulate(
         // FIXME - Bevy doesn't allow returning custom errors here...
         return;
     };
+
+    // FIXME - need here (or end of last frame) to copy the number of GPU spawn
+    // events into the prefix_sum buffer, before we do the prefix sum pass below.
+    // Currently without this, GPU events are broken.
+
+    // Init prefix sum compute pass
+    //
+    // Calculate the prefix sum of the number of particles to spawn in the init
+    // pass, which is equal to the number of compute threads dispatched.
+    //
+    // FIXME - vfx_prefix_sum updates BatchInfo::total_update_count, and for CPU
+    // init we already upload the prefix sum values calculated from CPU each
+    // frame. The only prefix sum left we don't currently do would be if we
+    // batched GPU spawning, but we don't currently.
+    //
+    // {
+    //     let mut compute_pass = HanabiComputePass::new(
+    //         "hanabi:init_prefix_sum",
+    //         &pipeline_cache,
+    //         &mut render_context,
+    //     );
+
+    //     trace!("record commands for init prefix sum pass...");
+
+    //     if compute_pass
+    //         .set_cached_compute_pipeline(effects_meta.prefix_sum_pipeline_id)
+    //         .is_err()
+    //     {
+    //         // FIXME - Bevy doesn't allow returning custom errors here...
+    //         trace!("ERROR - Failed to set prefix sum compute pipeline. Simulation
+    // aborted.");         return;
+    //     }
+
+    //     // Dispatch one thread per init effect batch.
+    //     const WORKGROUP_SIZE: u32 = 64;
+    //     // Note: This only works because we use the same batches for the init and
+    // update     // passes. A priori there's no reason why we couldn't split
+    // them, since likely     // the batches would be different.
+    //     let total_batch_count = batcher.len() as u32;
+    //     let workgroup_count = total_batch_count.div_ceil(WORKGROUP_SIZE);
+
+    //     // Setup vfx_prefix_sum pass
+    //     compute_pass.set_bind_group(0, prefix_sum_bind_group, &[]);
+    //     compute_pass.dispatch_workgroups(workgroup_count, 1, 1);
+    //     trace!(
+    //         "prefix sum dispatched: total_batch_count={} workgroup_count={}",
+    //         total_batch_count,
+    //         workgroup_count
+    //     );
+    // }
 
     // Compute init pass
     {
@@ -7548,8 +7682,8 @@ fn simulate(
         // particles in the batch after their update in the compute update pass. Since
         // particles may die during update, this may be different from the number of
         // particles updated.
-        let Some(queue_index) = batcher.dispatch_queue_index else {
-            warn!("Missing indirect dispatch queue for ribbon sorting.");
+        let Some(queue_index) = batcher.fill_dispatch_queue_index else {
+            warn!("Missing indirect dispatch queue for ribbon sorting (fill).");
             return;
         };
         gpu_buffer_operations.dispatch(
@@ -7557,6 +7691,22 @@ fn simulate(
             &mut render_context,
             &utils_pipeline,
             Some("hanabi:sort_fill_dispatch"),
+        );
+
+        // Compute sort sort dispatch pass - Fill the indirect dispatch structs for any
+        // batch of particles which needs sorting, based on the actual number of alive
+        // particles in the batch after their update in the compute update pass. Since
+        // particles may die during update, this may be different from the number of
+        // particles updated.
+        let Some(queue_index) = batcher.sort_dispatch_queue_index else {
+            warn!("Missing indirect dispatch queue for ribbon sorting (sort).");
+            return;
+        };
+        gpu_buffer_operations.dispatch(
+            queue_index,
+            &mut render_context,
+            &utils_pipeline,
+            Some("hanabi:sort_sort_dispatch"),
         );
 
         // Compute sort pass
@@ -7578,14 +7728,25 @@ fn simulate(
                     continue;
                 };
 
+                // Loop on individual effects instances in the batch. Currently we can't sort an
+                // entire batch at once, only a single instance. This is in part because each
+                // instance already requires 2 keys to sort (RIBBON_ID + AGE), and it's not
+                // clear that adding a third key is faster than doing multiple dispatches.
                 for (effect_index, effect_data) in effect_batch.effect_data.iter().enumerate() {
-                    let Some(indirect_dispatch_index) =
+                    let Some(fill_indirect_dispatch_index) =
                         effect_data.sort_fill_indirect_dispatch_index
                     else {
                         continue;
                     };
-                    let indirect_offset =
-                        sort_bind_groups.get_indirect_args_byte_offset(indirect_dispatch_index);
+                    let Some(sort_indirect_dispatch_index) =
+                        effect_data.sort_indirect_dispatch_index
+                    else {
+                        continue;
+                    };
+                    let fill_indirect_offset = sort_bind_groups
+                        .get_indirect_args_byte_offset(fill_indirect_dispatch_index);
+                    let sort_indirect_offset = sort_bind_groups
+                        .get_indirect_args_byte_offset(sort_indirect_dispatch_index);
 
                     // Fill the sort buffer with the key-value pairs to sort
                     {
@@ -7638,12 +7799,14 @@ fn simulate(
                         };
                         compute_pass.set_bind_group(0, bind_group, &[spawner_offset]);
 
-                        compute_pass
-                            .dispatch_workgroups_indirect(indirect_args_buffer, indirect_offset);
+                        compute_pass.dispatch_workgroups_indirect(
+                            indirect_args_buffer,
+                            fill_indirect_offset,
+                        );
                         compute_pass.pop_debug_group();
                     }
 
-                    // Do the actual sort
+                    // Block-sort particles
                     {
                         let mut compute_pass = HanabiComputePass::new(
                             "hanabi:sort",
@@ -7667,8 +7830,61 @@ fn simulate(
                             continue;
                         };
                         compute_pass.set_bind_group(0, bind_group, &[]);
-                        compute_pass
-                            .dispatch_workgroups_indirect(indirect_args_buffer, indirect_offset);
+                        compute_pass.dispatch_workgroups_indirect(
+                            indirect_args_buffer,
+                            sort_indirect_offset,
+                        );
+
+                        compute_pass.pop_debug_group();
+                    }
+
+                    // If the number of particles is larger than the block size (1024), we need to
+                    // dispatch mergesort passes to merge pairs of lists until the full list is
+                    // sorted. Since we don't know (from CPU) the number of particles, and so the
+                    // number of required passes, we over-estimate from the total effect capacity.
+                    let block_size = 1024; // see shader
+                    if effect_batch.capacity > block_size {
+                        let num_blocks = effect_batch.capacity.div_ceil(block_size);
+                        let num_passes = 32 - (num_blocks - 1).leading_zeros(); // log2(n-1) rounded up
+
+                        let mut compute_pass = HanabiComputePass::new(
+                            "hanabi:sort_merge",
+                            &pipeline_cache,
+                            &mut render_context,
+                        );
+                        compute_pass.push_debug_group("hanabi:sort_merge");
+
+                        let pipeline_id = sort_bind_groups.sort_merge_pipeline_id();
+                        if compute_pass
+                            .set_cached_compute_pipeline(pipeline_id)
+                            .is_err()
+                        {
+                            compute_pass.insert_debug_marker("ERROR:FailedToSetSortMergePipeline");
+                            compute_pass.pop_debug_group();
+                            return;
+                        }
+
+                        let Some(bind_group) = sort_bind_groups.sort_merge_bind_group() else {
+                            warn!("Missing sort bind group.");
+                            compute_pass.insert_debug_marker("ERROR:MissingSortMergeBindGroup");
+                            return;
+                        };
+
+                        let mut num_lists = num_blocks;
+                        for ipass in 0..num_passes {
+                            let offset = sort_bind_groups
+                                .merge_params_buffer()
+                                .dynamic_offset(ipass as usize);
+                            compute_pass.set_bind_group(0, bind_group, &[offset]);
+
+                            // For now, we use a naive serial mergesort, so we merge each pair of
+                            // lists serially in a single thread.
+                            let num_threads = num_lists / 2;
+                            let num_workgroups = num_threads.div_ceil(64);
+                            compute_pass.dispatch_workgroups(num_workgroups, 1, 1);
+
+                            num_lists = num_lists.div_ceil(2);
+                        }
 
                         compute_pass.pop_debug_group();
                     }
@@ -7682,7 +7898,7 @@ fn simulate(
                         );
                         compute_pass.push_debug_group("hanabi:copy_sorted_indices");
 
-                        let pipeline_id = sort_bind_groups.get_sort_copy_pipeline_id();
+                        let pipeline_id = sort_bind_groups.sort_copy_pipeline_id();
                         if compute_pass
                             .set_cached_compute_pipeline(pipeline_id)
                             .is_err()
@@ -7716,8 +7932,10 @@ fn simulate(
                         };
                         compute_pass.set_bind_group(0, bind_group, &[spawner_offset]);
 
-                        compute_pass
-                            .dispatch_workgroups_indirect(indirect_args_buffer, indirect_offset);
+                        compute_pass.dispatch_workgroups_indirect(
+                            indirect_args_buffer,
+                            fill_indirect_offset,
+                        );
 
                         compute_pass.pop_debug_group();
                     }

--- a/src/render/shader_contract_tests.rs
+++ b/src/render/shader_contract_tests.rs
@@ -331,6 +331,11 @@ fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::err
         contents: &padded_slice_content(&spawners, storage_alignment),
         usage: wgpu::BufferUsages::STORAGE,
     });
+    let copy_source_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("hanabi:test:ribbon:copy_source"),
+        contents: cast_slice(&[0_u32, 0]),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
     let sort_buffer = wgpu_device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("hanabi:test:ribbon:sort"),
         size: 4 + 4 * 12,
@@ -373,6 +378,7 @@ fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::err
             storage(1, true, false),
             storage(2, false, false),
             storage(3, true, true),
+            storage(4, true, true),
         ],
     });
     let fill_bg = wgpu_device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -428,6 +434,10 @@ fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::err
                     offset: 0,
                     size: NonZeroU64::new(storage_alignment as u64),
                 }),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: copy_source_buffer.as_entire_binding(),
             },
         ],
     });
@@ -501,7 +511,7 @@ fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::err
             pass.set_bind_group(
                 0,
                 &copy_bg,
-                &[(instance * storage_alignment as usize) as u32],
+                &[(instance * storage_alignment as usize) as u32, 0],
             );
             pass.dispatch_workgroups_indirect(
                 &dispatch_buffer,

--- a/src/render/shader_contract_tests.rs
+++ b/src/render/shader_contract_tests.rs
@@ -207,7 +207,7 @@ fn create_sort_pipeline(
         label: Some("hanabi:test:sort:pipe"),
         layout: Some(&pl),
         module: &shader,
-        entry_point: Some("main"),
+        entry_point: Some("sort_blocks"),
         cache: None,
         compilation_options: wgpu::PipelineCompilationOptions::default(),
     });
@@ -455,7 +455,7 @@ fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::err
         label: Some("hanabi:test:ribbon:fill"),
         layout: Some(&fill_pl),
         module: &fill_shader,
-        entry_point: Some("main"),
+        entry_point: Some("sort_fill"),
         cache: None,
         compilation_options: wgpu::PipelineCompilationOptions::default(),
     });
@@ -463,7 +463,7 @@ fn real_ribbon_sort_chain_isolated_per_instance() -> Result<(), Box<dyn std::err
         label: Some("hanabi:test:ribbon:copy"),
         layout: Some(&copy_pl),
         module: &copy_shader,
-        entry_point: Some("main"),
+        entry_point: Some("sort_copy"),
         cache: None,
         compilation_options: wgpu::PipelineCompilationOptions::default(),
     });

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -38,6 +38,8 @@ pub(crate) struct GpuMergeParams {
     /// merges two sorted lists, one of this size and the other of this size or
     /// smaller, into a single sorted list.
     pub max_list_size: u32,
+    /// Half of the ping-pong sort buffer to read from for this pass.
+    pub source_buffer: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -145,6 +147,10 @@ pub struct SortBindGroups {
 }
 
 impl SortBindGroups {
+    /// Number of fixed merge parameter entries that select the final source
+    /// half for the sort-copy pass.
+    pub(crate) const COPY_SOURCE_PARAM_COUNT: usize = 2;
+
     /// Size in bytes of the sort buffer.
     ///
     /// This includes the header 'count:u32' field, as well as up to 2 copies of
@@ -182,11 +188,19 @@ impl SortBindGroups {
         let merge_params_align =
             NonZeroU64::new(render_device.limits().min_storage_buffer_offset_alignment as u64)
                 .unwrap();
-        let merge_params_buffer = AlignedBufferVec::<GpuMergeParams>::new(
+        let mut merge_params_buffer = AlignedBufferVec::<GpuMergeParams>::new(
             BufferUsages::STORAGE,
             Some(merge_params_align),
             Some("hanabi:buffer:merge_params".to_string()),
         );
+        // These entries are selected by the copy pass after all merge stages.
+        // Entry 0 selects the first half and entry 1 selects the second half.
+        for source_buffer in 0..Self::COPY_SOURCE_PARAM_COUNT as u32 {
+            merge_params_buffer.push(GpuMergeParams {
+                max_list_size: 0,
+                source_buffer,
+            });
+        }
 
         // Initial room for 256 ribbon sort dispatches; the GpuBuffer grows on demand.
         let indirect_item_size = GpuDispatchIndirectArgs::SHADER_SIZE.get();
@@ -264,6 +278,8 @@ impl SortBindGroups {
                         true,
                         Some(GpuSpawnerParams::aligned_size(alignment)),
                     ),
+                    // @group(0) @binding(4) var<storage, read> merge_params : MergeParams;
+                    storage_buffer_read_only_sized(true, Some(GpuMergeParams::SHADER_SIZE)),
                 ),
             ),
         );
@@ -283,7 +299,7 @@ impl SortBindGroups {
             sort_fill_shader,
             sort_buffer,
             merge_params_buffer,
-            merge_params_changed: false,
+            merge_params_changed: true,
             indirect_args_buffer: indirect_buffer,
             sort_fill_bind_group_layout_descs: default(),
             sort_fill_bind_groups: default(),
@@ -320,16 +336,18 @@ impl SortBindGroups {
         let num_passes = 32 - (num_blocks - 1).leading_zeros(); // log2(n-1) rounded up
 
         // Check if already allocated
-        let existing_num_passes = self.merge_params_buffer.len() as u32;
+        let existing_num_passes =
+            (self.merge_params_buffer.len() - Self::COPY_SOURCE_PARAM_COUNT) as u32;
         if existing_num_passes >= num_passes {
             return;
         }
 
         // Allocate missing entries
         let mut list_size = 1024u32 << existing_num_passes;
-        for _ in existing_num_passes..num_passes {
+        for pass in existing_num_passes..num_passes {
             self.merge_params_buffer.push(GpuMergeParams {
                 max_list_size: list_size,
+                source_buffer: pass % 2,
             });
             list_size = list_size << 1;
         }
@@ -351,6 +369,7 @@ impl SortBindGroups {
             .write_buffer(render_device, render_queue)
         {
             self.sort_merge_bind_group = None;
+            self.sort_copy_bind_groups.clear();
             true
         } else {
             false
@@ -424,6 +443,14 @@ impl SortBindGroups {
         // Validate the sort pipeline
         if !matches!(
             pipeline_cache.get_compute_pipeline_state(self.sort_pipeline_id()),
+            CachedPipelineState::Ok(_)
+        ) {
+            return false;
+        }
+
+        // Validate the sort-merge pipeline.
+        if !matches!(
+            pipeline_cache.get_compute_pipeline_state(self.sort_merge_pipeline_id()),
             CachedPipelineState::Ok(_)
         ) {
             return false;
@@ -651,7 +678,7 @@ impl SortBindGroups {
                     // @group(0) @binding(0) var<storage, read_write> pairs : array<KeyValuePair>;
                     self.sort_buffer.as_entire_binding(),
                     // @group(0) @binding(1) var<storage, read> merge_params : MergeParams;
-                    self.merge_params_buffer.binding().unwrap(),
+                    self.merge_params_buffer.range_binding(0, 1).unwrap(),
                 )),
             );
             self.sort_merge_bind_group = Some(sort_merge_bind_group);
@@ -702,6 +729,8 @@ impl SortBindGroups {
                                 render_device.limits().min_storage_buffer_offset_alignment,
                             )),
                         },
+                        // @group(0) @binding(4) var<storage, read> merge_params : MergeParams;
+                        self.merge_params_buffer.range_binding(0, 1).unwrap(),
                     )),
                 ))
             }
@@ -1379,31 +1408,32 @@ mod gpu_tests {
         let merge_params = (0..num_passes)
             .map(|i| GpuMergeParams {
                 max_list_size: 1024 << i,
+                source_buffer: i % 2,
             })
             .collect::<Vec<_>>();
 
         // Dispatch to GPU
-        let workgroups = UVec3::new(1, 1, 1);
-        let merge_offset = 0; // list_size == 1024
+        let workgroups = [UVec3::new(1, 1, 1); 2];
         let view = test.dispatch(
-            "test_merge",
+            "merge_sort",
             num_particle,
             &values[..],
             &merge_params[..],
-            merge_offset,
-            workgroups,
+            &workgroups,
         );
 
-        // Validate content
+        // Validate that both ping-pong passes produced a globally sorted result
+        // in the first half of the buffer.
         let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
-        // The first 2 lists are merged into the scratch buffer (starting at 3000).
-        view_slice[3000..5048]
-            .windows(2)
-            .for_each(|x| assert!(x[0] <= x[1]));
-        // The rest of the scratch buffer is unmodified.
-        view_slice[5048..]
-            .iter()
-            .for_each(|x| assert_eq!(*x, dummy));
+        let mut expected = values[..num_particle as usize].to_vec();
+        expected.sort();
+        let s = format_slice(&expected[..num_particle as usize]);
+        eprintln!("expected:\n{s}");
+        let s = format_slice(&view_slice[..num_particle as usize]);
+        eprintln!("actual:\n{s}");
+        let s = format_slice(&view_slice[num_particle as usize..]);
+        eprintln!("scratch:\n{s}");
+        assert_eq!(&view_slice[..num_particle as usize], expected.as_slice());
     }
 
     /// Helper for all GPU merge tests.
@@ -1455,8 +1485,9 @@ mod gpu_tests {
         /// The `entry_point` is the compute shader entry point name to execute
         /// (often a test-only entry point). The `count` and `pairs` are the
         /// data of the sort buffer to upload to GPU before dispatching. The
-        /// `merge` data is the merge params content. `workgroups` is
-        /// the number of workgroups to dispatch.
+        /// `merge` data is the merge params content. Each item in `workgroups`
+        /// is the number of workgroups to dispatch for its corresponding
+        /// merge pass.
         ///
         /// # Returns
         ///
@@ -1468,9 +1499,10 @@ mod gpu_tests {
             count: u32,
             pairs: &[DualKeyValuePair],
             merge: &[GpuMergeParams],
-            merge_offset: u32,
-            workgroups: UVec3,
+            workgroups: &[UVec3],
         ) -> BufferView {
+            assert_eq!(merge.len(), workgroups.len());
+
             // Allocate sort buffer
             let sort_byte_size = 4 + pairs.len() as u64 * DualKeyValuePair::SHADER_SIZE.get();
             let sort_buffer = self.device.create_buffer(&BufferDescriptor {
@@ -1519,7 +1551,7 @@ mod gpu_tests {
                 &bind_group_layout,
                 &BindGroupEntries::sequential((
                     sort_buffer.as_entire_binding(),
-                    merge_buffer.binding().unwrap(),
+                    merge_buffer.range_binding(0, 1).unwrap(),
                 )),
             );
             let pipeline_layout = self
@@ -1559,13 +1591,15 @@ mod gpu_tests {
                     label: Some("test"),
                 });
 
-            // Dispatch test
-            {
+            // Each stage needs its own compute pass so the next ping-pong
+            // stage can observe storage-buffer writes from the previous one.
+            for (pass_index, workgroups) in workgroups.iter().enumerate() {
                 let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
                     label: Some(entry_point),
                     timestamp_writes: None,
                 });
                 compute_pass.set_pipeline(&pipeline);
+                let merge_offset = merge_buffer.dynamic_offset(pass_index);
                 compute_pass.set_bind_group(0, &bind_group, &[merge_offset]);
                 compute_pass.dispatch_workgroups(workgroups.x, workgroups.y, workgroups.z);
             }

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -930,64 +930,6 @@ mod gpu_tests {
         })
     }
 
-    /// Parallel merge-sort for any length.
-    #[test]
-    fn test_block_parallel_merge_sort() {
-        let mut test = SortTest::new();
-
-        println!("max_block_size = {}", test.max_block_size);
-        let block_size = 1024; // see shader
-        assert!(block_size <= test.max_block_size);
-
-        // Avoid multiples of the block size, try to exercise edge case sizes.
-        let num_kv = 3000;
-        let num_blocks = (num_kv + block_size - 1) / block_size;
-
-        let mut expected = Vec::with_capacity(num_kv as usize * 2);
-        for i in 0..num_kv as usize {
-            // Repeat both keys within each local run to exercise secondary-key
-            // ordering and duplicate-key payload preservation.
-            expected.push(DualKeyValuePair {
-                key: 63 - (i % 64) as u32,
-                key2: (i / 64) as f32,
-                value: i as u32,
-            });
-        }
-        // Scratch buffer
-        for _ in 0..num_kv as usize {
-            expected.push(DualKeyValuePair {
-                key: 0xFF00FF00u32,
-                key2: f32::INFINITY,
-                value: 0xFF00FF00u32,
-            });
-        }
-        let s = format_slice(&expected[..num_kv as usize]);
-        eprintln!("input:\n{s}\n");
-
-        // Dispatch to GPU
-        let workgroups = UVec3::new(num_blocks, 1, 1);
-        let view = test.dispatch(
-            "test_block_parallel_merge_sort",
-            num_kv,
-            &expected[..],
-            workgroups,
-        );
-
-        // Validate content
-        let count_slice: &[u32] = cast_slice(&view[..4]);
-        assert_eq!(count_slice[0], num_kv); // should not be overwritten
-        let actual: &[DualKeyValuePair] = cast_slice(&view[4..]);
-        let s = format_slice(&actual[..num_kv as usize]);
-        eprintln!("output:\n{s}");
-        let s = format_slice(&actual[num_kv as usize..]);
-        eprintln!("scratch:\n{s}");
-        assert!(
-            actual.windows(2).all(|pair| pair[0] <= pair[1]),
-            "local run is not sorted"
-        );
-        assert_eq!(expected.as_slice(), actual);
-    }
-
     #[test]
     fn test_serial_insertion_sort() {
         let mut test = SortTest::new();

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -14,7 +14,7 @@ use bevy::{
             BufferId, CachedComputePipelineId, CachedPipelineState, ComputePipelineDescriptor,
             PipelineCache, ShaderSize, ShaderType,
         },
-        renderer::RenderDevice,
+        renderer::{RenderDevice, RenderQueue},
     },
     shader::Shader,
     utils::default,
@@ -26,9 +26,19 @@ use wgpu::{
 
 use super::{gpu_buffer::GpuBuffer, GpuDispatchIndirectArgs, GpuEffectMetadata, StorageType};
 use crate::{
-    render::{GpuIndirectIndex, GpuSpawnerParams},
+    render::{aligned_buffer_vec::AlignedBufferVec, GpuIndirectIndex, GpuSpawnerParams},
     Attribute, ParticleLayout,
 };
+
+/// GPU mergesort parameters.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Pod, Zeroable, ShaderType)]
+pub(crate) struct GpuMergeParams {
+    /// Maximum number of items per list for this pass. The sort merge pass
+    /// merges two sorted lists, one of this size and the other of this size or
+    /// smaller, into a single sorted list.
+    pub max_list_size: u32,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct SortFillBindGroupLayoutKey {
@@ -89,12 +99,22 @@ struct GpuSortBufferSingleEntry {
     pub value: u32,
 }
 
+/// GPU resources for various compute passes related to particle sorting.
 #[derive(Resource)]
 pub struct SortBindGroups {
     /// Sort-fill pass compute shader.
     sort_fill_shader: Handle<Shader>,
-    /// GPU buffer of key-value pairs to sort.
+    /// GPU buffer of key-value pairs to sort. The buffer contains a header
+    /// 'count:u32' field storing the number of key-value pairs, and up to 2
+    /// copies of the pairs array (for ping-pong). Each kv-pair can be up to
+    /// 12B when using dual-key pairs.
     sort_buffer: Buffer,
+    /// GPU buffer containing the [`GpuMergeParams`] structs for the various
+    /// mergesort passes.
+    merge_params_buffer: AlignedBufferVec<GpuMergeParams>,
+    /// Is any merge param changed? If so, the buffer needs to be uploaded again
+    /// to GPU, and the bind group re-created. This is quite infrequent though.
+    merge_params_changed: bool,
     /// GPU buffer containing the [`GpuDispatchIndirect`] structs for the
     /// sort-fill and sort passes.
     indirect_args_buffer: GpuBuffer<GpuDispatchIndirectArgs>,
@@ -107,9 +127,17 @@ pub struct SortBindGroups {
     sort_bind_group_layout_desc: BindGroupLayoutDescriptor,
     /// Bind group for group #0 of the sort compute pass.
     sort_bind_group: Option<BindGroup>,
+    /// Bind group for group #0 of the sort merge compute pass.
+    sort_merge_bind_group: Option<BindGroup>,
+    /// Bind group layout descriptor for group #0 of the sort-merge compute
+    /// pass.
+    sort_merge_bind_group_layout_desc: BindGroupLayoutDescriptor,
+    /// Bind group layout descriptor for group #0 of the sort-copy compute pass.
     sort_copy_bind_group_layout_desc: BindGroupLayoutDescriptor,
     /// Pipeline for sort pass.
     sort_pipeline_id: CachedComputePipelineId,
+    /// Pipeline for sort-merge pass.
+    sort_merge_pipeline_id: CachedComputePipelineId,
     /// Pipeline for sort-copy pass.
     sort_copy_pipeline_id: CachedComputePipelineId,
     /// Bind groups for group #0 of the sort-copy compute pass.
@@ -117,10 +145,28 @@ pub struct SortBindGroups {
 }
 
 impl SortBindGroups {
+    /// Size in bytes of the sort buffer.
+    ///
+    /// This includes the header 'count:u32' field, as well as up to 2 copies of
+    /// the 'pairs' array (used for ping-pong during sorting). This allows
+    /// sorting up to ~131k particles.
+    pub const SORT_BUFFER_BYTE_SIZE: u32 = 3 * 1024 * 1024;
+
+    /// Size in elements of a sort block.
+    ///
+    /// This is the number of elements that can be sorted at once by the sort
+    /// pipeline. Beyond that limit, the sort pipeline only sorts each block
+    /// individually, and we need to dispatch  mergesort passes to merge those
+    /// blocks together into a single list.
+    pub const BLOCK_SIZE: u32 = 1024;
+
+    /// Allocate the GPU resources for the various sorting-related compute
+    /// passes.
     pub fn new(
         world: &mut World,
         sort_fill_shader: Handle<Shader>,
         sort_shader: Handle<Shader>,
+        sort_merge_shader: Handle<Shader>,
         sort_copy_shader: Handle<Shader>,
     ) -> Self {
         let render_device = world.resource::<RenderDevice>();
@@ -128,10 +174,19 @@ impl SortBindGroups {
 
         let sort_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("hanabi:buffer:sort:pairs"),
-            size: 3 * 1024 * 1024,
+            size: Self::SORT_BUFFER_BYTE_SIZE as u64,
             usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
             mapped_at_creation: false,
         });
+
+        let merge_params_align =
+            NonZeroU64::new(render_device.limits().min_storage_buffer_offset_alignment as u64)
+                .unwrap();
+        let merge_params_buffer = AlignedBufferVec::<GpuMergeParams>::new(
+            BufferUsages::STORAGE,
+            Some(merge_params_align),
+            Some("hanabi:buffer:merge_params".to_string()),
+        );
 
         // Initial room for 256 ribbon sort dispatches; the GpuBuffer grows on demand.
         let indirect_item_size = GpuDispatchIndirectArgs::SHADER_SIZE.get();
@@ -167,6 +222,28 @@ impl SortBindGroups {
             immediate_size: 0,
             zero_initialize_workgroup_memory: false,
         });
+
+        let sort_merge_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
+            "hanabi:bgl:sort_merge",
+            &BindGroupLayoutEntries::sequential(
+                ShaderStages::COMPUTE,
+                (
+                    storage_buffer_sized(false, Some(NonZeroU64::new(16).unwrap())),
+                    storage_buffer_read_only_sized(true, Some(GpuMergeParams::SHADER_SIZE)),
+                ),
+            ),
+        );
+
+        let sort_merge_pipeline_id =
+            pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
+                label: Some("hanabi:pipeline:sort_merge".into()),
+                layout: vec![sort_merge_bind_group_layout_desc.clone()],
+                shader: sort_merge_shader,
+                shader_defs: vec!["HAS_DUAL_KEY".into()],
+                entry_point: Some("merge_sort".into()),
+                immediate_size: 0,
+                zero_initialize_workgroup_memory: false,
+            });
 
         let alignment = render_device.limits().min_storage_buffer_offset_alignment;
         let sort_copy_bind_group_layout_desc = BindGroupLayoutDescriptor::new(
@@ -205,6 +282,8 @@ impl SortBindGroups {
         Self {
             sort_fill_shader,
             sort_buffer,
+            merge_params_buffer,
+            merge_params_changed: false,
             indirect_args_buffer: indirect_buffer,
             sort_fill_bind_group_layout_descs: default(),
             sort_fill_bind_groups: default(),
@@ -216,10 +295,65 @@ impl SortBindGroups {
             // would break Hanabi. Instead we create this bind group alongside all others, which is
             // more consistent too.
             sort_bind_group: None,
+            sort_merge_bind_group: None,
+            sort_merge_bind_group_layout_desc,
             sort_copy_bind_group_layout_desc,
             sort_pipeline_id,
+            sort_merge_pipeline_id,
             sort_copy_pipeline_id,
             sort_copy_bind_groups: default(),
+        }
+    }
+
+    #[inline]
+    pub fn merge_params_buffer(&self) -> &AlignedBufferVec<GpuMergeParams> {
+        &self.merge_params_buffer
+    }
+
+    /// Ensure the mergesort params are allocated for all passes to process a
+    /// given number of blocks.
+    pub fn ensure_mergesort_passes(&mut self, num_items: u32) {
+        let num_blocks = num_items.div_ceil(Self::BLOCK_SIZE);
+        if num_blocks <= 1 {
+            return;
+        }
+        let num_passes = 32 - (num_blocks - 1).leading_zeros(); // log2(n-1) rounded up
+
+        // Check if already allocated
+        let existing_num_passes = self.merge_params_buffer.len() as u32;
+        if existing_num_passes >= num_passes {
+            return;
+        }
+
+        // Allocate missing entries
+        let mut list_size = 1024u32 << existing_num_passes;
+        for _ in existing_num_passes..num_passes {
+            self.merge_params_buffer.push(GpuMergeParams {
+                max_list_size: list_size,
+            });
+            list_size = list_size << 1;
+        }
+
+        self.merge_params_changed = true;
+    }
+
+    pub fn write_merge_params(
+        &mut self,
+        render_device: &RenderDevice,
+        render_queue: &RenderQueue,
+    ) -> bool {
+        if !self.merge_params_changed {
+            return false;
+        }
+        self.merge_params_changed = false;
+        if self
+            .merge_params_buffer
+            .write_buffer(render_device, render_queue)
+        {
+            self.sort_merge_bind_group = None;
+            true
+        } else {
+            false
         }
     }
 
@@ -253,6 +387,11 @@ impl SortBindGroups {
     #[inline]
     pub fn sort_pipeline_id(&self) -> CachedComputePipelineId {
         self.sort_pipeline_id
+    }
+
+    #[inline]
+    pub fn sort_merge_pipeline_id(&self) -> CachedComputePipelineId {
+        self.sort_merge_pipeline_id
     }
 
     /// Check if the sort pipeline is ready to run for the given effect
@@ -292,7 +431,7 @@ impl SortBindGroups {
 
         // Validate the sort-copy pipeline
         if !matches!(
-            pipeline_cache.get_compute_pipeline_state(self.get_sort_copy_pipeline_id()),
+            pipeline_cache.get_compute_pipeline_state(self.sort_copy_pipeline_id()),
             CachedPipelineState::Ok(_)
         ) {
             return false;
@@ -394,7 +533,7 @@ impl SortBindGroups {
             .map(|(_, pipeline_id)| *pipeline_id)
     }
 
-    pub fn get_sort_copy_pipeline_id(&self) -> CachedComputePipelineId {
+    pub fn sort_copy_pipeline_id(&self) -> CachedComputePipelineId {
         self.sort_copy_pipeline_id
     }
 
@@ -498,6 +637,33 @@ impl SortBindGroups {
         self.sort_bind_group.as_ref()
     }
 
+    /// Ensure the bind group for the sort merge pass is created.
+    pub fn ensure_sort_merge_bind_group(
+        &mut self,
+        render_device: &RenderDevice,
+        pipeline_cache: &PipelineCache,
+    ) -> &BindGroup {
+        if self.sort_merge_bind_group.is_none() {
+            let sort_merge_bind_group = render_device.create_bind_group(
+                "hanabi:bg:sort_merge",
+                &pipeline_cache.get_bind_group_layout(&self.sort_merge_bind_group_layout_desc),
+                &BindGroupEntries::sequential((
+                    // @group(0) @binding(0) var<storage, read_write> pairs : array<KeyValuePair>;
+                    self.sort_buffer.as_entire_binding(),
+                    // @group(0) @binding(1) var<storage, read> merge_params : MergeParams;
+                    self.merge_params_buffer.binding().unwrap(),
+                )),
+            );
+            self.sort_merge_bind_group = Some(sort_merge_bind_group);
+        }
+        self.sort_merge_bind_group.as_ref().unwrap()
+    }
+
+    #[inline]
+    pub fn sort_merge_bind_group(&self) -> Option<&BindGroup> {
+        self.sort_merge_bind_group.as_ref()
+    }
+
     pub fn ensure_sort_copy_bind_group(
         &mut self,
         render_device: &RenderDevice,
@@ -565,8 +731,8 @@ mod gpu_tests {
         math::{FloatOrd, UVec3},
         render::{
             render_resource::{
-                binding_types::storage_buffer_sized, BindGroupEntries, BindGroupLayoutEntries,
-                ShaderSize, ShaderType,
+                binding_types::{storage_buffer_read_only_sized, storage_buffer_sized},
+                BindGroupEntries, BindGroupLayoutEntries, ShaderSize, ShaderType,
             },
             renderer::{RenderDevice, RenderQueue},
         },
@@ -579,7 +745,11 @@ mod gpu_tests {
         ShaderModuleDescriptor, ShaderSource, ShaderStages,
     };
 
-    use crate::{plugin::VFX_SORT_WGSL, test_utils::*};
+    use crate::{
+        plugin::{VFX_SORT_MERGE_WGSL, VFX_SORT_WGSL},
+        render::{aligned_buffer_vec::AlignedBufferVec, sort::GpuMergeParams, StorageType},
+        test_utils::*,
+    };
 
     #[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable, ShaderType)]
     #[repr(C)]
@@ -669,7 +839,8 @@ mod gpu_tests {
         let block_size = 1024; // see shader
         assert!(block_size <= test.max_block_size);
 
-        let num_kv = 1024.min(block_size);
+        // Avoid multiples of the block size, try to exercise edge case sizes.
+        let num_kv = 500.min(block_size - 3);
 
         let mut expected = Vec::with_capacity(num_kv as usize);
         for i in 0..num_kv as usize {
@@ -718,6 +889,76 @@ mod gpu_tests {
         }
     }
 
+    fn format_slice(data: &[DualKeyValuePair]) -> String {
+        let mut lid = 0;
+        data.chunks(8).fold("".to_string(), |acc, chunk| {
+            let sep = if lid % 1024 == 0 { "\n" } else { "" };
+            let line = chunk.iter().fold(format!("[{lid:04}]"), |acc, x| {
+                format!("{acc} ({0:03},{1:03},{2:04})", x.key, x.key2, x.value)
+            });
+            lid += chunk.len();
+            format!("{acc}{sep}{line}\n")
+        })
+    }
+
+    /// Parallel merge-sort for any length.
+    #[test]
+    fn test_block_parallel_merge_sort() {
+        let mut test = SortTest::new();
+
+        println!("max_block_size = {}", test.max_block_size);
+        let block_size = 1024; // see shader
+        assert!(block_size <= test.max_block_size);
+
+        // Avoid multiples of the block size, try to exercise edge case sizes.
+        let num_kv = 3000;
+        let num_blocks = (num_kv + block_size - 1) / block_size;
+
+        let mut expected = Vec::with_capacity(num_kv as usize * 2);
+        for i in 0..num_kv as usize {
+            // Repeat both keys within each local run to exercise secondary-key
+            // ordering and duplicate-key payload preservation.
+            expected.push(DualKeyValuePair {
+                key: 63 - (i % 64) as u32,
+                key2: (i / 64) as f32,
+                value: i as u32,
+            });
+        }
+        // Scratch buffer
+        for _ in 0..num_kv as usize {
+            expected.push(DualKeyValuePair {
+                key: 0xFF00FF00u32,
+                key2: f32::INFINITY,
+                value: 0xFF00FF00u32,
+            });
+        }
+        let s = format_slice(&expected[..num_kv as usize]);
+        eprintln!("input:\n{s}\n");
+
+        // Dispatch to GPU
+        let workgroups = UVec3::new(num_blocks, 1, 1);
+        let view = test.dispatch(
+            "test_block_parallel_merge_sort",
+            num_kv,
+            &expected[..],
+            workgroups,
+        );
+
+        // Validate content
+        let count_slice: &[u32] = cast_slice(&view[..4]);
+        assert_eq!(count_slice[0], num_kv); // should not be overwritten
+        let actual: &[DualKeyValuePair] = cast_slice(&view[4..]);
+        let s = format_slice(&actual[..num_kv as usize]);
+        eprintln!("output:\n{s}");
+        let s = format_slice(&actual[num_kv as usize..]);
+        eprintln!("scratch:\n{s}");
+        assert!(
+            actual.windows(2).all(|pair| pair[0] <= pair[1]),
+            "local run is not sorted"
+        );
+        assert_eq!(expected.as_slice(), actual);
+    }
+
     #[test]
     fn test_serial_insertion_sort() {
         let mut test = SortTest::new();
@@ -727,7 +968,7 @@ mod gpu_tests {
         let mut expected = Vec::with_capacity(num_kv as usize);
         for i in 0..num_kv {
             expected.push(DualKeyValuePair {
-                key: i % 4,
+                key: 256 - i,
                 key2: ((i / 4) % 3) as f32,
                 value: i,
             });
@@ -742,10 +983,8 @@ mod gpu_tests {
 
         // Compare results
         assert_eq!(cast_slice::<_, u32>(&view[..4]), &[0]);
-        assert_eq!(
-            cast_slice::<_, DualKeyValuePair>(&view[4..]),
-            expected.as_slice()
-        );
+        let actual = cast_slice::<_, DualKeyValuePair>(&view[4..]);
+        assert_eq!(actual, expected.as_slice());
     }
 
     /// Calculate the merge path for a parallel merge.
@@ -992,7 +1231,7 @@ mod gpu_tests {
             entry_point: &str,
             count: u32,
             pairs: &[DualKeyValuePair],
-            workrgoups: UVec3,
+            workgroups: UVec3,
         ) -> BufferView {
             // Allocate sort buffer
             let byte_size = 4 + pairs.len() as u64 * DualKeyValuePair::SHADER_SIZE.get();
@@ -1070,7 +1309,7 @@ mod gpu_tests {
                 });
                 compute_pass.set_pipeline(&pipeline);
                 compute_pass.set_bind_group(0, &bind_group, &[]);
-                compute_pass.dispatch_workgroups(workrgoups.x, workrgoups.y, workrgoups.z);
+                compute_pass.dispatch_workgroups(workgroups.x, workgroups.y, workgroups.z);
             }
 
             // Submit command queue and wait for execution
@@ -1108,6 +1347,264 @@ mod gpu_tests {
             let _ = futures::executor::block_on(rx);
             let view = buffer_slice.get_mapped_range();
             assert_eq!(view.len(), byte_size as usize);
+            println!("Result buffer downloaded to CPU");
+
+            view
+        }
+    }
+
+    #[test]
+    fn test_merge() {
+        let mut test = MergeTest::new();
+
+        // > 2 block sizes, but not exact
+        let num_particle = 3000;
+
+        // Each block of 1024 particles is sorted, but the total list is not
+        let mut values: Vec<_> = (0..num_particle)
+            .map(|i| DualKeyValuePair {
+                key: (i / 16) % 64,
+                key2: (i % 16) as f32 * 0.1,
+                value: i,
+            })
+            .collect();
+        let dummy = DualKeyValuePair {
+            key: u32::MAX,
+            key2: f32::INFINITY,
+            value: u32::MAX,
+        };
+        values.extend((0..num_particle).map(|_| dummy));
+
+        let num_passes = 2;
+        let merge_params = (0..num_passes)
+            .map(|i| GpuMergeParams {
+                max_list_size: 1024 << i,
+            })
+            .collect::<Vec<_>>();
+
+        // Dispatch to GPU
+        let workgroups = UVec3::new(1, 1, 1);
+        let merge_offset = 0; // list_size == 1024
+        let view = test.dispatch(
+            "test_merge",
+            num_particle,
+            &values[..],
+            &merge_params[..],
+            merge_offset,
+            workgroups,
+        );
+
+        // Validate content
+        let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
+        // The first 2 lists are merged into the scratch buffer (starting at 3000).
+        view_slice[3000..5048]
+            .windows(2)
+            .for_each(|x| assert!(x[0] <= x[1]));
+        // The rest of the scratch buffer is unmodified.
+        view_slice[5048..]
+            .iter()
+            .for_each(|x| assert_eq!(*x, dummy));
+    }
+
+    /// Helper for all GPU merge tests.
+    struct MergeTest {
+        #[allow(dead_code)]
+        pub renderer: MockRenderer,
+        pub device: RenderDevice,
+        pub queue: RenderQueue,
+        /// Max block size calculated from GPU device shared workgroup memory
+        /// limit.
+        #[allow(dead_code)]
+        pub max_block_size: u32,
+    }
+
+    impl MergeTest {
+        /// Create a new GPU sort test instance.
+        fn new() -> MergeTest {
+            let renderer = MockRenderer::new();
+            let device = renderer.device();
+            let queue = renderer.queue();
+
+            println!(
+                "max_compute_workgroup_storage_size = {}",
+                device.limits().max_compute_workgroup_storage_size
+            );
+
+            // SAFETY : for debugging only
+            #[allow(unsafe_code)]
+            unsafe {
+                device.wgpu_device().start_graphics_debugger_capture()
+            };
+
+            // Clamp max block size to the device's reported storage
+            let max_block_size = device.limits().max_compute_workgroup_storage_size
+                / (DualKeyValuePair::SHADER_SIZE.get() as u32);
+            println!("max_block_size = {}", max_block_size);
+
+            Self {
+                renderer,
+                device,
+                queue,
+                max_block_size,
+            }
+        }
+
+        /// Dispatch the merge test with the given sort buffer and merge params
+        /// data.
+        ///
+        /// The `entry_point` is the compute shader entry point name to execute
+        /// (often a test-only entry point). The `count` and `pairs` are the
+        /// data of the sort buffer to upload to GPU before dispatching. The
+        /// `merge` data is the merge params content. `workgroups` is
+        /// the number of workgroups to dispatch.
+        ///
+        /// # Returns
+        ///
+        /// A view over the GPU buffer content, downloaded from GPU to CPU after
+        /// the GPU executed the sort shader test.
+        fn dispatch(
+            &mut self,
+            entry_point: &str,
+            count: u32,
+            pairs: &[DualKeyValuePair],
+            merge: &[GpuMergeParams],
+            merge_offset: u32,
+            workgroups: UVec3,
+        ) -> BufferView {
+            // Allocate sort buffer
+            let sort_byte_size = 4 + pairs.len() as u64 * DualKeyValuePair::SHADER_SIZE.get();
+            let sort_buffer = self.device.create_buffer(&BufferDescriptor {
+                label: Some("sort_buffer"),
+                size: sort_byte_size,
+                usage: BufferUsages::STORAGE | BufferUsages::MAP_READ,
+                mapped_at_creation: true,
+            });
+            {
+                // Scope get_mapped_range_mut() to force a drop before unmap()
+                {
+                    let mut mapped = sort_buffer.slice(..).get_mapped_range_mut();
+                    mapped.slice(..4).copy_from_slice(cast_slice(&[count]));
+                    mapped.slice(4..).copy_from_slice(cast_slice(pairs));
+                }
+                sort_buffer.unmap();
+            }
+
+            // Allocate merge buffer
+            let merge_align = GpuMergeParams::aligned_size(
+                self.device.limits().min_storage_buffer_offset_alignment,
+            );
+            let mut merge_buffer = AlignedBufferVec::<GpuMergeParams>::new(
+                BufferUsages::STORAGE | BufferUsages::MAP_READ,
+                Some(merge_align),
+                Some("merge_buffer".to_string()),
+            );
+            for m in merge {
+                merge_buffer.push(*m);
+            }
+            assert!(merge_buffer.write_buffer(&self.device, &self.queue));
+
+            // Create GPU resources
+            let bind_group_layout = self.device.create_bind_group_layout(
+                "bind_group_layout",
+                &BindGroupLayoutEntries::sequential(
+                    ShaderStages::COMPUTE,
+                    (
+                        storage_buffer_sized(false, None),
+                        storage_buffer_read_only_sized(true, None),
+                    ),
+                ),
+            );
+            let bind_group = self.device.create_bind_group(
+                None,
+                &bind_group_layout,
+                &BindGroupEntries::sequential((
+                    sort_buffer.as_entire_binding(),
+                    merge_buffer.binding().unwrap(),
+                )),
+            );
+            let pipeline_layout = self
+                .device
+                .create_pipeline_layout(&PipelineLayoutDescriptor {
+                    label: Some("pipeline_layout"),
+                    bind_group_layouts: &[Some(&bind_group_layout)],
+                    immediate_size: 0,
+                });
+            let src = VFX_SORT_MERGE_WGSL
+                .replace("#ifdef HAS_DUAL_KEY", "")
+                .replace("#ifdef TEST", "")
+                .replace("#endif", "");
+            let shader_module =
+                self.device
+                    .create_and_validate_shader_module(ShaderModuleDescriptor {
+                        label: Some("vfx_sort_merge"),
+                        source: ShaderSource::Wgsl(src.into()),
+                    });
+            let pipeline = self
+                .device
+                .create_compute_pipeline(&ComputePipelineDescriptor {
+                    label: Some(entry_point),
+                    layout: Some(&pipeline_layout),
+                    module: &shader_module,
+                    entry_point: Some(entry_point),
+                    compilation_options: PipelineCompilationOptions {
+                        constants: &[],
+                        zero_initialize_workgroup_memory: false,
+                    },
+                    cache: None,
+                });
+
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("test"),
+                });
+
+            // Dispatch test
+            {
+                let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                    label: Some(entry_point),
+                    timestamp_writes: None,
+                });
+                compute_pass.set_pipeline(&pipeline);
+                compute_pass.set_bind_group(0, &bind_group, &[merge_offset]);
+                compute_pass.dispatch_workgroups(workgroups.x, workgroups.y, workgroups.z);
+            }
+
+            // Submit command queue and wait for execution
+            println!("Executing pipeline...");
+            let command_buffer = encoder.finish();
+            self.queue.submit([command_buffer]);
+            let (tx, rx) = futures::channel::oneshot::channel();
+            self.queue.on_submitted_work_done(move || {
+                tx.send(()).unwrap();
+            });
+            let _ = self.device.poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            });
+            let _ = futures::executor::block_on(rx);
+            println!("Pipeline executed");
+
+            // SAFETY : for debugging only
+            #[allow(unsafe_code)]
+            unsafe {
+                self.device.wgpu_device().stop_graphics_debugger_capture()
+            };
+
+            // Read back (GPU -> CPU)
+            println!("Downloading result buffer from GPU to CPU...");
+            let buffer_slice = sort_buffer.slice(..);
+            let (tx, rx) = futures::channel::oneshot::channel();
+            buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+                tx.send(result).unwrap();
+            });
+            let _ = self.device.poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            });
+            let _ = futures::executor::block_on(rx);
+            let view = buffer_slice.get_mapped_range();
+            assert_eq!(view.len(), sort_byte_size as usize);
             println!("Result buffer downloaded to CPU");
 
             view

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -349,7 +349,7 @@ impl SortBindGroups {
                 max_list_size: list_size,
                 source_buffer: pass % 2,
             });
-            list_size = list_size << 1;
+            list_size <<= 1;
         }
 
         self.merge_params_changed = true;

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -232,7 +232,7 @@ impl SortBindGroups {
             layout: vec![sort_bind_group_layout_desc.clone()],
             shader: sort_shader,
             shader_defs: vec!["HAS_DUAL_KEY".into()],
-            entry_point: Some("main".into()),
+            entry_point: Some("sort_blocks".into()),
             immediate_size: 0,
             zero_initialize_workgroup_memory: false,
         });
@@ -290,7 +290,7 @@ impl SortBindGroups {
                 layout: vec![sort_copy_bind_group_layout_desc.clone()],
                 shader: sort_copy_shader,
                 shader_defs: vec![],
-                entry_point: Some("main".into()),
+                entry_point: Some("sort_copy".into()),
                 immediate_size: 0,
                 zero_initialize_workgroup_memory: false,
             });
@@ -528,7 +528,7 @@ impl SortBindGroups {
                         layout: vec![bind_group_layout_desc.clone()],
                         shader: self.sort_fill_shader.clone(),
                         shader_defs: vec!["HAS_DUAL_KEY".into()],
-                        entry_point: Some("main".into()),
+                        entry_point: Some("sort_fill".into()),
                         immediate_size: 0,
                         zero_initialize_workgroup_memory: false,
                     });
@@ -930,8 +930,9 @@ mod gpu_tests {
         })
     }
 
+    /// Test sorting a single non-full block (less than 1024 elements).
     #[test]
-    fn test_serial_insertion_sort() {
+    fn test_sort_block() {
         let mut test = SortTest::new();
 
         let num_kv = 257u32;
@@ -947,13 +948,13 @@ mod gpu_tests {
 
         // Dispatch to GPU
         let workgroups = UVec3::new(1, 1, 1);
-        let view = test.dispatch("main", num_kv, &expected[..], workgroups);
+        let view = test.dispatch("sort_blocks", num_kv, &expected[..], workgroups);
 
         // Sort locally on CPU
-        expected.sort();
+        expected.sort(); // stable
 
         // Compare results
-        assert_eq!(cast_slice::<_, u32>(&view[..4]), &[0]);
+        assert_eq!(cast_slice::<_, u32>(&view[..4]), &[num_kv]); // unmodified
         let actual = cast_slice::<_, DualKeyValuePair>(&view[4..]);
         assert_eq!(actual, expected.as_slice());
     }

--- a/src/render/sort.rs
+++ b/src/render/sort.rs
@@ -562,18 +562,21 @@ impl SortBindGroups {
 #[cfg(all(test, feature = "gpu_tests"))]
 mod gpu_tests {
     use bevy::{
-        math::FloatOrd,
-        render::render_resource::{
-            binding_types::storage_buffer_sized, BindGroupEntries, BindGroupLayoutEntries,
-            ShaderSize, ShaderType,
+        math::{FloatOrd, UVec3},
+        render::{
+            render_resource::{
+                binding_types::storage_buffer_sized, BindGroupEntries, BindGroupLayoutEntries,
+                ShaderSize, ShaderType,
+            },
+            renderer::{RenderDevice, RenderQueue},
         },
     };
-    #[allow(unused_imports)]
     use bytemuck::{cast_slice, Pod, Zeroable};
+    use rand::RngExt;
     use wgpu::{
-        BufferDescriptor, BufferUsages, ComputePassDescriptor, ComputePipelineDescriptor,
-        PipelineCompilationOptions, PipelineLayoutDescriptor, ShaderModuleDescriptor, ShaderSource,
-        ShaderStages,
+        BufferDescriptor, BufferUsages, BufferView, ComputePassDescriptor,
+        ComputePipelineDescriptor, PipelineCompilationOptions, PipelineLayoutDescriptor,
+        ShaderModuleDescriptor, ShaderSource, ShaderStages,
     };
 
     use crate::{plugin::VFX_SORT_WGSL, test_utils::*};
@@ -605,19 +608,121 @@ mod gpu_tests {
         }
     }
 
+    /// Thread-level local register sort with Batcher's odd-even mergesort.
+    /// - spawn 64 threads (one workgroup)
+    /// - each thread sorts 16 elements (see numItemPerThreads in shader)
+    /// - no global sorting, only 16-element sorted sub-lists in the final array
+    #[test]
+    fn test_batcher_odd_even_mergesort() {
+        let mut test = SortTest::new();
+
+        let num_kv = 1024.min(test.max_block_size);
+
+        let mut expected = Vec::with_capacity(num_kv as usize);
+        for i in 0..num_kv as usize {
+            // Repeat both keys within each local run to exercise secondary-key
+            // ordering and duplicate-key payload preservation.
+            expected.push(DualKeyValuePair {
+                key: (i % 4) as u32,
+                key2: ((i / 4) % 2) as f32,
+                value: i as u32,
+            });
+        }
+
+        let num_items_per_thread = 16; // see shader
+
+        // Dispatch to GPU
+        let workgroups = UVec3::new(1, 1, 1);
+        let view = test.dispatch(
+            "test_batcher_odd_even_mergesort",
+            num_kv,
+            &expected[..],
+            workgroups,
+        );
+
+        // Validate content
+        let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
+        for (chunk_index, actual) in view_slice.chunks(num_items_per_thread).enumerate() {
+            assert!(
+                actual.windows(2).all(|pair| pair[0] <= pair[1]),
+                "local run {chunk_index} is not sorted"
+            );
+            let mut values: Vec<_> = actual.iter().map(|pair| pair.value).collect();
+            values.sort_unstable();
+            let first = chunk_index * num_items_per_thread;
+            let expected: Vec<_> = (first..first + actual.len()).map(|i| i as u32).collect();
+            assert_eq!(values, expected, "local run {chunk_index} lost a payload");
+        }
+    }
+
+    /// Workgroup-level sort.
+    ///
+    /// Dispatch a single sort of 1024 items, which fit inside workgroup-local
+    /// shared memory. Uses the block sort algorithm to co-operatively sort
+    /// the items in a single pass with 64 threads, without relying on
+    /// storage buffers (except for final output).
+    #[test]
+    fn test_block_sort() {
+        let mut test = SortTest::new();
+
+        println!("max_block_size = {}", test.max_block_size);
+        let block_size = 1024; // see shader
+        assert!(block_size <= test.max_block_size);
+
+        let num_kv = 1024.min(block_size);
+
+        let mut expected = Vec::with_capacity(num_kv as usize);
+        for i in 0..num_kv as usize {
+            // Repeat both keys within each local run to exercise secondary-key
+            // ordering and duplicate-key payload preservation.
+            expected.push(DualKeyValuePair {
+                key: 63 - (i % 64) as u32,
+                key2: ((i / 64) % 16) as f32,
+                value: i as u32,
+            });
+        }
+        let s = expected.chunks(8).fold("".to_string(), |acc, x| {
+            x.iter().fold(acc, |acc, x| {
+                format!("{acc} ({0:03},{1:03},{2:04})", x.key, x.key2, x.value)
+            }) + "\n"
+        });
+        eprintln!("input:\n{s}\n[...]");
+
+        //let num_items_per_thread = num_kv.div_ceil(64) as usize;
+        let num_items_per_thread = 16; // see shader
+
+        // Dispatch to GPU
+        let workgroups = UVec3::new(1, 1, 1);
+        let view = test.dispatch("test_block_sort", num_kv, &expected[..], workgroups);
+
+        // Validate content
+        let count_slice: &[u32] = cast_slice(&view[..4]);
+        assert_eq!(count_slice[0], num_kv); // should not be overwritten
+        let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
+        for (chunk_index, actual) in view_slice.chunks(block_size as usize).enumerate() {
+            let s = actual.chunks(8).fold("".to_string(), |acc, x| {
+                x.iter().fold(acc, |acc, x| {
+                    format!("{acc} ({0:03},{1:03},{2:04})", x.key, x.key2, x.value)
+                }) + "\n"
+            });
+            eprintln!("output chunk #{chunk_index}:\n{s}");
+            assert!(
+                actual.windows(2).all(|pair| pair[0] <= pair[1]),
+                "local run {chunk_index} is not sorted"
+            );
+            let mut values: Vec<_> = actual.iter().map(|pair| pair.value).collect();
+            values.sort_unstable();
+            let first = chunk_index * num_items_per_thread;
+            let expected: Vec<_> = (first..first + actual.len()).map(|i| i as u32).collect();
+            assert_eq!(values, expected, "local run {chunk_index} lost a payload");
+        }
+    }
+
     #[test]
     fn test_serial_insertion_sort() {
-        let renderer = MockRenderer::new();
-        let device = renderer.device();
-        let queue = renderer.queue();
+        let mut test = SortTest::new();
+
         let num_kv = 257u32;
-        let byte_size = 4 + num_kv as u64 * DualKeyValuePair::SHADER_SIZE.get();
-        let sort_buffer = device.create_buffer(&BufferDescriptor {
-            label: Some("sort_buffer"),
-            size: byte_size,
-            usage: BufferUsages::STORAGE | BufferUsages::MAP_READ,
-            mapped_at_creation: true,
-        });
 
         let mut expected = Vec::with_capacity(num_kv as usize);
         for i in 0..num_kv {
@@ -627,88 +732,15 @@ mod gpu_tests {
                 value: i,
             });
         }
-        {
-            let mut mapped = sort_buffer.slice(..).get_mapped_range_mut();
-            mapped.slice(..4).copy_from_slice(cast_slice(&[num_kv]));
-            mapped
-                .slice(4..)
-                .copy_from_slice(cast_slice(expected.as_slice()));
-        }
-        sort_buffer.unmap();
+
+        // Dispatch to GPU
+        let workgroups = UVec3::new(1, 1, 1);
+        let view = test.dispatch("main", num_kv, &expected[..], workgroups);
+
+        // Sort locally on CPU
         expected.sort();
 
-        let bind_group_layout = device.create_bind_group_layout(
-            "bind_group_layout",
-            &BindGroupLayoutEntries::single(
-                ShaderStages::COMPUTE,
-                storage_buffer_sized(false, None),
-            ),
-        );
-        let bind_group = device.create_bind_group(
-            None,
-            &bind_group_layout,
-            &BindGroupEntries::single(sort_buffer.as_entire_binding()),
-        );
-        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
-            label: Some("pipeline_layout"),
-            bind_group_layouts: &[Some(&bind_group_layout)],
-            immediate_size: 0,
-        });
-        let src = VFX_SORT_WGSL
-            .replace("#ifdef HAS_DUAL_KEY", "")
-            .replace("#ifdef TEST", "")
-            .replace("#endif", "");
-        let shader_module = device.create_and_validate_shader_module(ShaderModuleDescriptor {
-            label: Some("vfx_sort"),
-            source: ShaderSource::Wgsl(src.into()),
-        });
-        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
-            label: Some("test_serial_insertion_sort"),
-            layout: Some(&pipeline_layout),
-            module: &shader_module,
-            entry_point: Some("main"),
-            compilation_options: PipelineCompilationOptions {
-                constants: &[],
-                zero_initialize_workgroup_memory: false,
-            },
-            cache: None,
-        });
-
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("test"),
-        });
-        {
-            let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
-                label: Some("test_serial_insertion_sort"),
-                timestamp_writes: None,
-            });
-            compute_pass.set_pipeline(&pipeline);
-            compute_pass.set_bind_group(0, &bind_group, &[]);
-            compute_pass.dispatch_workgroups(1, 1, 1);
-        }
-        queue.submit([encoder.finish()]);
-        let (tx, rx) = futures::channel::oneshot::channel();
-        queue.on_submitted_work_done(move || {
-            tx.send(()).unwrap();
-        });
-        let _ = device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        });
-        let _ = futures::executor::block_on(rx);
-
-        let buffer_slice = sort_buffer.slice(..);
-        let (tx, rx) = futures::channel::oneshot::channel();
-        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
-            tx.send(result).unwrap();
-        });
-        let _ = device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        });
-        let _ = futures::executor::block_on(rx);
-        let view = buffer_slice.get_mapped_range();
-        assert_eq!(view.len(), byte_size as usize);
+        // Compare results
         assert_eq!(cast_slice::<_, u32>(&view[..4]), &[0]);
         assert_eq!(
             cast_slice::<_, DualKeyValuePair>(&view[4..]),
@@ -716,156 +748,174 @@ mod gpu_tests {
         );
     }
 
+    /// Calculate the merge path for a parallel merge.
+    #[test]
+    fn test_calc_merge_path() {
+        let mut test = SortTest::new();
+
+        let block_size = 1024.min(test.max_block_size); // total input buffer size
+        let list_len = block_size / 2 - 3;
+        let num_kv = list_len * 2; // ensure we don't have an odd size
+        println!("block_size = {}", block_size);
+        println!("list_len = {}", list_len);
+
+        let mut expected = Vec::with_capacity(num_kv as usize);
+        let mut values = vec![
+            DualKeyValuePair {
+                key: 0,
+                key2: 0.0,
+                value: 0,
+            };
+            num_kv as usize
+        ];
+        assert_eq!(num_kv % 2, 0);
+        assert_eq!(num_kv / 2, list_len);
+        {
+            let (values_a, values_b) = values.split_at_mut(list_len as usize);
+            let mut thread_rng = rand::rng();
+            let max_value = list_len - 30; // limit the range to force duplicate values
+            for i in 0..list_len {
+                values_a[i as usize].key = thread_rng.random_range(0..max_value);
+                values_a[i as usize].key2 = i as f32 * 0.1;
+                values_a[i as usize].value = i;
+
+                values_b[i as usize].key = thread_rng.random_range(0..max_value);
+                values_b[i as usize].key2 = i as f32 * 0.1;
+                values_b[i as usize].value = list_len + i;
+
+                expected.push(values_a[i as usize]);
+                expected.push(values_b[i as usize]);
+            }
+            values_a.sort();
+            values_b.sort();
+        }
+
+        // Dispatch to GPU
+        let workgroups = UVec3::new(1, 1, 1);
+        let view = test.dispatch("test_calc_merge_path", num_kv, &values[..], workgroups);
+
+        // Calculate the expected result by doing the actual sort, and deriving all the
+        // merge paths from it.
+        expected.sort();
+        let total_path_len = list_len * 2;
+        let path_len = total_path_len.div_ceil(64);
+        let num_paths = total_path_len.div_ceil(path_len);
+        println!("path_len = {path_len}");
+        println!("num_paths = {num_paths}");
+        let mut paths: Vec<_> = (0..num_paths)
+            .map(|ipath| {
+                let start = (ipath * path_len) as usize;
+                let end = (start + path_len as usize).min(total_path_len as usize);
+                let slice = &expected[start..end];
+                let mut ia = 0;
+                for kv in slice {
+                    if kv.value < list_len {
+                        ia += 1;
+                    }
+                }
+                ia
+            })
+            .collect();
+        for i in 1..paths.len() {
+            // The path at index #i is actually the cumulated path from start. Above we
+            // counted only the i_a within a cross-diagonal interval, but the GPU calculates
+            // the total i_a for the path starting at the beginning of the block up to the
+            // diagonal.
+            paths[i] += paths[i - 1];
+        }
+        //println!("EXPECTED:");
+        // for (i, exp_val) in paths.iter().enumerate() {
+        //     let diag = (i as u32 + 1) * path_len;
+        //     let i_a = *exp_val;
+        //     let i_b = diag - i_a;
+        //     println!("+ PATH #{i} : diag={diag} i_a={i_a} i_b={i_b}");
+        //     let s: String = (0..path_len)
+        //         .map(|idx| expected[idx as usize + (i * path_len as usize)])
+        //         .fold("".to_string(), |acc, x| {
+        //             format!(
+        //                 "{} {}[{},{},{}]",
+        //                 acc,
+        //                 if x.value < list_len { 'A' } else { 'B' },
+        //                 x.key,
+        //                 x.key2,
+        //                 x.value
+        //             )
+        //         });
+        //     println!("  {s}");
+        // }
+
+        // Validate content
+        let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
+        assert_eq!(view_slice.len(), list_len as usize * 2);
+        assert!(view_slice.len() >= paths.len());
+        for (i, exp_val) in paths.iter().enumerate() {
+            // The test shader stores the resulting i_a[] into the 'value' of the first N
+            // entries of the sort buffer, and the diagonal value of the path into the 'key'
+            // field.
+
+            let calc_diag = view_slice[i].key;
+            let exp_diag = ((i as u32 + 1) * path_len).min(total_path_len);
+            assert_eq!(calc_diag, exp_diag);
+
+            let calc_ia = view_slice[i].value;
+            let exp_ia = *exp_val;
+            assert_eq!(calc_ia, exp_ia);
+
+            // println!(
+            //     "-> [{}] diag={} a_i={} b_i={} [EXPECTED:{}]",
+            //     i,
+            //     view_slice[i].key,
+            //     view_slice[i].value,
+            //     view_slice[i].key - view_slice[i].value,
+            //     *exp_val
+            // );
+        }
+    }
+
     /// Calculate the effect index from a particle index using a binary search
     /// of the base particle prefix sum.
     #[test]
     fn test_binary_search_prefix_sum() {
-        let renderer = MockRenderer::new();
-        let device = renderer.device();
-        let queue = renderer.queue();
+        let mut test = SortTest::new();
 
-        println!(
-            "max_compute_workgroup_storage_size = {}",
-            device.limits().max_compute_workgroup_storage_size
-        );
+        let num_particle = 1024.min(test.max_block_size);
 
-        // SAFETY : for debugging only
-        #[allow(unsafe_code)]
-        unsafe {
-            device.wgpu_device().start_graphics_debugger_capture()
-        };
-
-        // Clamp max block size to the device's reported storage
-        let max_block_size = device.limits().max_compute_workgroup_storage_size
-            / (2 * DualKeyValuePair::SHADER_SIZE.get() as u32);
-        println!("max_block_size = {}", max_block_size);
-        let num_particle = 1024.min(max_block_size);
-
-        let byte_size = 4 + num_particle as u64 * DualKeyValuePair::SHADER_SIZE.get();
-        let sort_buffer = device.create_buffer(&BufferDescriptor {
-            label: Some("sort_buffer"),
-            size: byte_size,
-            usage: BufferUsages::STORAGE | BufferUsages::MAP_READ,
-            mapped_at_creation: true,
-        });
+        // We use the sort buffer as a generic test data I/O storage. The pairs array is
+        // exactly sized to the number of particles to test.
+        //
+        // Input:
+        // - count: number of effects
+        // - pairs:
+        //   - key[..num_effects] : prefix sum
+        //
+        // Output:
+        // - pairs:
+        //   - value[..num_particles] : index of the effect for the given particle
         let effects = [0, 35, 399, 1000];
         assert!((effects.len() as u32) < num_particle);
         let values: Vec<_> = (0..num_particle as usize)
             .map(|i| DualKeyValuePair {
                 key: effects.get(i).copied().unwrap_or(0xDEAD0000),
-                key2: i as f32 * 0.1,
-                value: i as u32,
+                key2: i as f32 * 0.1, // unused
+                value: i as u32,      // unused
             })
             .collect();
-        {
-            // Scope get_mapped_range_mut() to force a drop before unmap()
-            {
-                let mut mapped = sort_buffer.slice(..).get_mapped_range_mut();
-                mapped
-                    .slice(..4)
-                    .copy_from_slice(cast_slice(&[effects.len() as u32]));
-                mapped
-                    .slice(4..)
-                    .copy_from_slice(cast_slice(values.as_slice()));
-            }
-            sort_buffer.unmap();
-        }
 
-        // Create GPU resources
-        let bind_group_layout = device.create_bind_group_layout(
-            "bind_group_layout",
-            &BindGroupLayoutEntries::single(
-                ShaderStages::COMPUTE,
-                storage_buffer_sized(false, None),
-            ),
+        // Dispatch to GPU
+        let workgroups = UVec3::new(1, 1, 1);
+        let view = test.dispatch(
+            "test_find_effect_from_particle",
+            effects.len() as u32,
+            &values[..],
+            workgroups,
         );
-        let bind_group = device.create_bind_group(
-            None,
-            &bind_group_layout,
-            &BindGroupEntries::single(sort_buffer.as_entire_binding()),
-        );
-        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
-            label: Some("pipeline_layout"),
-            bind_group_layouts: &[Some(&bind_group_layout)],
-            immediate_size: 0,
-        });
-        let src = VFX_SORT_WGSL
-            .replace("#ifdef HAS_DUAL_KEY", "")
-            .replace("#ifdef TEST", "")
-            .replace("#endif", "");
-        let shader_module = device.create_and_validate_shader_module(ShaderModuleDescriptor {
-            label: Some("vfx_sort"),
-            source: ShaderSource::Wgsl(src.into()),
-        });
-        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
-            label: Some("test_binary_search_prefix_sum"),
-            layout: Some(&pipeline_layout),
-            module: &shader_module,
-            entry_point: Some("test_find_effect_from_particle"),
-            compilation_options: PipelineCompilationOptions {
-                constants: &[],
-                // Ensure the shader behaves even if memory is not zero-initialized
-                zero_initialize_workgroup_memory: false,
-            },
-            cache: None,
-        });
-
-        // Dispatch test
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("test"),
-        });
-        {
-            let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
-                label: Some("test_binary_search_prefix_sum"),
-                timestamp_writes: None,
-            });
-            compute_pass.set_pipeline(&pipeline);
-            compute_pass.set_bind_group(0, &bind_group, &[]);
-            compute_pass.dispatch_workgroups(1, 1, 1);
-        }
-
-        // Submit command queue and wait for execution
-        println!("Executing pipeline...");
-        let command_buffer = encoder.finish();
-        queue.submit([command_buffer]);
-        let (tx, rx) = futures::channel::oneshot::channel();
-        queue.on_submitted_work_done(move || {
-            tx.send(()).unwrap();
-        });
-        let _ = device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        });
-        let _ = futures::executor::block_on(rx);
-        println!("Pipeline executed");
-
-        // SAFETY : for debugging only
-        #[allow(unsafe_code)]
-        unsafe {
-            device.wgpu_device().stop_graphics_debugger_capture()
-        };
-
-        // Read back (GPU -> CPU)
-        println!("Downloading result buffer from GPU to CPU...");
-        let buffer_slice = sort_buffer.slice(..);
-        let (tx, rx) = futures::channel::oneshot::channel();
-        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
-            tx.send(result).unwrap();
-        });
-        let _ = device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        });
-        let _result = futures::executor::block_on(rx);
-        let view = buffer_slice.get_mapped_range();
-        println!("Result buffer downloaded to CPU");
 
         // Validate content
-        assert_eq!(view.len(), byte_size as usize);
         let view_slice: &[DualKeyValuePair] = cast_slice(&view[4..]);
         for (i, kv) in view_slice.iter().enumerate() {
             //println!("[#{}] k={} k2={} v={}", i, kv.key, kv.key2, kv.value);
 
+            // Do the binary search on CPU
             let mut effect_index = usize::MAX;
             for (idx, base_particle) in effects.iter().enumerate().rev() {
                 if i as u32 >= *base_particle {
@@ -874,11 +924,193 @@ mod gpu_tests {
                 }
             }
             assert!(effect_index <= effects.len());
+
+            // Validate the GPU result against the CPU one
             assert_eq!(
                 effect_index as u32, kv.value,
                 "Test failed for particle {} : expected effect index {}, got {}",
                 i, effect_index, kv.value
             );
+        }
+    }
+
+    /// Helper for all GPU sort tests.
+    struct SortTest {
+        #[allow(dead_code)]
+        pub renderer: MockRenderer,
+        pub device: RenderDevice,
+        pub queue: RenderQueue,
+        /// Max block size calculated from GPU device shared workgroup memory
+        /// limit.
+        pub max_block_size: u32,
+    }
+
+    impl SortTest {
+        /// Create a new GPU sort test instance.
+        fn new() -> SortTest {
+            let renderer = MockRenderer::new();
+            let device = renderer.device();
+            let queue = renderer.queue();
+
+            println!(
+                "max_compute_workgroup_storage_size = {}",
+                device.limits().max_compute_workgroup_storage_size
+            );
+
+            // SAFETY : for debugging only
+            #[allow(unsafe_code)]
+            unsafe {
+                device.wgpu_device().start_graphics_debugger_capture()
+            };
+
+            // Clamp max block size to the device's reported storage
+            let max_block_size = device.limits().max_compute_workgroup_storage_size
+                / (DualKeyValuePair::SHADER_SIZE.get() as u32);
+            println!("max_block_size = {}", max_block_size);
+
+            Self {
+                renderer,
+                device,
+                queue,
+                max_block_size,
+            }
+        }
+
+        /// Dispatch the sort test with the given sort buffer data.
+        ///
+        /// The `entry_point` is the compute shader entry point name to execute
+        /// (often a test-only entry point). The `count` and `pairs` are the
+        /// data of the sort buffer to upload to GPU before dispatching.
+        /// `workgroups` is the number of workgroups to dispatch.
+        ///
+        /// # Returns
+        ///
+        /// A view over the GPU buffer content, downloaded from GPU to CPU after
+        /// the GPU executed the sort shader test.
+        fn dispatch(
+            &mut self,
+            entry_point: &str,
+            count: u32,
+            pairs: &[DualKeyValuePair],
+            workrgoups: UVec3,
+        ) -> BufferView {
+            // Allocate sort buffer
+            let byte_size = 4 + pairs.len() as u64 * DualKeyValuePair::SHADER_SIZE.get();
+            let sort_buffer = self.device.create_buffer(&BufferDescriptor {
+                label: Some("sort_buffer"),
+                size: byte_size,
+                usage: BufferUsages::STORAGE | BufferUsages::MAP_READ,
+                mapped_at_creation: true,
+            });
+            {
+                // Scope get_mapped_range_mut() to force a drop before unmap()
+                {
+                    let mut mapped = sort_buffer.slice(..).get_mapped_range_mut();
+                    mapped.slice(..4).copy_from_slice(cast_slice(&[count]));
+                    mapped.slice(4..).copy_from_slice(cast_slice(pairs));
+                }
+                sort_buffer.unmap();
+            }
+
+            // Create GPU resources
+            let bind_group_layout = self.device.create_bind_group_layout(
+                "bind_group_layout",
+                &BindGroupLayoutEntries::single(
+                    ShaderStages::COMPUTE,
+                    storage_buffer_sized(false, None),
+                ),
+            );
+            let bind_group = self.device.create_bind_group(
+                None,
+                &bind_group_layout,
+                &BindGroupEntries::single(sort_buffer.as_entire_binding()),
+            );
+            let pipeline_layout = self
+                .device
+                .create_pipeline_layout(&PipelineLayoutDescriptor {
+                    label: Some("pipeline_layout"),
+                    bind_group_layouts: &[Some(&bind_group_layout)],
+                    immediate_size: 0,
+                });
+            let src = VFX_SORT_WGSL
+                .replace("#ifdef HAS_DUAL_KEY", "")
+                .replace("#ifdef TEST", "")
+                .replace("#endif", "");
+            let shader_module =
+                self.device
+                    .create_and_validate_shader_module(ShaderModuleDescriptor {
+                        label: Some("vfx_sort"),
+                        source: ShaderSource::Wgsl(src.into()),
+                    });
+            let pipeline = self
+                .device
+                .create_compute_pipeline(&ComputePipelineDescriptor {
+                    label: Some(entry_point),
+                    layout: Some(&pipeline_layout),
+                    module: &shader_module,
+                    entry_point: Some(entry_point),
+                    compilation_options: PipelineCompilationOptions {
+                        constants: &[],
+                        zero_initialize_workgroup_memory: false,
+                    },
+                    cache: None,
+                });
+
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("test"),
+                });
+
+            // Dispatch test
+            {
+                let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                    label: Some(entry_point),
+                    timestamp_writes: None,
+                });
+                compute_pass.set_pipeline(&pipeline);
+                compute_pass.set_bind_group(0, &bind_group, &[]);
+                compute_pass.dispatch_workgroups(workrgoups.x, workrgoups.y, workrgoups.z);
+            }
+
+            // Submit command queue and wait for execution
+            println!("Executing pipeline...");
+            let command_buffer = encoder.finish();
+            self.queue.submit([command_buffer]);
+            let (tx, rx) = futures::channel::oneshot::channel();
+            self.queue.on_submitted_work_done(move || {
+                tx.send(()).unwrap();
+            });
+            let _ = self.device.poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            });
+            let _ = futures::executor::block_on(rx);
+            println!("Pipeline executed");
+
+            // SAFETY : for debugging only
+            #[allow(unsafe_code)]
+            unsafe {
+                self.device.wgpu_device().stop_graphics_debugger_capture()
+            };
+
+            // Read back (GPU -> CPU)
+            println!("Downloading result buffer from GPU to CPU...");
+            let buffer_slice = sort_buffer.slice(..);
+            let (tx, rx) = futures::channel::oneshot::channel();
+            buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+                tx.send(result).unwrap();
+            });
+            let _ = self.device.poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            });
+            let _ = futures::executor::block_on(rx);
+            let view = buffer_slice.get_mapped_range();
+            assert_eq!(view.len(), byte_size as usize);
+            println!("Result buffer downloaded to CPU");
+
+            view
         }
     }
 }

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -280,56 +280,6 @@ fn find_log2(value: u32) -> u32 {
     return num;
 }
 
-/// Parallel merge-sort combining a block-level parallel sort followed by a serial mergesort.
-fn block_parallel_merge_sort(thread_id: u32, block_id: u32) {
-    let total_num_items = u32(sort_buffer.count);
-
-    // Loop over all blocks and block-sort each serially (TODO - parallelize this too)
-    let num_blocks = (total_num_items + blockSize - 1) / blockSize;
-    {
-        let offset = block_id * blockSize;
-        let count = min(offset + blockSize, total_num_items) - offset;  // <= blockSize
-        block_sort(thread_id, offset, offset, count);
-    }
-
-    // Wait for all threads to write per-block sorted lists into the storage sort buffer
-    storageBarrier();
-    workgroupBarrier();
-
-    // Recursively merge the blockSize-length sorted lists into a single globally sorted one.
-    // FIXME - parallelize this...
-    if (thread_id == 0 && block_id == 0) {
-        src = 0u;
-        dst = total_num_items;
-        merge_lists_serial(0u, blockSize, blockSize, blockSize, 0u, total_num_items);
-
-        // for (var i: u32 = 0; i < total_num_items; i += 1u) {
-        //     sort_buffer.pairs[total_num_items + i] = sort_buffer.pairs[i];
-        // }
-
-        // src = 0u;
-        // dst = total_num_items;
-        // var left = num_blocks;
-        // while (left > 1u) {
-        //     var step = 1u;
-        //     while (step < left) {
-        //         for (var i: u32 = 0u; i + step < left; i += step * 2u) {
-        //             merge_lists_serial(i, step, i + step, step, src, dst);
-        //         }
-        //         step <<= 1u;
-
-        //         //storageBarrier();
-
-        //         // Swap source/destination lists for next iteration
-        //         let tmp = src;
-        //         src = dst;
-        //         dst = tmp;
-        //     }
-        //     left >>= 1u;
-        // }
-    }
-}
-
 /// Sort each block in parallel on a separate workgroup.
 @compute @workgroup_size(64)
 fn parallel_block_sort(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
@@ -476,13 +426,6 @@ fn test_block_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32
     let tid = global_invocation_id.x;
     let total_num_items = u32(sort_buffer.count);
     block_sort(tid, 0u, 0u, total_num_items);
-}
-
-/// Test for parallel_merge_sort().
-@compute @workgroup_size(64)
-fn test_block_parallel_merge_sort(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
-    let block_id = workgroup_id.x;  // wgpu doesn't support @builtin(workgroup_index)
-    block_parallel_merge_sort(thread_id, block_id);
 }
 
 #endif

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -460,10 +460,11 @@ fn test_block_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32
 //     sort_buffer.count = 0;
 // }
 
-/// Block-sort 1024 particles per workgroup. Larger inputs are merged by
-/// vfx_sort_merge.wgsl in subsequent compute passes.
+/// Sort particles in blocks of 1024 per workgroup.
+///
+/// Larger inputs are merged by vfx_sort_merge.wgsl in subsequent compute passes.
 @compute @workgroup_size(64)
-fn main(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
+fn sort_blocks(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
     let block_id = workgroup_id.x;  // wgpu doesn't support @builtin(workgroup_index)
 
     let total_num_items = u32(sort_buffer.count);

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -39,13 +39,128 @@ fn compare_greater(kv1: KeyValuePair, kv2: KeyValuePair) -> bool {
 @group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
 
 /// Size of a block of KeyValuePair in workgroup memory.
-const blockSize: u32 = 512u;
+const blockSize: u32 = 1024u;
+
+/// Number of items sorted per thread, serially.
+const numItemPerThread: u32 = 16u;
+
+/// Number of threads per workgroup (block).
+const numThreads: u32 = 64u;
 
 // Workgroup has at least 16kB memory (max_compute_workgroup_storage_size).
 // Note that Vulkan on Windows 11 report 16352, not 16384 (so, lower than
 // the default in the wgpu docs).
-var<workgroup> arr0 : array<KeyValuePair, blockSize>;
-var<workgroup> arr1 : array<KeyValuePair, blockSize>;
+var<workgroup> shared_pairs : array<KeyValuePair, blockSize>;
+
+/// Sort locally inside a single workgroup, using workgroup-shared memory.
+///
+/// Workgroup has up to 16kB, for 8-byte keys (dual) that's 2k elements. Since
+/// we need 2 arrays for ping-pong, we can do up to 1024 elements at once.
+///
+/// https://moderngpu.github.io/mergesort.html#blocksort
+/// https://moderngpu.github.io/mergesort.html#sortnetworks
+fn block_sort(num_items: u32, tid: u32, data: ptr<function, array<KeyValuePair, numItemPerThread>>) {
+    // Each thread sorts serially its own slice into a local array
+    var pairs: array<KeyValuePair, numItemPerThread>;
+    let begin = tid * numItemPerThread;
+    let end = min(num_items, begin + numItemPerThread);
+    for (var i: u32 = begin; i < end; i += 1u) {
+        pairs[i - begin] = sort_buffer.pairs[i];
+    }
+
+
+
+    // Merge-sort blocks of 'size' items
+    for (var size: i32 = 2; size <= 512; size *= 2) {
+
+    }
+}
+
+/// Calculate a single merge path for a subsequent parallel merge.
+///
+/// INPUTS:
+/// - Values A : var<workgroup> shared_pairs[num_a]
+/// - Values B : var<workgroup> arr1[num_b]
+/// - Index of diagonal constraint : diag
+///
+/// OUTPUT:
+/// Index in A of the merge path end. The index in B is ib = (diag - ia),
+/// since a merge path is always of length 'diag' so (ia + ib == diag).
+///
+/// The merge path is such that the merged sub-list [0..diag[ contains the
+/// first 'i_a' elements of A and the first 'i_b' elements of B. This means
+/// that we can load and merge in parallel exactly the elements between two
+/// consecutive diagonals, since we know exactly in advance which elements
+/// of the merged lists will be used, before we even start the actual merge.
+/// So calling calc_merge_path() N times sub-divides some merge lists into
+/// N+1 independent mergeable intervals. We can then recusrively merge down.
+///
+/// https://moderngpu.github.io/bulkinsert.html#mergepath
+fn calc_merge_path(offset_a: u32, offset_b: u32, num_a: u32, num_b: u32, diag: u32) -> u32 {
+    // Intersection of cross-diagonal with the X axis (alongside A) at the
+    // bottom of the merge matrix. This is the min A value to consider.
+    var begin = diag - min(diag, num_b); // == min(0, diag - num_b) >= 0
+    // Intersection of cross-diagonal with the X axis (alongside A) at the
+    // top of the merge matrix. This is the max A value to consider.
+    var end = min(diag, num_a);
+
+    // Binary search the cross-diagonal intersection with the merge path,
+    // which is the index where the values are sorted.
+    while (begin < end) {
+        let mid = (begin + end) >> 1u;
+        // Only if b < a do we move B, otherwise in case of equality we
+        // favor A, to ensure stability (since A is the first merge list,
+        // so its elements are originally located before those of B before
+        // we merge).
+        if (compare_greater(shared_pairs[offset_a + mid], shared_pairs[offset_b + diag - 1u - mid])) {
+            end = mid;
+        } else {
+            begin = mid + 1;
+        }
+    }
+
+    return begin;
+}
+
+/// Batcher's odd-even merge sort.
+///
+/// INPUTS:
+/// - Values A : var<workgroup> shared_pairs[]
+/// - Offset from the start of shared_pairs where the values to sort start : offset
+/// - Number of values to sort : n
+///
+/// OUTPUTS:
+/// - Values A in shared_pairs[], sorted
+///
+/// This is a sorting network. Not asymptotically optimal, but reasonably efficient.
+/// It's more of a reference implementation, from 1998. Not the fastest by today's
+/// standards. It's not stable.
+///
+/// https://en.wikipedia.org/wiki/Batcher_odd%E2%80%93even_mergesort
+fn batcher_odd_even_mergesort(data: ptr<function, array<KeyValuePair, numItemPerThread>>) {
+    for (var p: u32 = 1; p < numItemPerThread; p += p) {
+        for (var k: u32 = p; k >= 1; k = k >> 1) {
+            for (var j: u32 = k % p; j + k < numItemPerThread; j += 2 * k) {
+                for (var i: u32 = 0; i < min(k, numItemPerThread - j - k); i += 1) {
+                    let i0 = i + j;
+                    let i1 = i + j + k;
+                    let f0 = f32(i0) / f32(2 * p);
+                    let f1 = f32(i1) / f32(2 * p);
+                    // i0 < i1 < numItemPerThread - 1
+                    if (floor(f0) == floor(f1)) {
+                        let idx0 = i0;
+                        let idx1 = i1;
+                        if (compare_greater(data[idx0], data[idx1])) {
+                            let kv = data[idx0];
+                            data[idx0] = data[idx1];
+                            data[idx1] = kv;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 /// Find the index of an effect from the index of a particle.
 ///
@@ -58,7 +173,7 @@ fn find_effect_from_particle(num_effects: u32, particle_index: u32) -> u32 {
     var nnn = 0;
     while (lo < hi) {
         let mid = (hi + lo) >> 1u;
-        let base_particle = arr0[mid].key;
+        let base_particle = shared_pairs[mid].key;
         if (particle_index >= base_particle) {
             lo = mid + 1u;
         } else if (particle_index < base_particle) {
@@ -74,25 +189,21 @@ fn find_effect_from_particle(num_effects: u32, particle_index: u32) -> u32 {
 
 #ifdef TEST
 
+/// Test for find_effect_from_particle().
 @compute @workgroup_size(64)
 fn test_find_effect_from_particle(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let tid = global_invocation_id.x;
     
-    let num_particles = arrayLength(&sort_buffer.pairs);
+    // Read test data from sort buffer
     let num_effects = u32(sort_buffer.count);
-
-    // Copy prefix sum into arr0[]
+    let num_particles = arrayLength(&sort_buffer.pairs);
     if (tid < num_effects) {
-        arr0[tid] = sort_buffer.pairs[tid];
+        shared_pairs[tid] = sort_buffer.pairs[tid];
     }
 
     workgroupBarrier();
-    
-    // Only branch after sync
-    if (tid >= 64) {
-        return;
-    }
 
+    // Execute the actual test
     let particle_per_thread = (num_particles + 63u) >> 6u;
     let first_particle = particle_per_thread * tid;
     let last_particle = min(first_particle + particle_per_thread, num_particles);
@@ -101,7 +212,167 @@ fn test_find_effect_from_particle(@builtin(global_invocation_id) global_invocati
     }
 }
 
+/// Test for batcher_odd_even_mergesort().
+@compute @workgroup_size(64)
+fn test_batcher_odd_even_mergesort(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let tid = global_invocation_id.x;
+    let total_num_items = u32(sort_buffer.count);
+
+    // Threads copy all items into a local register array
+    var pairs: array<KeyValuePair, numItemPerThread>;
+    let base_item = tid * numItemPerThread;
+    let num_items = min(numItemPerThread, total_num_items - base_item);
+    for (var i: u32 = base_item; i < base_item + num_items; i += 1u) {
+        pairs[i - base_item] = sort_buffer.pairs[i];
+    }
+
+    workgroupBarrier();
+
+    // Sort all items in the local array
+    batcher_odd_even_mergesort(&pairs);
+
+    workgroupBarrier();
+
+    // Threads copy all items back into sort_buffer
+    for (var i: u32 = base_item; i < base_item + num_items; i += 1u) {
+        sort_buffer.pairs[i] = pairs[i - base_item];
+    }
+}
+
+/// Test for calc_merge_path().
+@compute @workgroup_size(64)
+fn test_calc_merge_path(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let tid = global_invocation_id.x;
+
+    // 64 threads copy all items into shared_pairs
+    let total_num_items = u32(sort_buffer.count) >> 1u;
+    let num_items_per_thread = (total_num_items + 63u) >> 6u;
+    let base_item = tid * num_items_per_thread;
+    let num_items = min(num_items_per_thread, total_num_items - base_item);
+    for (var i: u32 = base_item; i < base_item + num_items; i += 1u) {
+        // First half -> shared_pairs
+        shared_pairs[i] = sort_buffer.pairs[i];
+        // Second half -> shared_pairs
+        shared_pairs[total_num_items + i] = sort_buffer.pairs[total_num_items + i];
+    }
+
+    workgroupBarrier();
+
+    // The total path length is the sum of the lengths of the two lists, which here
+    // because they're of the same size is (total_num_items * 2u).
+    let total_path_len = total_num_items * 2u;
+
+    // Divide the entire merge into one interval per thread. The last interval can
+    // be shorter, which exercises the final partial merge tile.
+    let path_len = (total_path_len + 63u) / 64u;
+    let num_paths = (total_path_len + path_len - 1) / path_len;
+
+    // Calculate the merge path for each section
+    if (tid < num_paths) {
+        let diag = min((tid + 1u) * path_len, total_path_len);
+        let start_a = 0u;
+        let num_a = total_num_items;
+        let start_b = num_a;
+        let num_b = num_a;  // merging 2 lists of same size
+        let a_i = calc_merge_path(start_a, start_b, num_a, num_b, diag);
+
+        // Copy results into sort_buffer
+        sort_buffer.pairs[tid].key = diag;
+        sort_buffer.pairs[tid].value = a_i;
+    }
+}
+
+/// Test for block_sort().
+@compute @workgroup_size(64)
+fn test_block_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let tid = global_invocation_id.x;
+    let total_num_items = u32(sort_buffer.count);
+
+    var pairs: array<KeyValuePair, numItemPerThread>;
+
+    // Each thread copies numItemPerThread into a local register array, then sort
+    // that array serially inside the thread, before copying the sorted result
+    // into shared workgroup memory for the block-level merge sort.
+    let num_threads = (total_num_items + numItemPerThread - 1) / numItemPerThread;
+    let begin = tid * numItemPerThread;
+    let end = min(total_num_items, begin + numItemPerThread);
+    if (tid < num_threads) {
+        // Copy pairs into register array
+        for (var i: u32 = begin; i < end; i += 1u) {
+            pairs[i - begin] = sort_buffer.pairs[i];
+        }
+
+        // Sort array serially inside this thread
+        batcher_odd_even_mergesort(&pairs);
+
+        // Copy the data into shared workgroup memory
+        for (var i: u32 = begin; i < end; i += 1u) {
+            shared_pairs[i] = pairs[i - begin];
+        }
+    }
+    
+    // Wait for all threads to have sorted their own thread-local values, and written
+    // them into their own slice of shared memory, before we read back shared memory below.
+    workgroupBarrier();
+
+    // shared_pairs[] contains a series of numItemPerThread-length sorted sub-arrays.
+    // Merge-sort in parallel all those sub-arrays into increasibly larger sub-arrays
+    // with increasngly more (= coop) threads collaborating to process each merge.
+    for (var coop: u32 = 2u; coop <= numThreads; coop = coop * 2u) {
+        let list = ~(coop - 1) & tid;
+        let diag = min(total_num_items, numItemPerThread * ((coop - 1) & tid));
+        let start = numItemPerThread * list;
+        let a0 = min(total_num_items, start);
+        let b0 = min(total_num_items, start + numItemPerThread * (coop / 2));
+        let b1 = min(total_num_items, start + numItemPerThread * coop);
+
+        let num_a = b0 - a0;
+        let num_b = b1 - b0;
+        let a_i = calc_merge_path(a0, b0, num_a, num_b, diag);
+
+        // Merge the 2 sorted lists
+        var ia = a0 + a_i;
+        var ib = b0 + diag - a_i;
+        for (var i: u32 = 0; i < numItemPerThread; i += 1u) {
+            if ((ib >= b1) || ((ia < b0) && !compare_greater(shared_pairs[ia], shared_pairs[ib]))) {
+                pairs[i] = shared_pairs[ia];
+                ia += 1u;
+            } else {
+                pairs[i] = shared_pairs[ib];
+                ib += 1u;
+            }
+        }
+
+        // We're about to write back exactly numItemPerThread elements into the shared array.
+        // However by design threads may read more values in either of the two merged lists,
+        // so we need to wait for all co-op threads to finish reading before we can write back.
+        workgroupBarrier();
+
+        // Copy back into shared memory for next iteration
+        for (var i: u32 = 0; i < numItemPerThread; i += 1u) {
+            shared_pairs[begin + i] = pairs[i];
+        }
+
+        // Next iteration (or the final write) need to read back from shared memory, so we need
+        // to wait for all threads to finish writing there.
+        workgroupBarrier();
+    }
+
+    // Copy sorted items from shared workgroup memory back into sort_buffer
+    if (tid < num_threads) {
+        for (var i: u32 = begin; i < end; i += 1u) {
+            sort_buffer.pairs[i] = shared_pairs[i];
+        }
+    }
+}
+
 #endif
+
+// GPU sorts
+// https://linebender.org/wiki/gpu/sorting/
+// https://moderngpu.github.io/mergesort.html
+// https://moderngpu.github.io/mergesort.html#blocksort
+// https://moderngpu.github.io/segsort.html
 
 /// Naive insertion sort. TODO: replace with something faster.
 @compute @workgroup_size(64)

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -517,50 +517,15 @@ fn test_block_parallel_merge_sort(@builtin(local_invocation_index) thread_id: u3
 //     sort_buffer.count = 0;
 // }
 
-/// Slightly less naive sort. Block-sort with 64 threads in parallel, up to 1024 particles.
-/// Beyond that limit, just loop over 1024 particle chunks serially.
+/// Block-sort 1024 particles per workgroup. Larger inputs are merged by
+/// vfx_sort_merge.wgsl in subsequent compute passes.
 @compute @workgroup_size(64)
 fn main(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
     let block_id = workgroup_id.x;  // wgpu doesn't support @builtin(workgroup_index)
 
     let total_num_items = u32(sort_buffer.count);
 
-    // Loop over all blocks and block-sort each serially (TODO - parallelize this too)
-    let num_blocks = (total_num_items + blockSize - 1) / blockSize;
-    {
-        let offset = block_id * blockSize;
-        let count = min(offset + blockSize, total_num_items) - offset;  // <= blockSize
-        block_sort(thread_id, offset, offset, count);
-    }
-
-    // Wait for all threads to write per-block sorted lists into the storage sort buffer
-    storageBarrier();
-
-    // Recursively merge the blockSize-length sorted lists into a single globally sorted one.
-    // FIXME - parallelize this...
-    if (thread_id == 0) {
-        src = 0u;
-        dst = total_num_items;
-        var left = num_blocks;
-        while (left > 1u) {
-            var step = 1u;
-            while (step < left) {
-                for (var i: u32 = 0u; i + step < left; i += step * 2u) {
-                    merge_lists_serial(i, step, i + step, step, src, dst);
-                }
-                step <<= 1u;
-
-                //storageBarrier();
-
-                // Swap source/destination lists for next iteration
-                let tmp = src;
-                src = dst;
-                dst = tmp;
-            }
-            left >>= 1u;
-        }
-    }
-
-    // Clear for next frame
-    sort_buffer.count = 0;
+    let offset = block_id * blockSize;
+    let count = min(offset + blockSize, total_num_items) - offset;  // <= blockSize
+    block_sort(thread_id, offset, offset, count);
 }

--- a/src/render/vfx_sort.wgsl
+++ b/src/render/vfx_sort.wgsl
@@ -38,41 +38,114 @@ fn compare_greater(kv1: KeyValuePair, kv2: KeyValuePair) -> bool {
 
 @group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
 
-/// Size of a block of KeyValuePair in workgroup memory.
-const blockSize: u32 = 1024u;
-
 /// Number of items sorted per thread, serially.
 const numItemPerThread: u32 = 16u;
 
 /// Number of threads per workgroup (block).
 const numThreads: u32 = 64u;
 
+/// Size of a block of KeyValuePair in workgroup memory.
+const blockSize: u32 = numThreads * numItemPerThread;  // 1024
+
 // Workgroup has at least 16kB memory (max_compute_workgroup_storage_size).
 // Note that Vulkan on Windows 11 report 16352, not 16384 (so, lower than
 // the default in the wgpu docs).
-var<workgroup> shared_pairs : array<KeyValuePair, blockSize>;
+var<workgroup> shared_pairs : array<KeyValuePair, blockSize>;  // 12 kB
 
-/// Sort locally inside a single workgroup, using workgroup-shared memory.
+/// Offset inside the sort buffer pairs of the source half to read unsorted pairs from.
+var<private> src: u32;
+
+/// Offset inside the sort buffer pairs of the destination half to write sorted pairs to.
+var<private> dst: u32;
+
+/// Sort locally inside a single block (workgroup), using workgroup-shared memory.
 ///
-/// Workgroup has up to 16kB, for 8-byte keys (dual) that's 2k elements. Since
-/// we need 2 arrays for ping-pong, we can do up to 1024 elements at once.
+/// `tid` is the local thread ID inside the block (0..64). The `src` and `dst` offsets are
+/// the starts of blockSize-length memory blocks inside the sort buffer pairs, to read from
+/// and write to, respectively. `total_num_items` is the number of items in the block; this
+/// is typically equal to blockSize, except for the last block. `src == dst` is valid, and
+/// simply sort in-place inside the storage buffer.
 ///
 /// https://moderngpu.github.io/mergesort.html#blocksort
 /// https://moderngpu.github.io/mergesort.html#sortnetworks
-fn block_sort(num_items: u32, tid: u32, data: ptr<function, array<KeyValuePair, numItemPerThread>>) {
-    // Each thread sorts serially its own slice into a local array
+fn block_sort(tid: u32, src: u32, dst: u32, total_num_items: u32) {
+    
     var pairs: array<KeyValuePair, numItemPerThread>;
+
+    // Each thread copies numItemPerThread into a local register array, then sort
+    // that array serially inside the thread, before copying the sorted result
+    // into shared workgroup memory for the block-level merge sort.
+    let num_threads = (total_num_items + numItemPerThread - 1) / numItemPerThread;
     let begin = tid * numItemPerThread;
-    let end = min(num_items, begin + numItemPerThread);
-    for (var i: u32 = begin; i < end; i += 1u) {
-        pairs[i - begin] = sort_buffer.pairs[i];
+    let end = min(total_num_items, begin + numItemPerThread);
+    if (tid < num_threads) {
+        // Copy pairs into register array
+        for (var i: u32 = begin; i < end; i += 1u) {
+            pairs[i - begin] = sort_buffer.pairs[src + i];
+        }
+
+        // Sort array serially inside this thread
+        let num = end - begin;
+        batcher_odd_even_mergesort(&pairs, num);
+
+        // Copy the data into shared workgroup memory
+        for (var i: u32 = begin; i < end; i += 1u) {
+            shared_pairs[i] = pairs[i - begin];
+        }
+    }
+    
+    // Wait for all threads to have sorted their own thread-local values, and written
+    // them into their own slice of shared memory, before we read back shared memory below.
+    workgroupBarrier();
+
+    // shared_pairs[] contains a series of numItemPerThread-length sorted sub-arrays.
+    // Merge-sort in parallel all those sub-arrays into increasibly larger sub-arrays
+    // with increasngly more (= coop) threads collaborating to process each merge.
+    for (var coop: u32 = 2u; coop <= numThreads; coop = coop * 2u) {
+        let list = ~(coop - 1) & tid;
+        let diag = min(total_num_items, numItemPerThread * ((coop - 1) & tid));
+        let start = numItemPerThread * list;
+        let a0 = min(total_num_items, start);
+        let b0 = min(total_num_items, start + numItemPerThread * (coop / 2));
+        let b1 = min(total_num_items, start + numItemPerThread * coop);
+
+        let num_a = b0 - a0;
+        let num_b = b1 - b0;
+        let a_i = calc_merge_path(a0, b0, num_a, num_b, diag);
+
+        // Merge the 2 sorted lists
+        var ia = a0 + a_i;
+        var ib = b0 + diag - a_i;
+        for (var i: u32 = 0; i < numItemPerThread; i += 1u) {
+            if ((ib >= b1) || ((ia < b0) && !compare_greater(shared_pairs[ia], shared_pairs[ib]))) {
+                pairs[i] = shared_pairs[ia];
+                ia += 1u;
+            } else {
+                pairs[i] = shared_pairs[ib];
+                ib += 1u;
+            }
+        }
+
+        // We're about to write back exactly numItemPerThread elements into the shared array.
+        // However by design threads may read more values in either of the two merged lists,
+        // so we need to wait for all co-op threads to finish reading before we can write back.
+        workgroupBarrier();
+
+        // Copy back into shared memory for next iteration
+        for (var i: u32 = 0; i < numItemPerThread; i += 1u) {
+            shared_pairs[begin + i] = pairs[i];
+        }
+
+        // Next iteration (or the final write) need to read back from shared memory, so we need
+        // to wait for all threads to finish writing there.
+        workgroupBarrier();
     }
 
-
-
-    // Merge-sort blocks of 'size' items
-    for (var size: i32 = 2; size <= 512; size *= 2) {
-
+    // Copy sorted items from shared workgroup memory back into sort_buffer
+    if (tid < num_threads) {
+        for (var i: u32 = begin; i < end; i += 1u) {
+            sort_buffer.pairs[dst + i] = shared_pairs[i];
+        }
     }
 }
 
@@ -137,7 +210,18 @@ fn calc_merge_path(offset_a: u32, offset_b: u32, num_a: u32, num_b: u32, diag: u
 /// standards. It's not stable.
 ///
 /// https://en.wikipedia.org/wiki/Batcher_odd%E2%80%93even_mergesort
-fn batcher_odd_even_mergesort(data: ptr<function, array<KeyValuePair, numItemPerThread>>) {
+fn batcher_odd_even_mergesort(data: ptr<function, array<KeyValuePair, numItemPerThread>>, num: u32) {
+    // Pad with elements which always compare greater, so they end up at the end
+    // of the array after all real elements, and when truncated we get back the
+    // sorted original array.
+    for (var i: u32 = num; i < numItemPerThread; i += 1u) {
+        data[i].key = 0xFFFFFFFFu;
+#ifdef HAS_DUAL_KEY
+        data[i].key2 = 0xFFFFFFFFu;
+#endif
+    }
+
+    // Actual numItemPerThread-length sort
     for (var p: u32 = 1; p < numItemPerThread; p += p) {
         for (var k: u32 = p; k >= 1; k = k >> 1) {
             for (var j: u32 = k % p; j + k < numItemPerThread; j += 2 * k) {
@@ -187,6 +271,110 @@ fn find_effect_from_particle(num_effects: u32, particle_index: u32) -> u32 {
     return lo - 1u;
 }
 
+/// Get the number N such that log2(value) == N rounded up.
+fn find_log2(value: u32) -> u32 {
+    var num = 31u - countLeadingZeros(value);
+    if ((value & (value - 1u)) != 0u) {  // not a power of 2
+        num += 1u;
+    }
+    return num;
+}
+
+/// Parallel merge-sort combining a block-level parallel sort followed by a serial mergesort.
+fn block_parallel_merge_sort(thread_id: u32, block_id: u32) {
+    let total_num_items = u32(sort_buffer.count);
+
+    // Loop over all blocks and block-sort each serially (TODO - parallelize this too)
+    let num_blocks = (total_num_items + blockSize - 1) / blockSize;
+    {
+        let offset = block_id * blockSize;
+        let count = min(offset + blockSize, total_num_items) - offset;  // <= blockSize
+        block_sort(thread_id, offset, offset, count);
+    }
+
+    // Wait for all threads to write per-block sorted lists into the storage sort buffer
+    storageBarrier();
+    workgroupBarrier();
+
+    // Recursively merge the blockSize-length sorted lists into a single globally sorted one.
+    // FIXME - parallelize this...
+    if (thread_id == 0 && block_id == 0) {
+        src = 0u;
+        dst = total_num_items;
+        merge_lists_serial(0u, blockSize, blockSize, blockSize, 0u, total_num_items);
+
+        // for (var i: u32 = 0; i < total_num_items; i += 1u) {
+        //     sort_buffer.pairs[total_num_items + i] = sort_buffer.pairs[i];
+        // }
+
+        // src = 0u;
+        // dst = total_num_items;
+        // var left = num_blocks;
+        // while (left > 1u) {
+        //     var step = 1u;
+        //     while (step < left) {
+        //         for (var i: u32 = 0u; i + step < left; i += step * 2u) {
+        //             merge_lists_serial(i, step, i + step, step, src, dst);
+        //         }
+        //         step <<= 1u;
+
+        //         //storageBarrier();
+
+        //         // Swap source/destination lists for next iteration
+        //         let tmp = src;
+        //         src = dst;
+        //         dst = tmp;
+        //     }
+        //     left >>= 1u;
+        // }
+    }
+}
+
+/// Sort each block in parallel on a separate workgroup.
+@compute @workgroup_size(64)
+fn parallel_block_sort(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
+    let block_id = workgroup_id.x;  // wgpu doesn't support @builtin(workgroup_index)
+    let total_num_items = u32(sort_buffer.count);
+    
+    // Sort each block independently
+    let offset = block_id * blockSize;
+    let block_num = min(offset + blockSize, total_num_items) - offset;
+    let block_src = src + offset;
+    let block_dst = dst + offset;
+    block_sort(thread_id, block_src, block_dst, block_num);
+}
+
+fn parallel_merge_sort(thread_id: u32, block_id: u32) {
+    let total_num_items = u32(sort_buffer.count);
+    let num_blocks = (total_num_items + blockSize - 1) / blockSize;
+    let num_passes = find_log2(num_blocks);
+
+    // Sort each block independently
+    {
+        let offset = block_id * blockSize;
+        let block_num = min(offset + blockSize, total_num_items) - offset;
+        let block_src = src + offset;
+        let block_dst = dst + offset;
+        block_sort(thread_id, block_src, block_dst, block_num);
+    }
+
+    // Merge-sort blocks into storage buffer by recusrively merging pairs of adacent sorted lists of increasing size
+    src = 0u;
+    dst = total_num_items;
+    for (var ipass: u32 = 0u; ipass < num_passes; ipass += 1u) {
+        let coop = 2u << ipass;
+
+        let list = ~(coop - 1u) & block_id;
+        let diag = min(total_num_items, blockSize * ((coop - 1u) & block_id));
+        let start = blockSize * list;
+        let a0 = min(total_num_items, start);
+        let b0 = min(total_num_items, start + blockSize * (coop / 2u));
+        let b1 = min(total_num_items, start + blockSize * coop);
+
+        // TODO... calc merge path + do the ping-pong merge
+    }
+}
+
 #ifdef TEST
 
 /// Test for find_effect_from_particle().
@@ -229,7 +417,7 @@ fn test_batcher_odd_even_mergesort(@builtin(global_invocation_id) global_invocat
     workgroupBarrier();
 
     // Sort all items in the local array
-    batcher_odd_even_mergesort(&pairs);
+    batcher_odd_even_mergesort(&pairs, numItemPerThread);
 
     workgroupBarrier();
 
@@ -287,83 +475,14 @@ fn test_calc_merge_path(@builtin(global_invocation_id) global_invocation_id: vec
 fn test_block_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let tid = global_invocation_id.x;
     let total_num_items = u32(sort_buffer.count);
+    block_sort(tid, 0u, 0u, total_num_items);
+}
 
-    var pairs: array<KeyValuePair, numItemPerThread>;
-
-    // Each thread copies numItemPerThread into a local register array, then sort
-    // that array serially inside the thread, before copying the sorted result
-    // into shared workgroup memory for the block-level merge sort.
-    let num_threads = (total_num_items + numItemPerThread - 1) / numItemPerThread;
-    let begin = tid * numItemPerThread;
-    let end = min(total_num_items, begin + numItemPerThread);
-    if (tid < num_threads) {
-        // Copy pairs into register array
-        for (var i: u32 = begin; i < end; i += 1u) {
-            pairs[i - begin] = sort_buffer.pairs[i];
-        }
-
-        // Sort array serially inside this thread
-        batcher_odd_even_mergesort(&pairs);
-
-        // Copy the data into shared workgroup memory
-        for (var i: u32 = begin; i < end; i += 1u) {
-            shared_pairs[i] = pairs[i - begin];
-        }
-    }
-    
-    // Wait for all threads to have sorted their own thread-local values, and written
-    // them into their own slice of shared memory, before we read back shared memory below.
-    workgroupBarrier();
-
-    // shared_pairs[] contains a series of numItemPerThread-length sorted sub-arrays.
-    // Merge-sort in parallel all those sub-arrays into increasibly larger sub-arrays
-    // with increasngly more (= coop) threads collaborating to process each merge.
-    for (var coop: u32 = 2u; coop <= numThreads; coop = coop * 2u) {
-        let list = ~(coop - 1) & tid;
-        let diag = min(total_num_items, numItemPerThread * ((coop - 1) & tid));
-        let start = numItemPerThread * list;
-        let a0 = min(total_num_items, start);
-        let b0 = min(total_num_items, start + numItemPerThread * (coop / 2));
-        let b1 = min(total_num_items, start + numItemPerThread * coop);
-
-        let num_a = b0 - a0;
-        let num_b = b1 - b0;
-        let a_i = calc_merge_path(a0, b0, num_a, num_b, diag);
-
-        // Merge the 2 sorted lists
-        var ia = a0 + a_i;
-        var ib = b0 + diag - a_i;
-        for (var i: u32 = 0; i < numItemPerThread; i += 1u) {
-            if ((ib >= b1) || ((ia < b0) && !compare_greater(shared_pairs[ia], shared_pairs[ib]))) {
-                pairs[i] = shared_pairs[ia];
-                ia += 1u;
-            } else {
-                pairs[i] = shared_pairs[ib];
-                ib += 1u;
-            }
-        }
-
-        // We're about to write back exactly numItemPerThread elements into the shared array.
-        // However by design threads may read more values in either of the two merged lists,
-        // so we need to wait for all co-op threads to finish reading before we can write back.
-        workgroupBarrier();
-
-        // Copy back into shared memory for next iteration
-        for (var i: u32 = 0; i < numItemPerThread; i += 1u) {
-            shared_pairs[begin + i] = pairs[i];
-        }
-
-        // Next iteration (or the final write) need to read back from shared memory, so we need
-        // to wait for all threads to finish writing there.
-        workgroupBarrier();
-    }
-
-    // Copy sorted items from shared workgroup memory back into sort_buffer
-    if (tid < num_threads) {
-        for (var i: u32 = begin; i < end; i += 1u) {
-            sort_buffer.pairs[i] = shared_pairs[i];
-        }
-    }
+/// Test for parallel_merge_sort().
+@compute @workgroup_size(64)
+fn test_block_parallel_merge_sort(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
+    let block_id = workgroup_id.x;  // wgpu doesn't support @builtin(workgroup_index)
+    block_parallel_merge_sort(thread_id, block_id);
 }
 
 #endif
@@ -375,23 +494,71 @@ fn test_block_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32
 // https://moderngpu.github.io/segsort.html
 
 /// Naive insertion sort. TODO: replace with something faster.
+// @compute @workgroup_size(64)
+// fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+//     // Naive single-threaded sort
+//     if (global_invocation_id.x != 0) {
+//         return;
+//     }
+
+//     // Insertion sort
+//     let num_items = sort_buffer.count;
+//     for (var i: i32 = 1; i < num_items; i += 1) {
+//         var kv = sort_buffer.pairs[i];
+//         var j = i;
+//         while (j > 0 && compare_greater(sort_buffer.pairs[j - 1], kv)) {
+//             sort_buffer.pairs[j] = sort_buffer.pairs[j - 1];
+//             j -= 1;
+//         }
+//         sort_buffer.pairs[j] = kv;
+//     }
+
+//     // Clear for next frame
+//     sort_buffer.count = 0;
+// }
+
+/// Slightly less naive sort. Block-sort with 64 threads in parallel, up to 1024 particles.
+/// Beyond that limit, just loop over 1024 particle chunks serially.
 @compute @workgroup_size(64)
-fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    // Naive single-threaded sort
-    if (global_invocation_id.x != 0) {
-        return;
+fn main(@builtin(local_invocation_index) thread_id: u32, @builtin(workgroup_id) workgroup_id: vec3<u32>) {
+    let block_id = workgroup_id.x;  // wgpu doesn't support @builtin(workgroup_index)
+
+    let total_num_items = u32(sort_buffer.count);
+
+    // Loop over all blocks and block-sort each serially (TODO - parallelize this too)
+    let num_blocks = (total_num_items + blockSize - 1) / blockSize;
+    {
+        let offset = block_id * blockSize;
+        let count = min(offset + blockSize, total_num_items) - offset;  // <= blockSize
+        block_sort(thread_id, offset, offset, count);
     }
 
-    // Insertion sort
-    let num_items = sort_buffer.count;
-    for (var i: i32 = 1; i < num_items; i += 1) {
-        var kv = sort_buffer.pairs[i];
-        var j = i;
-        while (j > 0 && compare_greater(sort_buffer.pairs[j - 1], kv)) {
-            sort_buffer.pairs[j] = sort_buffer.pairs[j - 1];
-            j -= 1;
+    // Wait for all threads to write per-block sorted lists into the storage sort buffer
+    storageBarrier();
+
+    // Recursively merge the blockSize-length sorted lists into a single globally sorted one.
+    // FIXME - parallelize this...
+    if (thread_id == 0) {
+        src = 0u;
+        dst = total_num_items;
+        var left = num_blocks;
+        while (left > 1u) {
+            var step = 1u;
+            while (step < left) {
+                for (var i: u32 = 0u; i + step < left; i += step * 2u) {
+                    merge_lists_serial(i, step, i + step, step, src, dst);
+                }
+                step <<= 1u;
+
+                //storageBarrier();
+
+                // Swap source/destination lists for next iteration
+                let tmp = src;
+                src = dst;
+                dst = tmp;
+            }
+            left >>= 1u;
         }
-        sort_buffer.pairs[j] = kv;
     }
 
     // Clear for next frame

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -20,11 +20,17 @@ struct IndirectIndexBuffer {
     data: array<u32>,
 }
 
+struct MergeParams {
+    max_list_size: u32,
+    source_buffer: u32,
+}
+
 @group(0) @binding(0) var<storage, read_write> indirect_index_buffer : IndirectIndexBuffer;
 @group(0) @binding(1) var<storage, read> sort_buffer : SortBuffer;
 // Technically read-only, but the type contains atomic<> fields and wasm is strict about it
 @group(0) @binding(2) var<storage, read_write> effect_metadatas : array<EffectMetadata>;
 @group(0) @binding(3) var<storage, read> spawner : Spawner;
+@group(0) @binding(4) var<storage, read> merge_params : MergeParams;
 
 /// Copy the sorted particle indices back into the effect index buffer.
 @compute @workgroup_size(64)
@@ -42,6 +48,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // in vfx_sort_fill. Sorting is optional and shouldn't influence that ping-pong logic.
     let write_index = effect_metadatas[effect_metadata_index].indirect_write_index;
 
-    let particle_index = sort_buffer.pairs[row_index].value;
+    let source_offset = merge_params.source_buffer * u32(sort_buffer.count);
+    let particle_index = sort_buffer.pairs[source_offset + row_index].value;
     indirect_index_buffer.data[(base_particle + row_index) * 3u + write_index] = particle_index;
 }

--- a/src/render/vfx_sort_copy.wgsl
+++ b/src/render/vfx_sort_copy.wgsl
@@ -34,7 +34,7 @@ struct MergeParams {
 
 /// Copy the sorted particle indices back into the effect index buffer.
 @compute @workgroup_size(64)
-fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+fn sort_copy(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let row_index = global_invocation_id.x;
     let effect_metadata_index = spawner.effect_metadata_index;
     let count = atomicLoad(&effect_metadatas[effect_metadata_index].alive_count); // TODO - atomic not needed

--- a/src/render/vfx_sort_fill.wgsl
+++ b/src/render/vfx_sort_fill.wgsl
@@ -31,7 +31,7 @@ struct RawParticleBuffer {
 
 /// Fill the sorting key-value pair buffer with data to prepare for actual sorting.
 @compute @workgroup_size(64)
-fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+fn sort_fill(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let thread_index = global_invocation_id.x;
     let effect_metadata_index = spawner.effect_metadata_index;
     let count = atomicLoad(&effect_metadatas[effect_metadata_index].alive_count); // TODO - atomic not needed

--- a/src/render/vfx_sort_merge.wgsl
+++ b/src/render/vfx_sort_merge.wgsl
@@ -1,0 +1,115 @@
+/// Key-value pair to sort, with optional secondary key.
+///
+/// Sorting operates on the key (and the secondary key as discriminant, if present,
+/// and if the primary keys are equal). The value is carried over alongside the key(s),
+/// unmodified. It generally represents or indexes the payload associated with the key(s).
+struct KeyValuePair {
+    /// Sorting key.
+    key: u32,
+#ifdef HAS_DUAL_KEY
+    /// Secondary sorting key. Used for values with equal primary key.
+    key2: u32,
+#endif
+    /// Value associated with the sort key(s), generally an index to some other data.
+    /// Copied as is and otherwise ignored by the sorting algorithm.
+    value: u32,
+}
+
+/// Buffer of key-value pairs to sort.
+struct SortBuffer {
+    /// Number of items in the buffer.
+    count: i32,
+    /// Pairs to sort. On output, contains the pairs in sorted order.
+    pairs: array<KeyValuePair>,
+}
+
+/// Check whether kv1 > kv2, comparing the key(s) of each pair.
+fn compare_greater(kv1: KeyValuePair, kv2: KeyValuePair) -> bool {
+    if (kv1.key > kv2.key) {
+        return true;
+    }
+#ifdef HAS_DUAL_KEY
+    if (kv1.key == kv2.key) {
+        return kv1.key2 > kv2.key2;
+    }
+#endif
+    return false;
+}
+
+struct MergeParams {
+    /// Maximum number of items per list for this pass.
+    max_list_size: u32,
+}
+
+@group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
+@group(0) @binding(1) var<storage, read> merge_params : MergeParams;
+
+/// Number of items sorted per thread, serially.
+const numItemPerThread: u32 = 16u;
+
+/// Number of threads per workgroup (block).
+const numThreads: u32 = 64u;
+
+/// Size of a block of KeyValuePair in workgroup memory.
+const blockSize: u32 = numThreads * numItemPerThread;  // 1024
+
+/// Merge two sorted lists [a..a+num_a) and [b..b+num_b) into a single sorted list.
+///
+/// The source elements are read from the sort buffer starting at offsets (src + a)
+/// and (src + b), and the merged list written starting at offset dst.
+fn merge_lists_serial(a: u32, num_a: u32, b: u32, num_b: u32, src: u32, dst: u32) {
+    var ia = a;
+    var ib = b;
+    let a_end = a + num_a;
+    let b_end = b + num_b;
+    for (var i: u32 = 0u; i < num_a + num_b; i += 1u) {
+        if ((ib >= b_end) || ((ia < a_end) && !compare_greater(sort_buffer.pairs[src + ia], sort_buffer.pairs[src + ib]))) {
+            sort_buffer.pairs[dst + i] = sort_buffer.pairs[src + ia];
+            ia += 1u;
+        } else {
+            sort_buffer.pairs[dst + i] = sort_buffer.pairs[src + ib];
+            ib += 1u;
+        }
+    }
+}
+
+/// Sort each block in parallel on a separate workgroup.
+@compute @workgroup_size(64)
+fn merge_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let tid = global_invocation_id.x;
+    let total_num_items = u32(sort_buffer.count);
+    let list_size = merge_params.max_list_size;
+    let num_lists = (total_num_items + list_size - 1u) / list_size;
+    // Round down; we skip the last list if the count is odd.
+    let num_merges = num_lists / 2u;
+    if (tid < num_merges) {
+        // We always merge 2 consecutive lists of up to list_size items. The last list may have
+        // less elements, if total_num_items is not a multiple of list_size (which is common).
+        let start_a = tid * list_size * 2u;
+        let start_b = start_a + list_size;
+        let end_b = min(start_b + list_size, total_num_items);
+        merge_lists_serial(start_a, list_size, start_b, end_b - start_b, 0u, total_num_items);
+    }
+}
+
+#ifdef TEST
+
+@compute @workgroup_size(64)
+fn test_merge(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let tid = global_invocation_id.x;
+    let total_num_items = u32(sort_buffer.count);
+    let list_size = merge_params.max_list_size;
+    let num_lists = (total_num_items + list_size - 1u) / list_size;
+    // Round down; we skip the last list if the count is odd.
+    let num_merges = num_lists / 2u;
+    if (tid < num_merges) {
+        // We always merge 2 consecutive lists of up to list_size items. The last list may have
+        // less elements, if total_num_items is not a multiple of list_size (which is common).
+        let start_a = tid * list_size * 2u;
+        let start_b = start_a + list_size;
+        let end_b = min(start_b + list_size, total_num_items);
+        merge_lists_serial(start_a, list_size, start_b, end_b - start_b, 0u, total_num_items);
+    }
+}
+
+#endif

--- a/src/render/vfx_sort_merge.wgsl
+++ b/src/render/vfx_sort_merge.wgsl
@@ -39,24 +39,18 @@ fn compare_greater(kv1: KeyValuePair, kv2: KeyValuePair) -> bool {
 struct MergeParams {
     /// Maximum number of items per list for this pass.
     max_list_size: u32,
+    /// Half of the ping-pong buffer to read from: 0 for the first half, 1 for
+    /// the second half.
+    source_buffer: u32,
 }
 
 @group(0) @binding(0) var<storage, read_write> sort_buffer : SortBuffer;
 @group(0) @binding(1) var<storage, read> merge_params : MergeParams;
 
-/// Number of items sorted per thread, serially.
-const numItemPerThread: u32 = 16u;
-
-/// Number of threads per workgroup (block).
-const numThreads: u32 = 64u;
-
-/// Size of a block of KeyValuePair in workgroup memory.
-const blockSize: u32 = numThreads * numItemPerThread;  // 1024
-
 /// Merge two sorted lists [a..a+num_a) and [b..b+num_b) into a single sorted list.
 ///
 /// The source elements are read from the sort buffer starting at offsets (src + a)
-/// and (src + b), and the merged list written starting at offset dst.
+/// and (src + b), and the merged list written starting at offset (dst + a).
 fn merge_lists_serial(a: u32, num_a: u32, b: u32, num_b: u32, src: u32, dst: u32) {
     var ia = a;
     var ib = b;
@@ -64,10 +58,10 @@ fn merge_lists_serial(a: u32, num_a: u32, b: u32, num_b: u32, src: u32, dst: u32
     let b_end = b + num_b;
     for (var i: u32 = 0u; i < num_a + num_b; i += 1u) {
         if ((ib >= b_end) || ((ia < a_end) && !compare_greater(sort_buffer.pairs[src + ia], sort_buffer.pairs[src + ib]))) {
-            sort_buffer.pairs[dst + i] = sort_buffer.pairs[src + ia];
+            sort_buffer.pairs[dst + a + i] = sort_buffer.pairs[src + ia];
             ia += 1u;
         } else {
-            sort_buffer.pairs[dst + i] = sort_buffer.pairs[src + ib];
+            sort_buffer.pairs[dst + a + i] = sort_buffer.pairs[src + ib];
             ib += 1u;
         }
     }
@@ -80,36 +74,17 @@ fn merge_sort(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let total_num_items = u32(sort_buffer.count);
     let list_size = merge_params.max_list_size;
     let num_lists = (total_num_items + list_size - 1u) / list_size;
-    // Round down; we skip the last list if the count is odd.
-    let num_merges = num_lists / 2u;
-    if (tid < num_merges) {
+    let num_merge_operations = (num_lists + 1u) / 2u;
+    if (tid < num_merge_operations) {
         // We always merge 2 consecutive lists of up to list_size items. The last list may have
         // less elements, if total_num_items is not a multiple of list_size (which is common).
+        // An unmatched last list is copied unchanged to the other ping-pong half.
         let start_a = tid * list_size * 2u;
         let start_b = start_a + list_size;
-        let end_b = min(start_b + list_size, total_num_items);
-        merge_lists_serial(start_a, list_size, start_b, end_b - start_b, 0u, total_num_items);
+        let num_a = min(list_size, total_num_items - start_a);
+        let num_b = min(list_size, total_num_items - min(start_b, total_num_items));
+        let src = merge_params.source_buffer * total_num_items;
+        let dst = (1u - merge_params.source_buffer) * total_num_items;
+        merge_lists_serial(start_a, num_a, start_b, num_b, src, dst);
     }
 }
-
-#ifdef TEST
-
-@compute @workgroup_size(64)
-fn test_merge(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
-    let tid = global_invocation_id.x;
-    let total_num_items = u32(sort_buffer.count);
-    let list_size = merge_params.max_list_size;
-    let num_lists = (total_num_items + list_size - 1u) / list_size;
-    // Round down; we skip the last list if the count is odd.
-    let num_merges = num_lists / 2u;
-    if (tid < num_merges) {
-        // We always merge 2 consecutive lists of up to list_size items. The last list may have
-        // less elements, if total_num_items is not a multiple of list_size (which is common).
-        let start_a = tid * list_size * 2u;
-        let start_b = start_a + list_size;
-        let end_b = min(start_b + list_size, total_num_items);
-        merge_lists_serial(start_a, list_size, start_b, end_b - start_b, 0u, total_num_items);
-    }
-}
-
-#endif

--- a/src/render/vfx_utils.wgsl
+++ b/src/render/vfx_utils.wgsl
@@ -10,6 +10,8 @@ struct BufferOperationArgs {
     dst_stride: u32,
     /// Number of u32 elements to process for this operation.
     count: u32,
+    /// Thread group size.
+    thread_group_size: u32,
 }
 
 @group(0) @binding(0) var<uniform> args : BufferOperationArgs;
@@ -59,7 +61,7 @@ fn fill_dispatch_args(@builtin(global_invocation_id) global_invocation_id: vec3<
 
     let src = args.src_offset + thread_index * args.src_stride;
     let dst = args.dst_offset + thread_index * args.dst_stride;
-    let thread_count = src_buffer[src];
+    let thread_count = (src_buffer[src] + args.thread_group_size - 1) / args.thread_group_size;
     let workgroup_count = calc_workground_count(thread_count);
     dst_buffer[dst] = workgroup_count;
     dst_buffer[dst + 1u] = 1u;


### PR DESCRIPTION
Switch GPU sorting of particles for ribbon effects from a naive single-threaded insertion sort to a modern parallel sort.

This change introduces a modern parallel sort architecture, which divides the sort task into 3 sequences of operations:
1. Intra-thread sorting of up to 16 elements with a simple odd-even mergesort, into a local thread array.
2. Intra-workgroup "block sort" where all 64 threads of a workgroup cooperate to mergesort those 64 sorted lists of 16 items into a sorted list of 1024 items.
3. Final multi-pass mergesort taking lists of 1024 items and merging them to obtain the final sorted array.

This change add state-of-the-art implementations for the first two thread-level and workgroup-level sort passes. Parallelizing of the final merge-sort pass is left for a future change, and is instead replaced with a naive serial variant.

In the `worms.rs` example on an RTX 4070, this reduces the GPU time from ~16.32ms down to ~1.85ms (~11%), split between:

- The workgroup-level block sort (0.05ms).
- The subsequent merge sort, for cases where the total number of items (particles) is > 1024 (0.55ms + 0.75ms + 0.51ms = 1.81ms; 3 passes).