### PR TITLE
fix pink screen in Metal HDR examples

### DIFF
--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -166,10 +166,10 @@ fn spawn_demo_ui(mut commands: Commands, demo: Res<Demo>) {
             Projection::Orthographic(OrthographicProjection::default_2d()),
             Camera {
                 order: 1000, // render UI above everything
-                clear_color: ClearColorConfig::None,
+                clear_color: ClearColorConfig::Custom(Color::NONE),
                 output_mode: CameraOutputMode::Write {
                     blend_state: Some(BlendState::ALPHA_BLENDING),
-                    clear_color: ClearColorConfig::None,
+                    clear_color: ClearColorConfig::Custom(Color::NONE),
                 },
                 ..default()
             },


### PR DESCRIPTION
Optional workaround for https://github.com/bevyengine/bevy/issues/25344

Screenshot:
<img width="3840" height="1882" alt="image" src="https://github.com/user-attachments/assets/cbc833bb-79cb-4c1f-86c5-8cea63d047e5" />

Examples that use HDR now start normally