### PR TITLE
Add main camera and frustum kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `HanabiMainCamera`, a component to tag the "main" camera that Hanabi uses
+  for camera-specific features. Add to exactly one `Camera` to tag it.
+- Added `KillFrustumModifier` to kill particles outside of the main camera frustum.
+
 ### Changed
 
 - Batch same-effect instances. This greatly improves performance when using many instances
@@ -13,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Batching is still limited to same-effect instances (same `EffectAsset`), and is currently not
   available for GPU particle spawning.
 - Parallelized most of the GPU sort. This dramatically improves performance when using ribbon effects.
+- `EvalContext::make_fn()` now takes an optional return token for the function return value.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hanabi"
-version = "0.19.1-dev"
+version = "0.20.0-dev"
 authors = ["Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 rust-version = "1.95.0"

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -891,6 +891,7 @@ pub trait EvalContext {
         &mut self,
         func_name: &str,
         args: &str,
+        ret: Option<&str>,
         module: &mut Module,
         f: &mut dyn FnMut(&mut Module, &mut dyn EvalContext) -> Result<String, ExprError>,
     ) -> Result<(), ExprError>;
@@ -4184,7 +4185,7 @@ mod tests {
         let func_name = "my_func";
         let args = "arg0: i32, arg1: f32";
         assert!(ctx
-            .make_fn(func_name, args, &mut module, &mut |m, ctx| {
+            .make_fn(func_name, args, None, &mut module, &mut |m, ctx| {
                 m.lit(3.);
                 let v = ctx.make_local_var();
                 assert_eq!(v, "var0");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,6 +577,29 @@ impl From<&PropertyInstance> for PropertyValue {
     }
 }
 
+/// Marker component to tag the "main" camera.
+///
+/// Various features in Hanabi need a single camera to work with. However, Bevy
+/// doesn't have a concept of a "main" camera. This component solves this and
+/// marks a camera as the "main" one that Hanabi effects will use for camera
+/// related features, like sorting by camera distance (for semi-transparent
+/// particles), reading the depth buffer (_e.g._ for collision), or checking the
+/// camera frustum bounds (_e.g._ for frustum culling).
+///
+/// The component must be added to at most one entity
+/// having a [`Camera`] component. If absent, camera-related features will not
+/// work (but all other features continue to work). If no camera-related feature
+/// is used, adding this component is not required. Generally you want to add it
+/// to the camera that renders the "main view" of your game or application, the
+/// one that defines the final rendered view.
+///
+/// Dynamically switching camera is supported, but note that only one camera per
+/// frame can be tagged (the unique camera tagged at the time of the render
+/// world extraction phase is the camera taken into account). Tagging multiple
+/// camera will result in a system error and break Hanabi rendering.
+#[derive(Default, Clone, Copy, Component)]
+pub struct HanabiMainCamera;
+
 /// The [`VisibilityClass`] used for all particle effects.
 #[derive(Default, Clone, Copy, Component, ExtractComponent)]
 pub struct EffectVisibilityClass;

--- a/src/modifier/accel.rs
+++ b/src/modifier/accel.rs
@@ -166,6 +166,7 @@ impl Modifier for RadialAccelModifier {
         context.make_fn(
             &func_name,
             "particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let origin = ctx.eval(m, self.origin)?;

--- a/src/modifier/force.rs
+++ b/src/modifier/force.rs
@@ -179,6 +179,7 @@ impl Modifier for ConformToSphereModifier {
         context.make_fn(
             &func_name,
             "particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let origin = ctx.eval(m, self.origin)?;

--- a/src/modifier/kill.rs
+++ b/src/modifier/kill.rs
@@ -7,6 +7,7 @@ use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    calc_func_id,
     graph::{EvalContext, ExprError},
     Attribute, BoxedModifier, ExprHandle, Modifier, ModifierContext, Module, ShaderWriter,
 };
@@ -176,6 +177,98 @@ impl Modifier for KillAabbModifier {
 "#,
             expr
         );
+
+        Ok(())
+    }
+}
+
+/// A modifier killing all particles that exit the camera's frustum.
+///
+/// This ensures camera moving off-screen (not visible) are immediately killed,
+/// to avoid simulating them for nothing. The camera frustum is read from the
+/// (unique) camera tagged with the [`HanabiMainCamera`] component; if this
+/// component is missing, this modifier does nothing.
+///
+/// # Attributes
+///
+/// This modifier requires the following particle attributes:
+/// - [`Attribute::POSITION`]
+#[derive(Debug, Default, Clone, Copy, Hash, Reflect, Serialize, Deserialize)]
+pub struct KillFrustumModifier {
+    /// Optional distance threshold (defaults to 0) the particle is allowed to
+    /// be at outside the frustum planes before being killed. This ensures that
+    /// _e.g._ a shaking camera won't kill particles at the edge of the screen,
+    /// before moving back to the area where the particle was, which could
+    /// effectively make the user "see" that they disappeared. The value can be
+    /// negative, but this will shrink the frustum inside the view, and will
+    /// kill particles still visible on screen, so is strongly discouraged.
+    pub threshold: Option<ExprHandle>,
+}
+
+impl KillFrustumModifier {
+    /// Create a new instance of an [`KillFrustumModifier`].
+    ///
+    /// The created instance has a default `threshold = 0.0` value.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the distance threshold from the camera frustum plances, that is the
+    /// distance outside of the screen that particles are allowed to be before
+    /// they're killed.
+    pub fn with_threshold(mut self, threshold: impl Into<ExprHandle>) -> Self {
+        self.threshold = Some(threshold.into());
+        self
+    }
+}
+
+impl Modifier for KillFrustumModifier {
+    fn context(&self) -> ModifierContext {
+        ModifierContext::Update
+    }
+
+    fn attributes(&self) -> &[Attribute] {
+        &[Attribute::POSITION]
+    }
+
+    fn boxed_clone(&self) -> BoxedModifier {
+        Box::new(*self)
+    }
+
+    fn apply(&self, module: &mut Module, context: &mut ShaderWriter) -> Result<(), ExprError> {
+        let func_id = calc_func_id(self);
+        let func_name = format!("kill_frustum_{0:016X}", func_id);
+
+        context.make_fn(
+            &func_name,
+            "particle: ptr<function, Particle>",
+            Some("bool"),
+            module,
+            &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
+                let threshold = if let Some(threshold) = self.threshold {
+                    ctx.eval(m, threshold)?
+                } else {
+                    "0.0".to_string()
+                };
+
+                Ok(format!(
+                    r##"    let p = transform_position_simulation_to_world((*particle).{0}).xyz;
+    let threshold = {1};
+    for (var i = 0; i < 6; i += 1) {{
+        if (dot(sim_params.frustum[i].xyz, p) + sim_params.frustum[i].w + threshold <= 0) {{
+            return true;
+        }}
+    }}
+    return false;
+"##,
+                    Attribute::POSITION.name(),
+                    threshold
+                ))
+            },
+        )?;
+
+        context.main_code +=
+            &format!("if ({func_name}(&particle)) {{\n    is_alive = false;\n}}\n");
 
         Ok(())
     }

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -333,6 +333,7 @@ impl EvalContext for ShaderWriter<'_> {
         &mut self,
         func_name: &str,
         args: &str,
+        ret: Option<&str>,
         module: &mut Module,
         f: &mut dyn FnMut(&mut Module, &mut dyn EvalContext) -> Result<String, ExprError>,
     ) -> Result<(), ExprError> {
@@ -352,8 +353,9 @@ impl EvalContext for ShaderWriter<'_> {
         self.extra_code += &ctx.extra_code;
 
         // Append the function itself
+        let ret = ret.map(|x| format!("-> {x} ")).unwrap_or_default();
         self.extra_code += &format!(
-            r##"fn {0}({1}) {{
+            r##"fn {0}({1}) {ret}{{
 {2}{3}}}"##,
             func_name, args, ctx.main_code, body
         );
@@ -521,6 +523,7 @@ impl EvalContext for RenderContext<'_> {
         &mut self,
         func_name: &str,
         args: &str,
+        ret: Option<&str>,
         module: &mut Module,
         f: &mut dyn FnMut(&mut Module, &mut dyn EvalContext) -> Result<String, ExprError>,
     ) -> Result<(), ExprError> {
@@ -538,8 +541,9 @@ impl EvalContext for RenderContext<'_> {
         self.render_extra += &ctx.render_extra;
 
         // Append the function itself
+        let ret = ret.map(|x| format!("-> {x} ")).unwrap_or_default();
         self.render_extra += &format!(
-            r##"fn {0}({1}) {{
+            r##"fn {0}({1}) {ret}{{
             {2};
         }}
         "##,
@@ -741,6 +745,8 @@ pub fn register_modifiers(type_registry: &AppTypeRegistry) {
     {
         let mut type_registry = type_registry.write();
 
+        // mod.rs
+        type_registry.register::<EmitSpawnEventModifier>();
         // accel.rs
         type_registry.register::<AccelModifier>();
         type_registry.register::<RadialAccelModifier>();
@@ -754,6 +760,7 @@ pub fn register_modifiers(type_registry: &AppTypeRegistry) {
         // kill.rs
         type_registry.register::<KillSphereModifier>();
         type_registry.register::<KillAabbModifier>();
+        type_registry.register::<KillFrustumModifier>();
         // output.rs
         type_registry.register::<ParticleTextureModifier>();
         type_registry.register::<SetColorModifier>();

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -775,6 +775,7 @@ pub fn register_modifiers(type_registry: &AppTypeRegistry) {
         type_registry.register::<SetPositionCircleModifier>();
         type_registry.register::<SetPositionSphereModifier>();
         type_registry.register::<SetPositionCone3dModifier>();
+        type_registry.register::<SetPositionBoxModifier>();
         // velocity.rs
         type_registry.register::<SetVelocityCircleModifier>();
         type_registry.register::<SetVelocitySphereModifier>();

--- a/src/modifier/position.rs
+++ b/src/modifier/position.rs
@@ -60,6 +60,7 @@ impl SetPositionCircleModifier {
         context.make_fn(
             &func_name,
             "particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let center = ctx.eval(m, self.center)?;
@@ -160,6 +161,7 @@ impl SetPositionSphereModifier {
         context.make_fn(
             &func_name,
             "particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let center = ctx.eval(m, self.center)?;
@@ -275,6 +277,7 @@ impl SetPositionCone3dModifier {
         context.make_fn(
             &func_name,
             "transform: mat4x4<f32>, particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let height = ctx.eval(m, self.height)?;

--- a/src/modifier/position.rs
+++ b/src/modifier/position.rs
@@ -384,6 +384,7 @@ impl SetPositionBoxModifier {
         context.make_fn(
             &func_name,
             "particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let center = ctx.eval(m, self.center)?;

--- a/src/modifier/velocity.rs
+++ b/src/modifier/velocity.rs
@@ -53,6 +53,7 @@ impl SetVelocityCircleModifier {
         context.make_fn(
             &func_name,
             "transform: mat4x4<f32>, particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let center = ctx.eval(m, self.center)?;
@@ -196,6 +197,7 @@ impl SetVelocityTangentModifier {
         context.make_fn(
             &func_name,
             "transform: mat4x4<f32>, particle: ptr<function, Particle>",
+            None,
             module,
             &mut |m: &mut Module, ctx: &mut dyn EvalContext| -> Result<String, ExprError> {
                 let origin = ctx.eval(m, self.origin)?;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -21,7 +21,7 @@ use bevy::{
     time::{time_system, TimeSystems},
 };
 
-use crate::asset::EffectAssetLoader;
+use crate::{asset::EffectAssetLoader, render::extract_main_view};
 use crate::{
     asset::{DefaultMesh, EffectAsset},
     compile_effects,
@@ -412,6 +412,7 @@ impl Plugin for HanabiPlugin {
                     extract_effects,
                     extract_sim_params,
                     extract_effect_events,
+                    extract_main_view.after(bevy::render::camera::extract_cameras),
                 ));
             })
             .add_systems(

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -12,21 +12,8 @@ use std::{
 use bevy::core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT};
 #[cfg(feature = "2d")]
 use bevy::math::FloatOrd;
-#[cfg(feature = "3d")]
 use bevy::{
-    core_pipeline::{
-        core_3d::{
-            AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transparent3d,
-            CORE_3D_DEPTH_FORMAT,
-        },
-        prepass::{OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey},
-    },
-    render::{
-        mesh::allocator::MeshSlabs,
-        render_phase::{BinnedPhaseItem, ViewBinnedRenderPhases},
-    },
-};
-use bevy::{
+    camera::primitives::Frustum,
     ecs::{
         change_detection::Tick,
         prelude::*,
@@ -59,6 +46,20 @@ use bevy::{
         Extract, MainWorld,
     },
 };
+#[cfg(feature = "3d")]
+use bevy::{
+    core_pipeline::{
+        core_3d::{
+            AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transparent3d,
+            CORE_3D_DEPTH_FORMAT,
+        },
+        prepass::{OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey},
+    },
+    render::{
+        mesh::allocator::MeshSlabs,
+        render_phase::{BinnedPhaseItem, ViewBinnedRenderPhases},
+    },
+};
 use bitflags::bitflags;
 use bytemuck::{Pod, Zeroable};
 use effect_cache::{CachedEffect, EffectSlice, SlabState};
@@ -75,8 +76,8 @@ use crate::{
         effect_cache::{AnyDrawIndirectArgs, CachedDrawIndirectArgs, SlabId},
     },
     AlphaMode, Attribute, CompiledParticleEffect, EffectProperties, EffectShaders,
-    EffectSimulation, EffectSpawner, EffectVisibilityClass, ParticleLayout, PropertyLayout,
-    SimulationCondition, TextureLayout,
+    EffectSimulation, EffectSpawner, EffectVisibilityClass, HanabiMainCamera, ParticleLayout,
+    PropertyLayout, SimulationCondition, TextureLayout,
 };
 
 mod aligned_buffer_vec;
@@ -214,8 +215,17 @@ pub(crate) struct SimParams {
 /// GPU representation of [`SimParams`], as well as additional per-frame
 /// effect-independent values.
 #[repr(C)]
+#[repr(align(16))] // vec4<f32>
 #[derive(Debug, Copy, Clone, Pod, Zeroable, ShaderType)]
 struct GpuSimParams {
+    /// Main view/camera frustum planes, for things like frustum culling. Each
+    /// plane is encoded as (normal, distance) over 4 components, in world
+    /// space.
+    frustum: [Vec4; 6],
+    /// World space position of the main view/camera, for things like
+    /// distance-based sorting. The W component is unused (but required for
+    /// padding in WGSL).
+    camera_position: Vec4,
     /// Delta time, in seconds, since last effect system update.
     delta_time: f32,
     /// Current effect system simulation time since startup, in seconds.
@@ -240,11 +250,15 @@ struct GpuSimParams {
     ///
     /// This is only used by the `vfx_indirect` compute shader.
     num_effects: u32,
+
+    pad0: u32,
 }
 
 impl Default for GpuSimParams {
     fn default() -> Self {
         Self {
+            frustum: [Vec4::ZERO; 6],
+            camera_position: Vec4::ZERO,
             delta_time: 0.04,
             time: 0.0,
             virtual_delta_time: 0.04,
@@ -252,6 +266,7 @@ impl Default for GpuSimParams {
             real_delta_time: 0.04,
             real_time: 0.0,
             num_effects: 0,
+            pad0: 0,
         }
     }
 }
@@ -1956,6 +1971,10 @@ pub(crate) struct ParticleUpdatePipelineKey {
     shader: Handle<Shader>,
     /// Particle layout.
     particle_layout: ParticleLayout,
+    /// Key: LOCAL_SPACE_SIMULATION
+    /// The effect is simulated in local space. The particle positions are
+    /// stored in simulation space.
+    local_space_simulation: bool,
     /// Minimum binding size in bytes for the particle layout buffer of the
     /// parent effect, if any.
     /// Key: READ_PARENT_PARTICLE
@@ -1994,6 +2013,9 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
         }
         if key.num_event_buffers > 0 {
             shader_defs.push("EMITS_GPU_SPAWN_EVENTS".into());
+        }
+        if key.local_space_simulation {
+            shader_defs.push("LOCAL_SPACE_SIMULATION".into());
         }
 
         let hash = calc_func_id(&key);
@@ -2929,6 +2951,71 @@ pub(crate) fn extract_sim_params(
         sim_params.real_time,
         sim_params.real_delta_time,
     );
+}
+
+/// Extracted [`HanabiMainCamera`], with additional extracted data.
+///
+/// This component is added inside the render world to the render view
+/// corresponding to the extracted camera of the main camera holding the
+/// [`HanabiMainCamera`] component, if any.
+#[derive(Debug, Component)]
+pub(crate) struct HanabiRenderCamera {
+    /// Main entity the camera/view was extracted from, which contains the
+    /// [`Camera`], the [`HanabiMainCamera`], and the original data extracted.
+    #[allow(dead_code)]
+    pub view: MainEntity,
+    /// Camera position in world space.
+    pub position: Vec3,
+    /// Frustum planes of the camera.
+    pub frustum: [Vec4; 6],
+}
+
+/// Extract camera related data for the main Hanabi view.
+///
+/// The main Hanabi view is the view of the [`Camera`] tagged with the
+/// [`HanabiMainCamera`], if any. That camera and its view data are used for
+/// various features that require a single camera.
+pub(crate) fn extract_main_view(
+    mut commands: Commands,
+    q_views: Extract<
+        Query<
+            (Entity, RenderEntity, &GlobalTransform, &Frustum),
+            (With<Camera>, With<HanabiMainCamera>),
+        >,
+    >,
+    q_render_view: Query<Entity, With<HanabiRenderCamera>>,
+) {
+    #[cfg(feature = "trace")]
+    let _span = bevy::log::info_span!("extract_main_view").entered();
+    trace!("extract_main_view()");
+
+    // Get the unique main view from the main world.
+    let Ok((entity, render_entity, global_transform, frustum)) = q_views.single() else {
+        trace!("No HanabiMainCamera component found (or multiple; this is not allowed).");
+        // Delete any previous (now invalid) render world camera
+        for entity in q_render_view.iter() {
+            commands.entity(entity).remove::<HanabiRenderCamera>();
+        }
+        return;
+    };
+
+    // Ensure uniqueness; delete any previous camera if it's on a different entity
+    // that the expected one.
+    q_render_view.iter().for_each(|e| {
+        if e != render_entity {
+            commands.entity(e).remove::<HanabiRenderCamera>();
+        }
+    });
+
+    let render_camera = HanabiRenderCamera {
+        view: entity.into(),
+        position: global_transform.translation(),
+        frustum: frustum.half_spaces.map(|h| h.normal_d()),
+    };
+    trace!("HanabiRenderCamera: {render_camera:?}");
+
+    let mut commands = commands.entity(render_entity);
+    commands.insert(render_camera);
 }
 
 /// Various GPU limits and aligned sizes computed once and cached.
@@ -3926,6 +4013,10 @@ pub fn prepare_init_update_pipelines(
                 .map(|p| p.children.len() as u32)
                 .unwrap_or_default();
 
+            let local_space_simulation = extracted_effect
+                .layout_flags
+                .contains(LayoutFlags::LOCAL_SPACE_SIMULATION);
+
             // FIXME: currently don't hava a way to determine when this is needed, because
             // we know the number of children per parent only after resolving
             // all parents, but by that point we forgot if this is a newly added
@@ -3945,6 +4036,7 @@ pub fn prepare_init_update_pipelines(
                 ParticleUpdatePipelineKey {
                     shader: extracted_effect.effect_shaders.update.clone(),
                     particle_layout: particle_layout.clone(),
+                    local_space_simulation,
                     parent_particle_layout_min_binding_size,
                     num_event_buffers,
                     particle_bind_group_layout_desc: particle_bind_group_layout_desc.clone(),
@@ -4416,6 +4508,7 @@ pub(crate) fn prepare_batch_inputs(
         Option<&CachedEffectEvents>,
     )>,
     mut sort_bind_groups: ResMut<SortBindGroups>,
+    q_render_camera: Query<&HanabiRenderCamera>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("prepare_batch_inputs").entered();
@@ -4580,7 +4673,16 @@ pub(crate) fn prepare_batch_inputs(
 
     // Update simulation parameters, including the total effect count for this frame
     {
+        let dummy = HanabiRenderCamera {
+            view: Entity::PLACEHOLDER.into(),
+            frustum: default(),
+            position: default(),
+        };
+        let render_camera = q_render_camera.single().unwrap_or(&dummy);
+
         let mut gpu_sim_params: GpuSimParams = sim_params.into();
+        gpu_sim_params.frustum = render_camera.frustum;
+        gpu_sim_params.camera_position = render_camera.position.extend(0.0);
         gpu_sim_params.num_effects = prepared_effect_count;
         trace!(
             "Simulation parameters: time={} delta_time={} virtual_time={} \

--- a/src/render/shader_contract_tests.rs
+++ b/src/render/shader_contract_tests.rs
@@ -1294,6 +1294,7 @@ fn real_vfx_update_contracts() -> Result<(), Box<dyn std::error::Error>> {
         real_delta_time: 1.0,
         real_time: 0.0,
         num_effects: 2,
+        ..default()
     };
     let draw_init = [
         GpuDrawIndexedIndirectArgs {
@@ -1633,6 +1634,7 @@ fn real_vfx_indirect_contracts() -> Result<(), Box<dyn std::error::Error>> {
         real_delta_time: 1.0,
         real_time: 0.0,
         num_effects: 2,
+        ..default()
     };
     let sim_params_buffer = wgpu_device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("hanabi:test:indirect:sim"),

--- a/src/render/vfx_common.wgsl
+++ b/src/render/vfx_common.wgsl
@@ -1,6 +1,10 @@
 #define_import_path bevy_hanabi::vfx_common
 
 struct SimParams {
+    /// Frustum planes (xyz,d) of the main Hanabi camera, in world space.
+    frustum: array<vec4<f32>, 6>,
+    /// World space position of the main Hanabi camera.
+    camera_position: vec4<f32>,
     /// Delta time in seconds since last simulation tick.
     delta_time: f32,
     /// Time in seconds since the start of simulation.
@@ -354,4 +358,25 @@ fn rand_normal_vec4(mean: vec4f, std_dev: vec4f) -> vec4f {
 
 fn proj(u: vec3<f32>, v: vec3<f32>) -> vec3<f32> {
     return dot(v, u) / dot(u,u) * u;
+}
+
+/// Unpack a compressed transform stored in transposed row-major form.
+fn unpack_compressed_transform(compressed_transform: mat3x4<f32>) -> mat4x4<f32> {
+    return transpose(
+        mat4x4(
+            compressed_transform[0],
+            compressed_transform[1],
+            compressed_transform[2],
+            vec4<f32>(0.0, 0.0, 0.0, 1.0)
+        )
+    );
+}
+
+// Unpacks a compressed transform and transposes is.
+fn unpack_compressed_transform_3x3_transpose(compressed_transform: mat3x4<f32>) -> mat3x3<f32> {
+    return mat3x3(
+        compressed_transform[0].xyz,
+        compressed_transform[1].xyz,
+        compressed_transform[2].xyz,
+    );
 }

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -3,7 +3,8 @@
     IndirectBuffer, SimParams, Spawner, BatchInfo,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
-    rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
+    rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj,
+    unpack_compressed_transform, unpack_compressed_transform_3x3_transpose
 }
 
 struct Particle {
@@ -96,27 +97,6 @@ fn get_camera_rotation_effect_space() -> mat3x3<f32> {
 #else
     return view_rot;
 #endif
-}
-
-/// Unpack a compressed transform stored in transposed row-major form.
-fn unpack_compressed_transform(compressed_transform: mat3x4<f32>) -> mat4x4<f32> {
-    return transpose(
-        mat4x4(
-            compressed_transform[0],
-            compressed_transform[1],
-            compressed_transform[2],
-            vec4<f32>(0.0, 0.0, 0.0, 1.0)
-        )
-    );
-}
-
-// Unpacks a compressed transform and transposes is.
-fn unpack_compressed_transform_3x3_transpose(compressed_transform: mat3x4<f32>) -> mat3x3<f32> {
-    return mat3x3(
-        compressed_transform[0].xyz,
-        compressed_transform[1].xyz,
-        compressed_transform[2].xyz,
-    );
 }
 
 /// Transform a simulation space position into a world space position.

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -3,7 +3,8 @@
     EffectMetadata, RenderGroupIndirect, SimParams, Spawner, DrawIndexedIndirectArgs, BatchInfo,
     seed, tau, pcg_hash, to_float01, frand, frand2, frand3, frand4,
     rand_uniform_f, rand_uniform_vec2, rand_uniform_vec3, rand_uniform_vec4,
-    rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj
+    rand_normal_f, rand_normal_vec2, rand_normal_vec3, rand_normal_vec4, proj,
+    unpack_compressed_transform, unpack_compressed_transform_3x3_transpose
 }
 
 struct Particle {
@@ -72,6 +73,31 @@ fn find_location_from_particle(update_particle_index: u32) -> EffectLocation {
     return EffectLocation(effect_index, base_particle, update_index);
 }
 
+/// Transform a simulation space position into a world space position.
+///
+/// The simulation space depends on the effect's SimulationSpace value, and is either
+/// the effect space (SimulationSpace::Local) or the world space (SimulationSpace::Global).
+fn transform_position_simulation_to_world(sim_position: vec3<f32>) -> vec4<f32> {
+#ifdef LOCAL_SPACE_SIMULATION
+    let transform = unpack_compressed_transform(spawners[spawner_index].transform);
+    return transform * vec4<f32>(sim_position, 1.0);
+#else
+    return vec4<f32>(sim_position, 1.0);
+#endif
+}
+
+fn transform_normal_simulation_to_world(sim_normal: vec3<f32>) -> vec3<f32> {
+#ifdef LOCAL_SPACE_SIMULATION
+    // We use the inverse transpose transform to transform normals.
+    // The inverse transpose is the same as the transposed inverse, so we can
+    // safely use the inverse transform.
+    let transform = unpack_compressed_transform_3x3_transpose(spawners[spawner_index].inverse_transform);
+    return transform * sim_normal;
+#else
+    return sim_normal;
+#endif
+}
+
 @group(0) @binding(0) var<uniform> sim_params : SimParams;
 @group(0) @binding(1) var<storage, read_write> draw_indirect_buffer : array<DrawIndexedIndirectArgs>;
 
@@ -102,6 +128,7 @@ fn find_location_from_particle(update_particle_index: u32) -> EffectLocation {
 
 var<private> effect_metadata_index: u32;
 var<private> properties_array_index: u32;
+var<private> spawner_index: u32;
 
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
@@ -113,7 +140,8 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Find the index of the effect this particle is part of.
     let location = find_location_from_particle(update_particle_index);
-    let spawner = &spawners[batch_info.spawner_base + location.effect_index];
+    spawner_index = batch_info.spawner_base + location.effect_index;
+    let spawner = &spawners[spawner_index];
     effect_metadata_index = (*spawner).effect_metadata_index;
     let base_particle = (*spawner).slab_offset;
 


### PR DESCRIPTION
Add a new component `HanabiMainCamera` to tag the "main" view that Hanabi uses for all single-camera features. This component must be added to one camera only.

Augment the simulation parameters (`GpuSimParams`) with the world space position of the main camera, and the equation of its 6 frustum planes.

Add a new `KillFrustumModifier` which marks all particles outside the main camera frustum as dead. This prevents simulating particles which left the screen (not visible anymore). However care must be taken with moving cameras (e.g. player view) to not kill too aggressively, otherwise the player might notice particles "disappearing". The modifier allows a threshold distance to leave some margin around the frustum.

Changed `EvalContext::make_fn()` to add a new optional return token emitted as the function's return type, if any.