### PR TITLE
Add broad support for texture access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `HanabiMainCamera`, a component to tag the "main" camera that Hanabi uses
   for camera-specific features. Add to exactly one `Camera` to tag it.
 - Added `KillFrustumModifier` to kill particles outside of the main camera frustum.
+- Added the ability to access the effect's material (the user bound textures) from all passes.
+- Added support for 1D and 3D textures, and 2D array textures, as well as cube textures
+  and depth textures, to the `TextureSampleExpr`. See `SlotDimension` for all supported variants.
+- Added a new `TextureLoadExpr` doing a non-sampling texture load (`textureLoad()` in WGSL).
+  This can be used in all passes (all modifier contexts).
+- Added a new `lut.rs` example that demonstrates using a 2D array texture as a look-up table (LUT).
+  This can be used to approximate any kind of curve or gradient.
 
 ### Changed
 
@@ -22,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   available for GPU particle spawning.
 - Parallelized most of the GPU sort. This dramatically improves performance when using ribbon effects.
 - `EvalContext::make_fn()` now takes an optional return token for the function return value.
+- Renamed `TextureSampleExpr::image` to `slot_index`, and changed its type to be a `u32` slot index
+  defined at module build time. Dynamically switching between texture with a slot expression
+  was broken, and is explicitly not supported anymore. If you want to dynamically switch between textures,
+  consider using an array texture instead, which is a better way to achieve the same result.
+- Added `TextureSlot::dimension` to specify the type of texture that a texture slot accepts.
+- Added `TextureSampleExpr::slot_dimension` to specify the type of texture being sampled.
+  This must match the associated slot's `TextureSlot::dimension` when bound.
+- `TextureSamplerExpr` now correctly returns an error if used from any pass but the Render one,
+  instead of generating invalid WGSL code. This is a restriction of the WGSL language itself
+  (sampled texture read, via `textureSample()`, can only be used in the fragment shader).
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,9 @@ name = "puffs"
 [[example]]
 name = "lightning"
 
+[[example]]
+name = "lut"
+
 [[test]]
 name = "empty_effect"
 path = "gpu_tests/empty_effect.rs"

--- a/build_examples_wasm.bat
+++ b/build_examples_wasm.bat
@@ -6,7 +6,6 @@ echo Setting RUSTFLAGS to enable unstable web_sys APIs...
 set RUSTFLAGS=--cfg web_sys_unstable_apis --cfg getrandom_backend="wasm_js"
 
 echo Build all examples for WASM...
-REM 3D
 cargo b --release --example lightning --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example firework --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example portal --target wasm32-unknown-unknown --features="bevy/webgpu"
@@ -22,14 +21,13 @@ cargo b --release --example init --target wasm32-unknown-unknown --features="bev
 cargo b --release --example lifetime --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example ordering --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example ribbon --target wasm32-unknown-unknown --features="bevy/webgpu"
-REM 3D + PNG
 cargo b --release --example gradient --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example circle --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example billboard --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example worms --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example instancing --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example puffs --target wasm32-unknown-unknown --features="bevy/webgpu"
-REM 2D
+cargo b --release --example lut --target wasm32-unknown-unknown --features="bevy/webgpu"
 cargo b --release --example 2d --target wasm32-unknown-unknown --features="bevy/webgpu"
 
 wasm-bindgen --out-name wasm_lightning --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/lightning.wasm
@@ -53,6 +51,7 @@ wasm-bindgen --out-name wasm_billboard --no-typescript --out-dir examples/wasm/t
 wasm-bindgen --out-name wasm_worms --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/worms.wasm
 wasm-bindgen --out-name wasm_instancing --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/instancing.wasm
 wasm-bindgen --out-name wasm_puffs --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/puffs.wasm
+wasm-bindgen --out-name wasm_lut --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/lut.wasm
 wasm-bindgen --out-name wasm_2d --no-typescript --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/2d.wasm
 
 echo Done. See docs/wasm.md for help on running the examples locally.

--- a/build_examples_wasm.sh
+++ b/build_examples_wasm.sh
@@ -4,7 +4,6 @@ echo Setting RUSTFLAGS to enable unstable web_sys APIs...
 export RUSTFLAGS=--cfg=web_sys_unstable_apis
 
 echo Build all examples for WASM...
-# 3D
 cargo b --release --example lightning --target wasm32-unknown-unknown
 cargo b --release --example firework --target wasm32-unknown-unknown
 cargo b --release --example portal --target wasm32-unknown-unknown
@@ -20,14 +19,13 @@ cargo b --release --example init --target wasm32-unknown-unknown
 cargo b --release --example lifetime --target wasm32-unknown-unknown
 cargo b --release --example ordering --target wasm32-unknown-unknown
 cargo b --release --example ribbon --target wasm32-unknown-unknown
-# 3D + PNG
-cargo b --release --example
+cargo b --release --example gradient --target wasm32-unknown-unknown
 cargo b --release --example circle --target wasm32-unknown-unknown
 cargo b --release --example billboard --target wasm32-unknown-unknown
 cargo b --release --example worms --target wasm32-unknown-unknown
 cargo b --release --example instancing --target wasm32-unknown-unknown
 cargo b --release --example puffs --target wasm32-unknown-unknown
-# 2D
+cargo b --release --example lut --target wasm32-unknown-unknown
 cargo b --release --example 2d --target wasm32-unknown-unknown
 
 echo Bindgen all examples...
@@ -52,6 +50,7 @@ wasm-bindgen --out-name wasm_billboard --out-dir examples/wasm/target --target w
 wasm-bindgen --out-name wasm_worms --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/worms.wasm
 wasm-bindgen --out-name wasm_instancing --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/instancing.wasm
 wasm-bindgen --out-name wasm_puffs --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/puffs.wasm
+wasm-bindgen --out-name wasm_lut --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/lut.wasm
 wasm-bindgen --out-name wasm_2d --out-dir examples/wasm/target --target web target/wasm32-unknown-unknown/release/examples/2d.wasm
 
 echo Done. See docs/wasm.md for help on running the examples locally.

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -113,10 +113,8 @@ fn setup(
     // per-particle rotation)
     let rotation_attr = writer.attr(Attribute::F32_0).expr();
 
-    let texture_slot = writer.lit(0u32).expr();
-
     let mut module = writer.finish();
-    module.add_texture_slot("color");
+    module.add_texture_slot("color", SlotDimension::D2);
 
     let effect = effects.add(
         EffectAsset::new(32768, SpawnerSettings::rate(64.0.into()), module)
@@ -129,7 +127,7 @@ fn setup(
             .init(init_rotation)
             .init(init_color)
             .render(ParticleTextureModifier {
-                texture_slot,
+                texture_slot: 0,
                 sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(OrientModifier {

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -112,12 +112,9 @@ fn setup(
         .expr();
     let update_sprite_index = SetAttributeModifier::new(Attribute::SPRITE_INDEX, sprite_index);
 
-    let texture_slot = writer.lit(0u32).expr();
-    let texture_slot2 = writer.lit(1u32).expr();
-
     let mut module = writer.finish();
-    module.add_texture_slot("color");
-    module.add_texture_slot("shape");
+    module.add_texture_slot("color", SlotDimension::D2);
+    module.add_texture_slot("shape", SlotDimension::D2);
 
     let effect = effects.add(
         EffectAsset::new(
@@ -132,11 +129,11 @@ fn setup(
         .init(init_lifetime)
         .update(update_sprite_index)
         .render(ParticleTextureModifier {
-            texture_slot,
+            texture_slot: 0,
             sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
         })
         .render(ParticleTextureModifier {
-            texture_slot: texture_slot2,
+            texture_slot: 1,
             sample_mapping: ImageSampleMapping::ModulateRGB,
         })
         .render(FlipbookModifier { sprite_grid_size })

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -68,12 +68,9 @@ fn setup(
         speed: writer.lit(2.).expr(),
     };
 
-    // Use texture slot #0 in ParticleTextureModifier
-    let texture_slot = writer.lit(0u32).expr();
-
     // Define that texture slot (giving it a name for convenience)
     let mut module = writer.finish();
-    module.add_texture_slot("color");
+    module.add_texture_slot("color", SlotDimension::D2);
 
     let effect = effects.add(
         EffectAsset::new(32768, SpawnerSettings::rate(1000.0.into()), module)
@@ -83,7 +80,7 @@ fn setup(
             .init(init_age)
             .init(init_lifetime)
             .render(ParticleTextureModifier {
-                texture_slot,
+                texture_slot: 0,
                 sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
             })
             .render(ColorOverLifetimeModifier::new(gradient)),

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -281,14 +281,12 @@ fn setup(
     let radial_accel =
         RadialAccelModifier::new(writer.lit(Vec3::ZERO).expr(), writer.lit(-3).expr());
 
-    let texture_slot = writer.lit(0u32).expr();
-
     let prop_color = writer.add_property("prop_color", 0xFFFFFFFFu32.into());
     let prop_color = writer.prop(prop_color);
     let update_col = SetAttributeModifier::new(Attribute::COLOR, prop_color.expr());
 
     let mut module = writer.finish();
-    module.add_texture_slot("color");
+    module.add_texture_slot("color", SlotDimension::D2);
 
     let alt_effect = effects.add(
         EffectAsset::new(512, SpawnerSettings::rate(102.0.into()), module)
@@ -300,7 +298,7 @@ fn setup(
             .update(radial_accel)
             .update(update_col)
             .render(ParticleTextureModifier {
-                texture_slot,
+                texture_slot: 0,
                 sample_mapping: ImageSampleMapping::Modulate,
             }),
     );

--- a/examples/lut.rs
+++ b/examples/lut.rs
@@ -1,0 +1,246 @@
+//! Example of using a texture as a look-up table (LUT).
+//!
+//! This example spawns an effect which emits particles with a large initial
+//! velocity, then decelerate due to drag. The particle color is looked up from
+//! a 2D array texture based on its current age (U) and velocity (V), together
+//! forming a texture coordinate (U,V) where to read. The array layer itself is
+//! read from a property, and therefore can be dynamically changed by pressing
+//! the UP/DOWN arrow or SPACE keys. In this example we use 4 layers,
+//! representing 4 different color themes.
+//!
+//! Note that the example demonstrates reading a LUT texture from the Update
+//! pass. For this read to be any useful, it writes the calculated particle's
+//! color into the Attribute::COLOR, which occupies 4 bytes per particle in the
+//! particle buffer. However, because the particle color is only used during
+//! rendering, and the lookup is deterministic, this approach is NOT the
+//! recommended way to achieve the visual result of this example. In a
+//! production context, you should instead read the LUT directly inside the
+//! Render pass and use the value there, without storing it, to avoid wasting 4
+//! bytes per particle. This example is for demonstration only.
+
+use bevy::{asset::RenderAssetUsages, core_pipeline::tonemapping::Tonemapping, prelude::*};
+use bevy_hanabi::{expr::TextureLoadExpr, prelude::*};
+
+mod utils;
+use utils::*;
+use wgpu::{Extent3d, TextureFormat};
+
+const DEMO_DESC: &str = include_str!("lut.txt");
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app_exit = utils::DemoApp::new("lut")
+        .with_desc(DEMO_DESC)
+        .build()
+        .add_systems(Startup, setup)
+        .add_systems(Update, update)
+        .run();
+    app_exit.into_result()
+}
+
+fn setup(
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+    mut effects: ResMut<Assets<EffectAsset>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Make a 2d-array image. Each layer contains a "color theme" for the particles.
+    // Within a layer, the U coordinate (alongside X) corresponds to the particle
+    // normalized age (= age / lifetime). The V coordinate corresponds to the
+    // normalized velocity.
+    let mut data = vec![0u8; 128 * 128 * 4 * 4];
+    for ilayer in 0..4 {
+        for j in 0..128 {
+            for i in 0..128 {
+                let offset = ilayer * 128 * 128 + j * 128 + i;
+                let c = match ilayer {
+                    0 => Color::hsl(i as f32 / 127.0 * 60.0, 0.8, 0.3 + j as f32 / 127.0 * 0.7)
+                        .to_linear(),
+                    1 => Color::hsl(
+                        i as f32 / 127.0 * 60.0 + 120.0,
+                        0.8,
+                        0.3 + j as f32 / 127.0 * 0.7,
+                    )
+                    .to_linear(),
+                    2 => Color::hsl(
+                        i as f32 / 127.0 * 60.0 + 240.0,
+                        0.8,
+                        0.3 + j as f32 / 127.0 * 0.7,
+                    )
+                    .to_linear(),
+                    3 => Color::hsl(
+                        i as f32 / 127.0 * 60.0 + 300.0,
+                        0.8,
+                        0.3 + j as f32 / 127.0 * 0.7,
+                    )
+                    .to_linear(),
+                    _ => panic!(),
+                };
+                data[offset * 4 + 0] = (c.red * 255.0) as u8;
+                data[offset * 4 + 1] = (c.green * 255.0) as u8;
+                data[offset * 4 + 2] = (c.blue * 255.0) as u8;
+                data[offset * 4 + 3] = 255;
+            }
+        }
+    }
+    let image = Image::new(
+        Extent3d {
+            width: 128,
+            height: 128,
+            depth_or_array_layers: 4,
+        },
+        wgpu::TextureDimension::D2,
+        data,
+        TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+    let image = images.add(image);
+
+    // Main 3D camera
+    commands.spawn((
+        Transform::from_translation(Vec3::Z * 100.),
+        Camera3d::default(),
+        Tonemapping::None,
+    ));
+
+    // Some light
+    commands.spawn(DirectionalLight {
+        color: Color::WHITE,
+        // Crank the illuminance way (too) high to make the reference cube clearly visible
+        illuminance: 100000.,
+        shadow_maps_enabled: false,
+        ..Default::default()
+    });
+
+    // A reference cube showing the position of the particle emitter. This is only
+    // for reference; this is not needed for the effect to actually work.
+    let cube = meshes.add(Cuboid {
+        half_size: Vec3::splat(0.5),
+    });
+    let mat = materials.add(utils::COLOR_PURPLE);
+
+    let writer = ExprWriter::new();
+
+    let age = writer.lit(0.).expr();
+    let init_age = SetAttributeModifier::new(Attribute::AGE, age);
+
+    let lifetime = writer.lit(5.).expr();
+    let init_lifetime = SetAttributeModifier::new(Attribute::LIFETIME, lifetime);
+
+    let drag = writer.lit(2.0).expr();
+    let update_drag = LinearDragModifier::new(drag);
+
+    let init_pos = SetPositionSphereModifier {
+        center: writer.lit(Vec3::ZERO).expr(),
+        radius: writer.lit(1.).expr(),
+        dimension: ShapeDimension::Volume,
+    };
+
+    let init_vel = SetVelocitySphereModifier {
+        center: writer.lit(Vec3::ZERO).expr(),
+        speed: writer.lit(100.).expr(),
+    };
+
+    // x = u32(clamp(age / lifetime, 0.0, 1.0) * 127.0)
+    let x = ((writer.attr(Attribute::AGE) / writer.attr(Attribute::LIFETIME))
+        .clamp(writer.lit(0.), writer.lit(1.))
+        * writer.lit(127.))
+    .cast(ValueType::Scalar(ScalarType::Uint))
+    .expr();
+    // y = u32(min(1.0, velocity / 50.0) * 127.0)
+    let y = ((writer.attr(Attribute::VELOCITY).length() / writer.lit(50.)).min(writer.lit(1.0))
+        * writer.lit(127.0))
+    .cast(ValueType::Scalar(ScalarType::Uint))
+    .expr();
+    // coordinates = vec2<u32>(x, y)
+    let coordinates = writer
+        .push(Expr::Binary {
+            op: BinaryOperator::Vec2,
+            left: x,
+            right: y,
+        })
+        .expr();
+    // array_index = property.layer
+    let prop_layer = writer.add_property("layer", Value::Scalar(ScalarValue::Uint(0)));
+    let array_index = writer.prop(prop_layer).expr();
+    // lut_color = textureLoad(texture#0, coordinates, array_index)
+    let lut_color = writer
+        .push(Expr::TextureLoad(TextureLoadExpr {
+            slot_index: 0,
+            slot_dimension: SlotDimension::D2Array,
+            coordinates,
+            array_index: Some(array_index),
+            mip_level: None,
+        }))
+        .expr();
+    // convert HDR vec4<f32>(r,g,b,a) -> LDR u32(0xAABBGGRR); this allows storing
+    // only 4 bytes instead 16 bytes per particle for the color.
+    let lut_color = writer
+        .push(Expr::Unary {
+            op: UnaryOperator::Pack4x8unorm,
+            expr: lut_color,
+        })
+        .expr();
+    let update_lut = SetAttributeModifier::new(Attribute::COLOR, lut_color);
+
+    let mut module = writer.finish();
+    let _ = module.add_texture_slot("lut", SlotDimension::D2Array);
+
+    let effect = effects.add(
+        EffectAsset::new(32768, SpawnerSettings::rate(30.0.into()), module)
+            .with_name("lut")
+            .init(init_pos)
+            .init(init_vel)
+            .init(init_age)
+            .init(init_lifetime)
+            .update(update_drag)
+            .update(update_lut),
+    );
+
+    commands
+        .spawn((
+            Name::new("emit:random"),
+            ParticleEffect::new(effect),
+            Transform::from_translation(Vec3::new(0., 0., 0.)),
+            EffectProperties::default(),
+            EffectMaterial {
+                // Assign our LUT image to texture slot #0
+                images: vec![image],
+            },
+        ))
+        .with_children(|p| {
+            // Reference cube to visualize the emit origin
+            p.spawn((Mesh3d(cube), MeshMaterial3d(mat)));
+        });
+}
+
+fn update(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut q_properties: Query<&mut EffectProperties>,
+) {
+    let Ok(mut properties) = q_properties.single_mut() else {
+        return;
+    };
+
+    // Read the current 2D array texture layer index stored in the "layer" property
+    let layer_index = properties
+        .get_stored("layer")
+        .map(|v| v.as_scalar().as_u32())
+        .unwrap_or(0);
+
+    // Update the index if the user press a key
+    let mut new_index = layer_index;
+    if keyboard_input.just_pressed(KeyCode::ArrowDown)
+        || keyboard_input.just_pressed(KeyCode::Space)
+    {
+        new_index = (new_index + 1) % 4;
+    } else if keyboard_input.just_pressed(KeyCode::ArrowUp) {
+        new_index = (new_index + 3) % 4;
+    }
+
+    // If the value changed, write down the new value, and it gets uploaded to GPU
+    // automatically by Hanabi.
+    if new_index != layer_index {
+        properties.set("layer", new_index.into());
+    }
+}

--- a/examples/lut.rs
+++ b/examples/lut.rs
@@ -76,7 +76,7 @@ fn setup(
                     .to_linear(),
                     _ => panic!(),
                 };
-                data[offset * 4 + 0] = (c.red * 255.0) as u8;
+                data[offset * 4] = (c.red * 255.0) as u8;
                 data[offset * 4 + 1] = (c.green * 255.0) as u8;
                 data[offset * 4 + 2] = (c.blue * 255.0) as u8;
                 data[offset * 4 + 3] = 255;

--- a/examples/lut.txt
+++ b/examples/lut.txt
@@ -1,0 +1,5 @@
+This example shows how to use a texture as a lookup table (LUT).
+
+The effect emits particles whose color is sampled from a texture, based on the particle age and velocity. There are 4 color palettes, stored as 4 layers of a 2D array texture. A property dynamically select which layer to use.
+
+Use the up/down arrows and SPACE key to change the color palette.

--- a/examples/worms.rs
+++ b/examples/worms.rs
@@ -104,12 +104,12 @@ fn create_head_effect() -> EffectAsset {
 
     // Make each particle round.
     let particle_texture_modifier = ParticleTextureModifier {
-        texture_slot: writer.lit(0u32).expr(),
+        texture_slot: 0,
         sample_mapping: ImageSampleMapping::Modulate,
     };
 
     let mut module = writer.finish();
-    module.add_texture_slot("shape");
+    module.add_texture_slot("shape", SlotDimension::D2);
 
     // Allocate room for 100 "head" particles (100 worms)
     EffectAsset::new(100, SpawnerSettings::rate(2.0.into()), module)

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -1,6 +1,5 @@
 @echo on
 echo Run all examples
-REM 3D
 cargo r --example lightning
 cargo r --example firework
 cargo r --example portal
@@ -9,6 +8,7 @@ cargo r --example spawn
 cargo r --example multicam
 cargo r --example visibility
 cargo r --example random
+cargo r --example ribbon
 cargo r --example spawn_on_command
 cargo r --example activate
 cargo r --example force_field
@@ -16,12 +16,11 @@ cargo r --example init
 cargo r --example lifetime
 cargo r --example ordering
 cargo r --example ribbon
-REM 3D + PNG
 cargo r --example gradient
 cargo r --example circle
 cargo r --example billboard
 cargo r --example worms
 cargo r --example instancing
 cargo r --example puffs
-REM 2D
+cargo r --example lut
 cargo r --example 2d

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -8,7 +8,6 @@ cargo r --example spawn
 cargo r --example multicam
 cargo r --example visibility
 cargo r --example random
-cargo r --example ribbon
 cargo r --example spawn_on_command
 cargo r --example activate
 cargo r --example force_field

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -1,5 +1,4 @@
 echo Run all examples
-# 3D
 cargo r --example lightning
 cargo r --example firework
 cargo r --example portal
@@ -15,12 +14,11 @@ cargo r --example init
 cargo r --example lifetime
 cargo r --example ordering
 cargo r --example ribbon
-# 3D + PNG
 cargo r --example gradient
 cargo r --example circle
 cargo r --example billboard
 cargo r --example worms
 cargo r --example instancing
 cargo r --example puffs
-# 2D
+cargo r --example lut
 cargo r --example 2d

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1220,7 +1220,6 @@ mod tests {
         let mut module = Module::default();
         let origin = module.lit(Vec3::ZERO);
         let one = module.lit(1.);
-        let slot_zero = module.lit(0u32);
         let init_age = SetAttributeModifier::new(Attribute::AGE, one);
         let init_lifetime = SetAttributeModifier::new(Attribute::LIFETIME, one);
         let init_pos_sphere = SetPositionSphereModifier {
@@ -1239,7 +1238,7 @@ mod tests {
             //.update(AccelModifier::default())
             .update(LinearDragModifier::new(one))
             .update(ConformToSphereModifier::new(origin, one, one, one, one))
-            .render(ParticleTextureModifier::new(slot_zero))
+            .render(ParticleTextureModifier::new(0))
             .render(ColorOverLifetimeModifier::default())
             .render(SizeOverLifetimeModifier::default())
             .render(OrientModifier::new(OrientMode::ParallelCameraDepthPlane))
@@ -1287,7 +1286,7 @@ mod tests {
         let texture_layout = TextureLayout::default();
         let mut render_context =
             RenderContext::new(&property_layout, &particle_layout, &texture_layout);
-        ParticleTextureModifier::new(slot_zero)
+        ParticleTextureModifier::new(0)
             .apply_render(module, &mut render_context)
             .unwrap();
         ColorOverLifetimeModifier::default()

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1251,8 +1251,13 @@ mod tests {
         let module = &mut effect.module;
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut init_context =
-            ShaderWriter::new(ModifierContext::Init, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut init_context = ShaderWriter::new(
+            ModifierContext::Init,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(init_pos_sphere.apply(module, &mut init_context).is_ok());
         assert!(init_vel_sphere.apply(module, &mut init_context).is_ok());
         assert!(init_age.apply(module, &mut init_context).is_ok());
@@ -1263,8 +1268,13 @@ mod tests {
         let drag_mod = LinearDragModifier::constant(module, 3.5);
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut update_context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut update_context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(accel_mod.apply(module, &mut update_context).is_ok());
         assert!(drag_mod.apply(module, &mut update_context).is_ok());
         assert!(ConformToSphereModifier::new(origin, one, one, one, one)

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1545,7 +1545,6 @@ impl CastExpr {
     }
 }
 
-
 /// Expression to sample a texture from the effect's material with filtering.
 ///
 /// This supports all texture types supported by [`SlotDimension`]. The texture
@@ -1699,7 +1698,6 @@ impl TextureSampleExpr {
         // Note: do not use to_wgsl_string(), we want an index suffix and not a WGSL
         // literal value.
         let slot_index = self.slot_index;
-        context.mark_texture_slot_used(slot_index);
         if self.slot_dimension.is_array() {
             Ok(format!(
                     "textureSample(material_texture_{slot_index}, material_sampler_{slot_index}, {coordinates}, {array_index})",

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -789,6 +789,7 @@ impl Module {
 ///
 /// [`Graph`]: crate::graph::Graph
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum ExprError {
     /// Expression type error.
     ///
@@ -5302,6 +5303,47 @@ mod tests {
             let mut de = ron::de::Deserializer::from_str("\"#4294967296\"").unwrap();
             let ret = ExprHandle::deserialize(&mut de);
             assert!(ret.is_err());
+        }
+    }
+
+    #[test]
+    fn texture_load_expr() {
+        let mut module = Module::default();
+        let coordinates = module.lit(Vec2::ZERO);
+        let array_index = module.lit(0_u32);
+        let mip_level = module.lit(0_u32);
+
+        let dims = [
+            SlotDimension::D1,
+            SlotDimension::D2,
+            SlotDimension::D2Array,
+            SlotDimension::Cube,
+            SlotDimension::CubeArray,
+            SlotDimension::D3,
+            SlotDimension::DepthD2,
+            SlotDimension::DepthD2Array,
+            SlotDimension::DepthCube,
+            SlotDimension::DepthCubeArray,
+        ];
+        let mips = [None, Some(mip_level)];
+        for dim in &dims {
+            for mip in &mips {
+                let mip = *mip;
+
+                let res = TextureLoadExpr::new(4, *dim, coordinates, None, mip);
+                assert_eq!(
+                    res.is_ok(),
+                    !dim.is_array() && !dim.is_cube(),
+                    "array=false dim={dim:?} res={res:?} mip={mip:?}"
+                );
+
+                let res = TextureLoadExpr::new(4, *dim, coordinates, Some(array_index), mip);
+                assert_eq!(
+                    res.is_ok(),
+                    dim.is_array() && !dim.is_cube(),
+                    "array=true dim={dim:?} res={res:?} mip={mip:?}"
+                );
+            }
         }
     }
 }

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -1146,7 +1146,8 @@ impl Expr {
     /// let mut module = Module::default();
     /// # let pl = PropertyLayout::empty();
     /// # let pal = ParticleLayout::default();
-    /// # let mut context = ShaderWriter::new(ModifierContext::Update, &pl, &pal);
+    /// # let tl = TextureLayout::default();
+    /// # let mut context = ShaderWriter::new(ModifierContext::Update, &pl, &pal, &tl);
     /// let handle = module.lit(1.);
     /// let expr = module.get(handle).unwrap();
     /// assert_eq!(Ok("1.".to_string()), expr.eval(&module, &mut context));

--- a/src/graph/expr.rs
+++ b/src/graph/expr.rs
@@ -115,7 +115,7 @@ use thiserror::Error;
 use super::Value;
 use crate::{
     Attribute, ModifierContext, ParticleLayout, Property, PropertyLayout, ScalarType,
-    TextureLayout, TextureSlot, ToWgslString, ValueType, VectorType,
+    SlotDimension, TextureLayout, TextureSlot, ToWgslString, ValueType, VectorType,
 };
 
 /// A one-based ID into a collection of a [`Module`].
@@ -474,8 +474,8 @@ impl Module {
     /// # Returns
     ///
     /// The handle of the texture inside this module. This handle is used in
-    /// expressions like the [`TextureSampleExpr`] to reference this texture
-    /// slot.
+    /// expressions like [`TextureSampleExpr`] or [`TextureLoadExpr`] to
+    /// reference this texture slot.
     ///
     /// # Panics
     ///
@@ -484,10 +484,17 @@ impl Module {
     /// slot name.
     ///
     /// [`EffectMaterial`]: crate::EffectMaterial
-    pub fn add_texture_slot(&mut self, name: impl Into<String>) -> TextureHandle {
+    pub fn add_texture_slot(
+        &mut self,
+        name: impl Into<String>,
+        slot_dimension: SlotDimension,
+    ) -> TextureHandle {
         let name = name.into();
         assert!(!self.texture_layout.layout.iter().any(|t| t.name == name));
-        self.texture_layout.layout.push(TextureSlot { name });
+        self.texture_layout.layout.push(TextureSlot {
+            name,
+            dimension: slot_dimension,
+        });
         // SAFETY - We just pushed a new slot into the array, so its length is non-zero.
         #[allow(unsafe_code)]
         unsafe {
@@ -820,8 +827,21 @@ pub enum ExprError {
     ///
     /// The operation was expecting a given [`ModifierContext`], but instead
     /// another [`ModifierContext`] was available.
-    #[error("Invalid modifier context {0}, expected {1} instead.")]
-    InvalidModifierContext(ModifierContext, ModifierContext),
+    #[error("Invalid modifier context {0}, expected {1} instead.{2}")]
+    InvalidModifierContext(ModifierContext, ModifierContext, &'static str),
+
+    /// Texture slot index out of bounds.
+    ///
+    /// Some expression attempted to index a texture slot out of bounds.
+    #[error("Texture slot #{0} out of bounds; effect has only {1} slots.")]
+    SlotBoundsError(u32, u32),
+
+    /// Texture slot dimension mismatch.
+    ///
+    /// Some expression expected a slot dimension, but the actual dimension of
+    /// the slot declared in the [`Module`] was different.
+    #[error("Texture slot #{0} has dimension {1:?}, but an expression expected a dimension of {2:?} instead.")]
+    SlotDimensionError(u32, SlotDimension, SlotDimension),
 }
 
 /// Evaluation context for transforming expressions into WGSL code.
@@ -845,6 +865,9 @@ pub trait EvalContext {
 
     /// Get the property layout of the effect.
     fn property_layout(&self) -> &PropertyLayout;
+
+    /// Get the texture layout of the effect.
+    fn texture_layout(&self) -> &TextureLayout;
 
     /// Evaluate an expression, returning its WGSL shader code.
     ///
@@ -988,11 +1011,18 @@ pub enum Expr {
     /// An expression to cast an expression to another type.
     Cast(CastExpr),
 
-    /// Access to textures.
+    /// Access to textures (filtered).
     ///
-    /// An expression to sample a texture from the effect's material. Currently
-    /// only color textures (returning a `vec4<f32>`) are supported.
+    /// An expression to sample a texture from the effect's material, with
+    /// filering (including mip-mapping). This is only valid in the fragment
+    /// shader, during the [`ModifierContext::Render`] pass.
     TextureSample(TextureSampleExpr),
+
+    /// Access to textures (unfiltered).
+    ///
+    /// An expression to load from a texture of the effect's material. All
+    /// textures supported by [`SlotDimension`] are valid.
+    TextureLoad(TextureLoadExpr),
 }
 
 impl Expr {
@@ -1038,7 +1068,7 @@ impl Expr {
                 ..
             } => module.is_const(*first) && module.is_const(*second) && module.is_const(*third),
             Expr::Cast(expr) => module.is_const(expr.inner),
-            Expr::TextureSample(_) => false,
+            Expr::TextureSample(_) | Expr::TextureLoad(_) => false,
         }
     }
 
@@ -1060,7 +1090,7 @@ impl Expr {
             }
             Expr::Ternary { .. } => false,
             Expr::Cast(_) => false,
-            Expr::TextureSample(_) => false,
+            Expr::TextureSample(_) | Expr::TextureLoad(_) => false,
         }
     }
 
@@ -1095,6 +1125,7 @@ impl Expr {
             Expr::Ternary { .. } => None,
             Expr::Cast(expr) => Some(expr.value_type()),
             Expr::TextureSample(expr) => Some(expr.value_type()),
+            Expr::TextureLoad(expr) => Some(expr.value_type()),
         }
     }
 
@@ -1255,6 +1286,7 @@ impl Expr {
                 Ok(format!("{}({})", expr.target.to_wgsl_string(), inner))
             }
             Expr::TextureSample(expr) => expr.eval(module, context),
+            Expr::TextureLoad(expr) => expr.eval(module, context),
         }
     }
 }
@@ -1513,50 +1545,111 @@ impl CastExpr {
     }
 }
 
-/// Expression to sample a texture from the effect's material.
+
+/// Expression to sample a texture from the effect's material with filtering.
 ///
-/// This currently supports only 4-component textures sampled with [the WGSL
-/// `textureSample()` function], that is all textures which return a `vec4<f32>`
-/// when sampled. This is the case of most color textures, including
-/// single-channel (e.g. red) textures which return zero for missing components,
-/// but excludes depth textures.
+/// This supports all texture types supported by [`SlotDimension`]. The texture
+/// is sampled with [the WGSL `textureSample()` function], and returns a
+/// `vec4<f32>` if the texture is a non-depth texture, or a `f32` if it it; see
+/// [`SlotDimension::is_depth()`]. Note that this read is filtered in all
+/// dimensions, including mip-mapping.
+///
+/// Note that WGSL restricts the use of `textureSample()` to the fragment
+/// shader. Hanabi will emit an error if this expression is used in the
+/// [`ModifierContext::Init`] or [`ModifierContext::Update`]. For
+/// [`ModifierContext::Render`], there's no distinction currently between the
+/// vertex and fragment shader, so Hanabi cannot proactively emit an error if
+/// the expression ends up used in the vertex shader. If you need to read a
+/// texture from any of those forbidden contexts, use [`TextureLoadExpr`]
+/// instead.
 ///
 /// [the WGSL `textureSample()` function]: https://www.w3.org/TR/WGSL/#texturesample
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 pub struct TextureSampleExpr {
-    /// The index of the image to sample. This is the texture slot defined in
-    /// the [`Module`]. The texture bound to the slot is defined in the
-    /// [`EffectMaterial`] component.
+    /// The index of the texture slot to sample.
+    ///
+    /// A texture slot is defined in the [`Module`] by calling
+    /// [`Module::add_texture_slot()`]. The texture bound to each slot is
+    /// defined in the [`EffectMaterial`] component.
     ///
     /// [`EffectMaterial`]: crate::EffectMaterial
-    pub image: ExprHandle,
-    /// The coordinates to sample at.
+    pub slot_index: u32,
+    /// The type of texture to sample. This must match the dimension of the
+    /// slot at index `slot_index`.
+    pub slot_dimension: SlotDimension,
+    /// The coordinates to sample at. This is a floating-point scalar or vector,
+    /// depending on the image dimension (1D/2D/3D).
     pub coordinates: ExprHandle,
+    /// Optional array index to load (u32 or i32). Mandatory for loading from
+    /// array textures, and must be `None` for non-array textures. See
+    /// [`SlotDimension::is_array()`].
+    pub array_index: Option<ExprHandle>,
 }
 
 impl TextureSampleExpr {
     /// Create a new texture sample expression.
+    ///
+    /// Not all combinations of slot dimension and array index are supported.
+    /// The `array_index` must be `Some` if [`SlotDimension::is_array`] is
+    /// `true`, and `None` otherwise. This function returns an error if the
+    /// specified combination is invalid. Check the [WGSL specification] of
+    /// the `textureSample()` function for more details.
+    ///
+    /// [WGSL specification]: https://www.w3.org/TR/WGSL/#texturesample
     #[inline]
-    pub fn new(image: ExprHandle, coordinates: ExprHandle) -> Self {
-        Self { image, coordinates }
+    pub fn new(
+        slot_index: u32,
+        slot_dimension: SlotDimension,
+        coordinates: ExprHandle,
+        array_index: Option<ExprHandle>,
+    ) -> Result<Self, ExprError> {
+        if slot_dimension.is_array() {
+            if array_index.is_none() {
+                return Err(ExprError::TypeError(
+                    "TextureSampleExpr with array texture requires an array index".to_string(),
+                ));
+            }
+        } else {
+            if array_index.is_some() {
+                return Err(ExprError::TypeError(
+                    "TextureSampleExpr with non-array texture doesn't support array index"
+                        .to_string(),
+                ));
+            }
+        }
+        Ok(Self {
+            slot_index,
+            slot_dimension,
+            coordinates,
+            array_index,
+        })
     }
 
     /// Get the value type of the expression.
     pub fn value_type(&self) -> ValueType {
-        // FIXME - depth textures return a single f32 when sampled
-        ValueType::Vector(VectorType::VEC4F)
+        if self.slot_dimension.is_depth() {
+            ValueType::Scalar(ScalarType::Float)
+        } else {
+            ValueType::Vector(VectorType::VEC4F)
+        }
     }
 
-    /// Try to evaluate if the texture sample expression is valid.
+    /// Try to evaluate if the texture load expression is valid.
     ///
-    /// This only checks that the expressions exist in the module.
+    /// This checks that the fields are consistent with the slot dimension, and
+    /// the expressions exist in the module.
     pub fn is_valid(&self, module: &Module) -> Option<bool> {
-        let Some(_image) = module.get(self.image) else {
+        if self.slot_dimension.is_array() != self.array_index.is_some() {
+            return Some(false);
+        }
+        if module.get(self.coordinates).is_none() {
             return Some(false);
         };
-        let Some(_coordinates) = module.get(self.coordinates) else {
-            return Some(false);
-        };
+        if let Some(array_index) = self.array_index {
+            if module.get(array_index).is_none() {
+                return Some(false);
+            };
+        }
         Some(true)
     }
 
@@ -1566,13 +1659,254 @@ impl TextureSampleExpr {
         module: &Module,
         context: &mut dyn EvalContext,
     ) -> Result<String, ExprError> {
-        let image = module.try_get(self.image)?;
-        let image = image.eval(module, context)?;
+        // Sampling type texture access can only be used in a fragment shader, so only
+        // in the Render context. This is a WGSL restriction.
+        if context.modifier_context() != ModifierContext::Render {
+            return Err(ExprError::InvalidModifierContext(
+                context.modifier_context(),
+                ModifierContext::Render,
+                " TextureSampleExpr can only be used in a fragment shader. Use TextureLoadExpr instead.",
+            ));
+        }
+
         let coordinates = module.try_get(self.coordinates)?;
         let coordinates = coordinates.eval(module, context)?;
-        Ok(format!(
-            "textureSample(material_texture_{image}, material_sampler_{image}, {coordinates})",
-        ))
+
+        let array_index = if let Some(array_index) = self.array_index {
+            let array_index = module.try_get(array_index)?;
+            array_index.eval(module, context)?
+        } else {
+            // WGSL spec says i32 or u32; both are fine
+            "0".to_string()
+        };
+
+        // Bound-check the slot index
+        let slot_count = context.texture_layout().layout.len() as u32;
+        if self.slot_index >= slot_count {
+            return Err(ExprError::SlotBoundsError(self.slot_index, slot_count));
+        }
+
+        // Validate the expected slot dimension
+        let layout_dimension = context.texture_layout().layout[self.slot_index as usize].dimension;
+        if layout_dimension != self.slot_dimension {
+            return Err(ExprError::SlotDimensionError(
+                self.slot_index,
+                layout_dimension,
+                self.slot_dimension,
+            ));
+        }
+
+        // Note: do not use to_wgsl_string(), we want an index suffix and not a WGSL
+        // literal value.
+        let slot_index = self.slot_index;
+        context.mark_texture_slot_used(slot_index);
+        if self.slot_dimension.is_array() {
+            Ok(format!(
+                    "textureSample(material_texture_{slot_index}, material_sampler_{slot_index}, {coordinates}, {array_index})",
+                ))
+        } else {
+            Ok(format!(
+                    "textureSample(material_texture_{slot_index}, material_sampler_{slot_index}, {coordinates})",
+                ))
+        }
+    }
+}
+
+/// Expression to load a value from a texture of the effect's material, without
+/// filtering.
+///
+/// This supports all texture types supported by [`SlotDimension`]. The texture
+/// is read with [the WGSL `textureLoad()` function], and returns a
+/// `vec4<f32>` if the texture is a non-depth texture, or a `f32` if it it; see
+/// [`SlotDimension::is_depth()`]. Note that this read is unfiltered; this is
+/// the reason why the expression takes an explicit `mip_level`. To use
+/// filering, including mip-mapping, use [`TextureSampleExpr`] instead, but note
+/// that filtered read can only occur in the fragment shader during the
+/// [`ModifierContext::Render`] pass.
+///
+/// Hanabi currently doesn't support "gather"-type loads (loading 4 values at
+/// once with `textureGather()`).
+///
+/// [the WGSL `textureLoad()` function]: https://www.w3.org/TR/WGSL/#textureload
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+pub struct TextureLoadExpr {
+    /// The index of the texture slot to load from.
+    ///
+    /// A texture slot is defined in the [`Module`] by calling
+    /// [`Module::add_texture_slot()`]. The texture bound to each slot is
+    /// defined in the [`EffectMaterial`] component.
+    ///
+    /// [`EffectMaterial`]: crate::EffectMaterial
+    pub slot_index: u32,
+    /// The type of texture to load from. This must match the dimension of the
+    /// slot at index `slot_index`.
+    pub slot_dimension: SlotDimension,
+    /// The coordinates to load at. This is an integral (i32 or u32) scalar or
+    /// vector, depending on the image dimension (1D/2D/3D). Array index and
+    /// mip-map level are specified separately.
+    pub coordinates: ExprHandle,
+    /// Optional array index to load (u32 or i32). Mandatory for loading from
+    /// array textures, and must be `None` for non-array textures.
+    pub array_index: Option<ExprHandle>,
+    /// Optional mip level to load (u32 or i32). Defaults to 0 (full
+    /// resolution).
+    pub mip_level: Option<ExprHandle>,
+}
+
+impl TextureLoadExpr {
+    /// Create a new texture load expression.
+    ///
+    /// Not all combinations of slot dimension and array index / mip-map level
+    /// are supported. Direct loading from cube textures is also not supported
+    /// (only sampled loading, through [`TextureSampleExpr`]). This function
+    /// returns an error if the specified combination is invalid. Check the
+    /// [WGSL specification] of the `textureLoad()` function for more details.
+    ///
+    /// [WGSL specification]: https://www.w3.org/TR/WGSL/#textureload
+    #[inline]
+    pub fn new(
+        slot_index: u32,
+        slot_dimension: SlotDimension,
+        coordinates: ExprHandle,
+        array_index: Option<ExprHandle>,
+        mip_level: Option<ExprHandle>,
+    ) -> Result<Self, ExprError> {
+        if slot_dimension.is_cube() {
+            return Err(ExprError::TypeError(format!(
+                "TextureLoadExpr doesn't support slot dimension {:?}.",
+                slot_dimension
+            )));
+        }
+        if slot_dimension.is_array() {
+            if array_index.is_none() {
+                return Err(ExprError::TypeError(
+                    "TextureLoadExpr with array texture requires an array index".to_string(),
+                ));
+            }
+        } else {
+            if array_index.is_some() {
+                return Err(ExprError::TypeError(
+                    "TextureLoadExpr with non-array texture doesn't support array index"
+                        .to_string(),
+                ));
+            }
+        }
+        Ok(Self {
+            slot_index,
+            slot_dimension,
+            coordinates,
+            array_index,
+            mip_level,
+        })
+    }
+
+    /// Get the value type of the expression.
+    ///
+    /// # Panics
+    ///
+    /// This panics if [`slot_dimension`] is unsupported.
+    ///
+    /// [`slot_dimension`]: Self::slot_dimension
+    pub fn value_type(&self) -> ValueType {
+        assert!(!self.slot_dimension.is_cube());
+        if self.slot_dimension.is_depth() {
+            ValueType::Scalar(ScalarType::Float)
+        } else {
+            ValueType::Vector(VectorType::VEC4F)
+        }
+    }
+
+    /// Try to evaluate if the texture load expression is valid.
+    ///
+    /// This checks that the fields are consistent with the slot dimension, and
+    /// the expressions exist in the module.
+    pub fn is_valid(&self, module: &Module) -> Option<bool> {
+        if !match self.slot_dimension {
+            SlotDimension::D1 | SlotDimension::D2 | SlotDimension::D3 | SlotDimension::DepthD2 => {
+                self.mip_level.is_some() && self.array_index.is_none()
+            }
+            SlotDimension::D2Array | SlotDimension::DepthD2Array => {
+                self.mip_level.is_some() && self.array_index.is_some()
+            }
+            _ => false,
+        } {
+            return Some(false);
+        }
+        if module.get(self.coordinates).is_none() {
+            return Some(false);
+        };
+        if let Some(mip_level) = self.mip_level {
+            if module.get(mip_level).is_none() {
+                return Some(false);
+            };
+        }
+        if let Some(array_index) = self.array_index {
+            if module.get(array_index).is_none() {
+                return Some(false);
+            };
+        }
+        Some(true)
+    }
+
+    /// Evaluate the expression in the given context.
+    pub fn eval(
+        &self,
+        module: &Module,
+        context: &mut dyn EvalContext,
+    ) -> Result<String, ExprError> {
+        let coordinates = module.try_get(self.coordinates)?;
+        let coordinates = coordinates.eval(module, context)?;
+
+        let array_index = if let Some(array_index) = self.array_index {
+            let array_index = module.try_get(array_index)?;
+            array_index.eval(module, context)?
+        } else {
+            // WGSL spec says i32 or u32; both are fine
+            "0".to_string()
+        };
+
+        let mip_level = if let Some(mip_level) = self.mip_level {
+            let mip_level = module.try_get(mip_level)?;
+            mip_level.eval(module, context)?
+        } else {
+            // WGSL spec says i32 or u32; both are fine
+            "0".to_string()
+        };
+
+        // Bound-check the slot index
+        let slot_count = context.texture_layout().layout.len() as u32;
+        if self.slot_index >= slot_count {
+            return Err(ExprError::SlotBoundsError(self.slot_index, slot_count));
+        }
+
+        // Validate the expected slot dimension
+        let layout_dimension = context.texture_layout().layout[self.slot_index as usize].dimension;
+        if layout_dimension != self.slot_dimension {
+            return Err(ExprError::SlotDimensionError(
+                self.slot_index,
+                layout_dimension,
+                self.slot_dimension,
+            ));
+        }
+
+        // Note: do not use to_wgsl_string(), we want an index suffix and not a WGSL
+        // literal value.
+        let slot_index = self.slot_index;
+        match self.slot_dimension {
+            SlotDimension::D1 | SlotDimension::D2 | SlotDimension::D3 | SlotDimension::DepthD2 => {
+                Ok(format!(
+                    "textureLoad(material_texture_{slot_index}, {coordinates}, {mip_level})",
+                ))
+            }
+            SlotDimension::D2Array | SlotDimension::DepthD2Array => {
+                Ok(format!(
+                    "textureLoad(material_texture_{slot_index}, {coordinates}, {array_index}, {mip_level})",
+                ))
+            }
+            _ => Err(ExprError::TypeError(format!(
+                "TextureLoadExpr doesn't support slot dimension {:?}",
+                self.slot_dimension))),
+        }
     }
 }
 
@@ -4164,8 +4498,13 @@ mod tests {
     fn local_var() {
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let mut h = HashSet::new();
         for _ in 0..100 {
             let v = ctx.make_local_var();
@@ -4177,8 +4516,13 @@ mod tests {
     fn make_fn() {
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let mut module = Module::default();
 
         // Make a function
@@ -4232,9 +4576,14 @@ mod tests {
         let property_layout =
             PropertyLayout::new(&[Property::new("my_prop", ScalarValue::Float(3.))]);
         let particle_layout = ParticleLayout::default();
+        let texture_layout = TextureLayout::default();
         let m = w.finish();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         // Evaluate the expression
         let x = m.try_get(x).unwrap();
@@ -4273,8 +4622,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         for (expr, op) in [
             (add, "+"),
@@ -4329,8 +4683,13 @@ mod tests {
 
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
 
             let expr = ctx.eval(&m, handle);
             assert!(expr.is_ok());
@@ -4353,8 +4712,13 @@ mod tests {
 
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
 
             let expr = ctx.eval(&m, value);
             assert!(expr.is_ok());
@@ -4375,8 +4739,13 @@ mod tests {
             {
                 let property_layout = PropertyLayout::default();
                 let particle_layout = ParticleLayout::default();
-                let mut ctx =
-                    ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+                let texture_layout = TextureLayout::default();
+                let mut ctx = ShaderWriter::new(
+                    ModifierContext::Update,
+                    &property_layout,
+                    &particle_layout,
+                    &texture_layout,
+                );
 
                 let expr = ctx.eval(&m, value);
                 assert!(expr.is_ok());
@@ -4393,8 +4762,13 @@ mod tests {
 
                 let property_layout = PropertyLayout::default();
                 let particle_layout = ParticleLayout::default();
-                let mut ctx =
-                    ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+                let texture_layout = TextureLayout::default();
+                let mut ctx = ShaderWriter::new(
+                    ModifierContext::Update,
+                    &property_layout,
+                    &particle_layout,
+                    &texture_layout,
+                );
 
                 let expr = ctx.eval(&m, vec);
                 assert!(expr.is_ok());
@@ -4454,8 +4828,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         for (expr, op, inner) in [
             (
@@ -4528,8 +4907,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         for (expr, op) in [
             (atan2, "atan2"),
@@ -4583,8 +4967,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         for (expr, op, third) in [
             (mix, "mix", t),
@@ -4633,8 +5022,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         for (expr, cast, target) in [
             (x, cx, ValueType::Vector(VectorType::VEC3I)),
@@ -4659,8 +5053,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
 
         let res = ctx.eval(&m, x);
         assert!(res.is_ok());
@@ -4669,9 +5068,13 @@ mod tests {
 
         // Use a different context; it's invalid to reuse a mutated context, as the
         // expression cache will have been generated with the wrong context.
-        let mut ctx =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout)
-                .with_attribute_pointer();
+        let mut ctx = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        )
+        .with_attribute_pointer();
 
         let res = ctx.eval(&m, x);
         assert!(res.is_ok());
@@ -4762,8 +5165,13 @@ mod tests {
         {
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             let value = ctx.eval(&m, a).unwrap();
             assert_eq!(value, "(var0) + (var0)");
             assert_eq!(ctx.main_code, "let var0 = frand();\n");
@@ -4772,8 +5180,13 @@ mod tests {
         {
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             let value = ctx.eval(&m, b).unwrap();
             assert_eq!(value, "mix(var0, var0, var0)");
             assert_eq!(ctx.main_code, "let var0 = frand();\n");
@@ -4782,8 +5195,13 @@ mod tests {
         {
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             let value = ctx.eval(&m, c).unwrap();
             assert_eq!(value, "abs((var0) + (var0))");
             assert_eq!(ctx.main_code, "let var0 = frand();\n");
@@ -4839,7 +5257,7 @@ mod tests {
             assert_eq!(handle, serde_handle);
         }
 
-        // de -- literatl string
+        // de -- literal string
         {
             let mut de = ron::de::Deserializer::from_str("\"#42\"").unwrap();
             let serde_handle = ExprHandle::deserialize(&mut de).unwrap();

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -775,7 +775,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        node::Node as _, EvalContext, ModifierContext, ParticleLayout, PropertyLayout, ShaderWriter,
+        node::Node as _, EvalContext, ModifierContext, ParticleLayout, PropertyLayout,
+        ShaderWriter, TextureLayout,
     };
 
     #[test]
@@ -797,8 +798,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str = context.eval(&module, out).unwrap();
         assert_eq!(str, "(3.) + (2.)".to_string());
     }
@@ -821,8 +827,13 @@ mod tests {
         let out = outputs[0];
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str = context.eval(&module, out).unwrap();
         assert_eq!(str, "(3.) - (2.)".to_string());
     }
@@ -845,8 +856,13 @@ mod tests {
         let out = outputs[0];
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str = context.eval(&module, out).unwrap();
         assert_eq!(str, "(3.) * (2.)".to_string());
     }
@@ -869,8 +885,13 @@ mod tests {
         let out = outputs[0];
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str = context.eval(&module, out).unwrap();
         assert_eq!(str, "(3.) / (2.)".to_string());
     }
@@ -890,8 +911,13 @@ mod tests {
         let out = outputs[0];
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str = context.eval(&module, out).unwrap();
         assert_eq!(str, format!("particle.{}", Attribute::POSITION.name()));
     }
@@ -910,8 +936,13 @@ mod tests {
         assert_eq!(outputs.len(), 2);
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str0 = context.eval(&module, outputs[0]).unwrap();
         let str1 = context.eval(&module, outputs[1]).unwrap();
         assert_eq!(str0, format!("sim_params.{}", BuiltInOperator::Time.name()));
@@ -935,8 +966,13 @@ mod tests {
         assert_eq!(outputs.len(), 1);
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let str = context.eval(&module, outputs[0]).unwrap();
         assert_eq!(str, "normalize(vec3<f32>(1.,1.,1.))".to_string());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,6 +825,38 @@ impl SlotDimension {
                 | SlotDimension::DepthCubeArray
         )
     }
+
+    /// Convert this slot dimension to a WGSL texture type name.
+    pub fn to_wgsl_texture_type(&self) -> String {
+        match *self {
+            SlotDimension::D1 => "texture_1d<f32>",
+            SlotDimension::D2 => "texture_2d<f32>",
+            SlotDimension::D2Array => "texture_2d_array<f32>",
+            SlotDimension::D3 => "texture_3d<f32>",
+            SlotDimension::Cube => "texture_cube<f32>",
+            SlotDimension::CubeArray => "texture_cube_array<f32>",
+            SlotDimension::DepthD2 => "texture_depth_2d<f32>",
+            SlotDimension::DepthD2Array => "texture_depth_2d_array<f32>",
+            SlotDimension::DepthCube => "texture_depth_cube<f32>",
+            SlotDimension::DepthCubeArray => "texture_depth_cube_array<f32>",
+        }
+        .to_string()
+    }
+
+    /// Convert this slot dimension to a WGSL sampler type.
+    ///
+    /// This returns `sampler_comparison` if [`is_depth()`] is `true`, or
+    /// `sampler` otherwise.
+    ///
+    /// [`is_depth()`]: Self::is_depth
+    pub fn to_wgsl_sampler_type(&self) -> String {
+        if self.is_depth() {
+            "sampler_comparison"
+        } else {
+            "sampler"
+        }
+        .to_string()
+    }
 }
 
 /// Texture slot of a [`Module`].
@@ -877,12 +909,11 @@ impl TextureSlot {
 
         // Cube textures need a number of layer multiple of 6. And non-array ones need
         // exactly 6.
-        if self.dimension.is_cube() {
-            if !self.dimension.is_array() && (array_layer_count != 6) {
-                return false;
-            } else if !array_layer_count.is_multiple_of(6) {
-                return false;
-            }
+        if self.dimension.is_cube()
+            && ((!self.dimension.is_array() && (array_layer_count != 6))
+                || !array_layer_count.is_multiple_of(6))
+        {
+            return false;
         }
 
         // A layer count > 1 requires an array textures or a cube texture
@@ -952,36 +983,6 @@ impl TextureSlot {
             SamplerBindingType::Filtering
         };
         BindingType::Sampler(sampler_binding_type)
-    }
-
-    /// Convert this slot to a WGSL texture type.
-    pub fn to_wgsl_texture_type(&self) -> String {
-        match self.dimension {
-            SlotDimension::D1 => "texture_1d<f32>",
-            SlotDimension::D2 => "texture_2d<f32>",
-            SlotDimension::D2Array => "texture_2d_array<f32>",
-            SlotDimension::D3 => "texture_3d<f32>",
-            SlotDimension::Cube => "texture_cube<f32>",
-            SlotDimension::CubeArray => "texture_cube_array<f32>",
-            SlotDimension::DepthD2 => "texture_depth_2d<f32>",
-            SlotDimension::DepthD2Array => "texture_depth_2d_array<f32>",
-            SlotDimension::DepthCube => "texture_depth_cube<f32>",
-            SlotDimension::DepthCubeArray => "texture_depth_cube_array<f32>",
-        }
-        .to_string()
-    }
-
-    /// Convert this slot to a WGSL sampler type.
-    ///
-    /// This returns `sampler_comparison` if [`SlotDimension::is_depth()`] is
-    /// `true`, or `sampler` otherwise.
-    pub fn to_wgsl_sampler_type(&self) -> String {
-        if self.dimension.is_depth() {
-            "sampler_comparison"
-        } else {
-            "sampler"
-        }
-        .to_string()
     }
 }
 
@@ -1068,8 +1069,8 @@ impl TextureLayout {
         for (slot_index, slot) in self.layout.iter().enumerate() {
             let tex_index = bind_index;
             let sampler_index = bind_index + 1;
-            let texture_type = slot.to_wgsl_texture_type();
-            let sampler_type = slot.to_wgsl_sampler_type();
+            let texture_type = slot.dimension.to_wgsl_texture_type();
+            let sampler_type = slot.dimension.to_wgsl_sampler_type();
             code.push_str(&format!(
                 "@group({group_index}) @binding({tex_index}) var material_texture_{slot_index}: {texture_type};
 @group({group_index}) @binding({sampler_index}) var material_sampler_{slot_index}: {sampler_type};
@@ -3038,5 +3039,83 @@ else { return c1; }
         };
         let accepts = (TextureDimension::D2, LayerMatchFlags::MULTIPLE_OF_SIX, true);
         check_texslot(&slot_depth_cube_array, accepts);
+    }
+
+    #[test]
+    fn slotdim_is() {
+        for dim in [
+            SlotDimension::D1,
+            SlotDimension::D2,
+            SlotDimension::D2Array,
+            SlotDimension::Cube,
+            SlotDimension::CubeArray,
+            SlotDimension::D3,
+            SlotDimension::DepthD2,
+            SlotDimension::DepthD2Array,
+            SlotDimension::DepthCube,
+            SlotDimension::DepthCubeArray,
+        ] {
+            // The canonical WGSL name, which is what the SlotDimentions debug-format to,
+            // happens to always contain "array" if the texture is an array texture, "depth"
+            // if it's used for comparison, and "cube" if it's a cube texture. We use this
+            // as validation.
+            let name = format!("{:?}", dim).to_ascii_lowercase();
+
+            let is_array = name.contains("array");
+            assert_eq!(is_array, dim.is_array());
+
+            let is_depth = name.contains("depth");
+            assert_eq!(is_depth, dim.is_depth());
+
+            let is_cube = name.contains("cube");
+            assert_eq!(is_cube, dim.is_cube());
+        }
+    }
+
+    #[test]
+    fn slotdim_texture_type() {
+        for dim in [
+            SlotDimension::D1,
+            SlotDimension::D2,
+            SlotDimension::D2Array,
+            SlotDimension::Cube,
+            SlotDimension::CubeArray,
+            SlotDimension::D3,
+            SlotDimension::DepthD2,
+            SlotDimension::DepthD2Array,
+            SlotDimension::DepthCube,
+            SlotDimension::DepthCubeArray,
+        ] {
+            let tex = dim.to_wgsl_texture_type();
+
+            let slot_type = format!("{dim:?}")
+                .to_ascii_lowercase()
+                .replace("array", "_array")
+                .replace("depth", "depth_")
+                .replace("d1", "1d")
+                .replace("d2", "2d")
+                .replace("d3", "3d");
+
+            assert_eq!(tex, format!("texture_{slot_type}<f32>"));
+        }
+    }
+
+    #[test]
+    fn slotdim_sampler_type() {
+        for dim in [
+            SlotDimension::D1,
+            SlotDimension::D2,
+            SlotDimension::D2Array,
+            SlotDimension::Cube,
+            SlotDimension::CubeArray,
+            SlotDimension::D3,
+            SlotDimension::DepthD2,
+            SlotDimension::DepthD2Array,
+            SlotDimension::DepthCube,
+            SlotDimension::DepthCubeArray,
+        ] {
+            let sampler = dim.to_wgsl_sampler_type();
+            assert_eq!(sampler.contains("comparison"), dim.is_depth());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,10 @@ use bevy::{
     camera::visibility::VisibilityClass,
     platform::collections::{HashMap, HashSet},
     prelude::*,
-    render::{extract_component::ExtractComponent, sync_world::SyncToRenderWorld},
+    render::{
+        extract_component::ExtractComponent, render_resource::IntoBindGroupLayoutEntryBuilder as _,
+        sync_world::SyncToRenderWorld,
+    },
 };
 use rand::{RngExt as _, SeedableRng as _};
 use serde::{Deserialize, Serialize};
@@ -218,6 +221,10 @@ pub use properties::*;
 pub use render::{DebugSettings, LayoutFlags, ShaderCache};
 pub use spawn::{tick_spawners, CpuValue, EffectSpawner, Random, SpawnerSettings};
 pub use time::{EffectSimulation, EffectSimulationTime};
+use wgpu::{
+    BindGroupLayoutEntry, BindingType, SamplerBindingType, ShaderStages, TextureDescriptor,
+    TextureDimension, TextureSampleType, TextureViewDimension,
+};
 
 #[allow(missing_docs)]
 pub mod prelude {
@@ -724,16 +731,258 @@ pub struct EffectMaterial {
     pub images: Vec<Handle<Image>>,
 }
 
+/// Dimension of a texture for a material slot.
+///
+/// This defines the type of WGSL texture read or sampler used, and what format
+/// is expected for the [`Image`] bound to that slot. Image binding is done via
+/// the [`EffectMaterial`] component.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[reflect(Default)]
+pub enum SlotDimension {
+    /// A one dimensional texture. `texture_1d` in WGSL.
+    #[serde(rename = "1d")]
+    D1,
+
+    /// A two dimensional texture. `texture_2d` in WGSL.
+    #[serde(rename = "2d")]
+    #[default]
+    D2,
+
+    /// A two dimensional array texture. `texture_2d_array` in WGSL.
+    #[serde(rename = "2d-array")]
+    D2Array,
+
+    /// A cubemap texture. `texture_cube` in WGSL.
+    #[serde(rename = "cube")]
+    Cube,
+
+    /// A cubemap array texture. `texture_cube_array` in WGSL.
+    #[serde(rename = "cube-array")]
+    CubeArray,
+
+    /// A three dimensional texture. `texture_3d` in WGSL.
+    #[serde(rename = "3d")]
+    D3,
+
+    /// A two dimensional depth texture. `texture_depth_2d`.
+    #[serde(rename = "depth-2d")]
+    DepthD2,
+
+    /// A two dimensional array texture. `texture_depth_2d_array` in WGSL.
+    #[serde(rename = "depth-2d-array")]
+    DepthD2Array,
+
+    /// A cubemap texture. `texture_depth_cube` in WGSL.
+    #[serde(rename = "depth-cube")]
+    DepthCube,
+
+    /// A cubemap array texture. `texture_depth_cube_array` in WGSL.
+    #[serde(rename = "depth-cube-array")]
+    DepthCubeArray,
+}
+
+impl SlotDimension {
+    /// Check if this slot dimension uses an array texture.
+    ///
+    /// Array textures require an addition `array_index` when loading a value or
+    /// sampling the texture. See [`TextureSampleExpr`] and [`TextureLoadExpr`].
+    pub fn is_array(&self) -> bool {
+        matches!(
+            *self,
+            SlotDimension::D2Array
+                | SlotDimension::CubeArray
+                | SlotDimension::DepthD2Array
+                | SlotDimension::DepthCubeArray
+        )
+    }
+
+    /// Check if this slot dimension uses a depth texture.
+    ///
+    /// Depth textures use a comparison sampler, and always return a scalar
+    /// `f32` value. Non-depth textures conversely return a `vec4<f32>`, and use
+    /// an interpolating sampler (and optional mip-map).
+    pub fn is_depth(&self) -> bool {
+        matches!(
+            *self,
+            SlotDimension::DepthD2
+                | SlotDimension::DepthD2Array
+                | SlotDimension::DepthCube
+                | SlotDimension::DepthCubeArray
+        )
+    }
+
+    /// Check if this slot dimension uses a cube texture.
+    ///
+    /// Cube textures have some usage restrictions. In particular, you cannot
+    /// use them with a [`TextureLoadExpr`]. They always need a multiple of 6
+    /// layers (and exactly 6 if not an array).
+    pub fn is_cube(&self) -> bool {
+        matches!(
+            *self,
+            SlotDimension::Cube
+                | SlotDimension::CubeArray
+                | SlotDimension::DepthCube
+                | SlotDimension::DepthCubeArray
+        )
+    }
+}
+
 /// Texture slot of a [`Module`].
 ///
 /// A texture slot defines a named bind point where a texture can be attached
-/// and sampled by an effect during rendering. A slot also has an implicit
+/// and read/sampled by an effect during rendering. A slot also has an implicit
 /// unique index corresponding to its position in the [`TextureLayout::layout`]
 /// array of the effect.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 pub struct TextureSlot {
     /// Unique slot name.
     pub name: String,
+    /// Texture dimension the slot uses. This determines the sampler of the slot
+    /// in the WGSL shader.
+    pub dimension: SlotDimension,
+}
+
+impl TextureSlot {
+    /// Check if this slot accepts the given texture type.
+    ///
+    /// - `texture_dimension` determines the cardinality 1D/2D/3D of the texture
+    ///   access.
+    /// - `array_layer_count` is the number of layers of an array texture. It
+    ///   can only be > 1 for a [`SlotDimension`] corresponding to an array
+    ///   texture.
+    /// - `is_depth` determines if the texture is accessed via a comparison
+    ///   sampler as a depth texture. Note that this doesn't mean that the
+    ///   texture must contain values that semantically represent a depth value;
+    ///   the semantic of a texture value is irrelevant for the shader compiler,
+    ///   and only matters for the author.
+    pub fn accepts(
+        &self,
+        texture_dimension: TextureDimension,
+        array_layer_count: u32,
+        is_depth: bool,
+    ) -> bool {
+        let expected_dimension = match self.dimension {
+            SlotDimension::D1 => TextureDimension::D1,
+            SlotDimension::D3 => TextureDimension::D3,
+            _ => TextureDimension::D2,
+        };
+        if texture_dimension != expected_dimension {
+            return false;
+        }
+
+        // Depth slots need a texture with a depth format
+        if self.dimension.is_depth() != is_depth {
+            return false;
+        }
+
+        // Cube textures need a number of layer multiple of 6. And non-array ones need
+        // exactly 6.
+        if self.dimension.is_cube() {
+            if !self.dimension.is_array() && (array_layer_count != 6) {
+                return false;
+            } else if !array_layer_count.is_multiple_of(6) {
+                return false;
+            }
+        }
+
+        // A layer count > 1 requires an array textures or a cube texture
+        if array_layer_count > 1 {
+            self.dimension.is_array() || self.dimension.is_cube()
+        } else {
+            true
+        }
+    }
+
+    /// Get the WGPU binding type [`BindingType`] for a texture bound to this
+    /// slot.
+    ///
+    /// This returns a [`BindingType::Texture`].
+    pub fn to_texture_binding_type(&self) -> BindingType {
+        let (sample_type, view_dimension) = match self.dimension {
+            SlotDimension::D1 => (
+                TextureSampleType::Float { filterable: true },
+                TextureViewDimension::D1,
+            ),
+            SlotDimension::D2 => (
+                TextureSampleType::Float { filterable: true },
+                TextureViewDimension::D2,
+            ),
+            SlotDimension::D2Array => (
+                TextureSampleType::Float { filterable: true },
+                TextureViewDimension::D2Array,
+            ),
+            SlotDimension::D3 => (
+                TextureSampleType::Float { filterable: true },
+                TextureViewDimension::D3,
+            ),
+            SlotDimension::Cube => (
+                TextureSampleType::Float { filterable: true },
+                TextureViewDimension::Cube,
+            ),
+            SlotDimension::CubeArray => (
+                TextureSampleType::Float { filterable: true },
+                TextureViewDimension::CubeArray,
+            ),
+            SlotDimension::DepthD2 => (TextureSampleType::Depth, TextureViewDimension::D2),
+            SlotDimension::DepthD2Array => {
+                (TextureSampleType::Depth, TextureViewDimension::D2Array)
+            }
+            SlotDimension::DepthCube => (TextureSampleType::Depth, TextureViewDimension::Cube),
+            SlotDimension::DepthCubeArray => {
+                (TextureSampleType::Depth, TextureViewDimension::CubeArray)
+            }
+        };
+        BindingType::Texture {
+            sample_type,
+            view_dimension,
+            multisampled: false,
+        }
+    }
+
+    /// Get the WGPU binding type [`BindingType`] for a sampler bound to this
+    /// slot.
+    ///
+    /// This returns a [`BindingType::Sampler`] which is either a
+    /// [`SamplerBindingType::Comparison`] if [`SlotDimension::is_depth()`] is
+    /// `true`, or [`SamplerBindingType::Filtering`] otherwise.
+    pub fn to_sampler_binding_type(&self) -> BindingType {
+        let sampler_binding_type = if self.dimension.is_depth() {
+            SamplerBindingType::Comparison
+        } else {
+            SamplerBindingType::Filtering
+        };
+        BindingType::Sampler(sampler_binding_type)
+    }
+
+    /// Convert this slot to a WGSL texture type.
+    pub fn to_wgsl_texture_type(&self) -> String {
+        match self.dimension {
+            SlotDimension::D1 => "texture_1d<f32>",
+            SlotDimension::D2 => "texture_2d<f32>",
+            SlotDimension::D2Array => "texture_2d_array<f32>",
+            SlotDimension::D3 => "texture_3d<f32>",
+            SlotDimension::Cube => "texture_cube<f32>",
+            SlotDimension::CubeArray => "texture_cube_array<f32>",
+            SlotDimension::DepthD2 => "texture_depth_2d<f32>",
+            SlotDimension::DepthD2Array => "texture_depth_2d_array<f32>",
+            SlotDimension::DepthCube => "texture_depth_cube<f32>",
+            SlotDimension::DepthCubeArray => "texture_depth_cube_array<f32>",
+        }
+        .to_string()
+    }
+
+    /// Convert this slot to a WGSL sampler type.
+    ///
+    /// This returns `sampler_comparison` if [`SlotDimension::is_depth()`] is
+    /// `true`, or `sampler` otherwise.
+    pub fn to_wgsl_sampler_type(&self) -> String {
+        if self.dimension.is_depth() {
+            "sampler_comparison"
+        } else {
+            "sampler"
+        }
+        .to_string()
+    }
 }
 
 /// Texture layout.
@@ -757,6 +1006,72 @@ impl TextureLayout {
     /// to it.
     pub fn get_slot_by_name(&self, name: &str) -> Option<usize> {
         self.layout.iter().position(|slot| slot.name == name)
+    }
+
+    /// Check if the given texture is compatible with the given slot.
+    ///
+    /// This checks that the slot index is valid, and that
+    /// [`TextureSlot::accepts()`] is `true` for that slot.
+    pub fn is_compatible(&self, slot_index: u32, texture_descriptor: &TextureDescriptor) -> bool {
+        if slot_index >= self.layout.len() as u32 {
+            return false;
+        }
+        if texture_descriptor.sample_count > 1 {
+            // Multisampled textures not currently supported by Hanabi
+            return false;
+        }
+        let slot = &self.layout[slot_index as usize];
+        slot.accepts(
+            texture_descriptor.dimension,
+            texture_descriptor.array_layer_count(),
+            texture_descriptor.format.is_depth_stencil_format(),
+        )
+    }
+
+    /// Append the bindings for the textures described by this layout.
+    pub fn append_layout_bindings(
+        &self,
+        start_binding: u32,
+        entries: &mut Vec<BindGroupLayoutEntry>,
+    ) {
+        let mut bind_index = start_binding;
+        for slot in &self.layout {
+            let tex_index = bind_index;
+            let sampler_index = bind_index + 1;
+            entries.push(
+                slot.to_texture_binding_type()
+                    .into_bind_group_layout_entry_builder()
+                    .build(tex_index, ShaderStages::COMPUTE | ShaderStages::VERTEX),
+            );
+            entries.push(
+                slot.to_sampler_binding_type()
+                    .into_bind_group_layout_entry_builder()
+                    .build(sampler_index, ShaderStages::COMPUTE | ShaderStages::VERTEX),
+            );
+            bind_index += 2;
+        }
+    }
+
+    /// Generate the WGSL code for the material bindings of this layout.
+    pub fn to_wgsl_binding(&self, group_index: u32, start_index: u32) -> String {
+        if self.layout.is_empty() {
+            return String::new();
+        }
+        let mut code = String::with_capacity(160 * self.layout.len());
+        let mut bind_index = start_index;
+        for (slot_index, slot) in self.layout.iter().enumerate() {
+            let tex_index = bind_index;
+            let sampler_index = bind_index + 1;
+            let texture_type = slot.to_wgsl_texture_type();
+            let sampler_type = slot.to_wgsl_sampler_type();
+            code.push_str(&format!(
+                "@group({group_index}) @binding({tex_index}) var material_texture_{slot_index}: {texture_type};
+@group({group_index}) @binding({sampler_index}) var material_sampler_{slot_index}: {sampler_type};
+"
+            ));
+            bind_index += 2;
+        }
+        code
     }
 }
 
@@ -984,6 +1299,11 @@ impl EffectShaderSources {
             "@group(2) @binding(3) var<storage, read> properties : array<Properties>;".to_string()
         };
 
+        // Generate the shader code defining the material bindings for the simulation
+        // (init and update) passes. These occupy the @group(2) @binding(4..) range.
+        let texture_layout = asset.texture_layout();
+        let sim_material_bindings_code = texture_layout.to_wgsl_binding(2, 4);
+
         // Event buffer bindings for the update pass, if the effect emits GPU events to
         // one or more other effects.
         let mut emit_event_buffer_bindings_code = String::with_capacity(256);
@@ -1048,8 +1368,12 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
         // Generate the shader code for the initializing shader
         let (init_code, init_extra, init_sim_space_transform_code, consume_gpu_spawn_events) = {
             // Apply all the init modifiers
-            let mut init_context =
-                ShaderWriter::new(ModifierContext::Init, &property_layout, &particle_layout);
+            let mut init_context = ShaderWriter::new(
+                ModifierContext::Init,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             for m in asset.init_modifiers() {
                 if let Err(err) = m.apply(&mut module, &mut init_context) {
                     error!(
@@ -1086,6 +1410,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             .replace("{{INIT_EXTRA}}", &init_extra)
             .replace("{{PROPERTIES}}", &properties_code)
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
+            .replace("{{MATERIAL_BINDINGS}}", &sim_material_bindings_code)
             .replace(
                 "{{SIMULATION_SPACE_TRANSFORM_PARTICLE}}",
                 &init_sim_space_transform_code,
@@ -1098,8 +1423,12 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
 
         // Generate the shader code for the update shader
         let (mut update_code, update_extra, emit_gpu_spawn_events) = {
-            let mut update_context =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let mut update_context = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             for m in asset.update_modifiers() {
                 if let Err(err) = m.apply(&mut module, &mut update_context) {
                     error!(
@@ -1163,7 +1492,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             alpha_cutoff_code,
             flipbook_scale_code,
             flipbook_row_count_code,
-            material_bindings_code,
+            render_material_bindings_code,
         ) = {
             let texture_layout = module.texture_layout();
             let mut render_context =
@@ -1219,18 +1548,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
                 "Generating material bindings code for layout: {:?}",
                 texture_layout
             );
-            let mut material_bindings_code = String::new();
-            let mut bind_index = 0;
-            for (slot, _) in texture_layout.layout.iter().enumerate() {
-                let tex_index = bind_index;
-                let sampler_index = bind_index + 1;
-                material_bindings_code.push_str(&format!(
-                    "@group(3) @binding({tex_index}) var material_texture_{slot}: texture_2d<f32>;
-@group(3) @binding({sampler_index}) var material_sampler_{slot}: sampler;
-"
-                ));
-                bind_index += 2;
-            }
+            let material_bindings_code = texture_layout.to_wgsl_binding(3, 0);
 
             (
                 render_context.vertex_code,
@@ -1315,6 +1633,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             .replace("{{UPDATE_EXTRA}}", &update_extra)
             .replace("{{PROPERTIES}}", &properties_code)
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
+            .replace("{{MATERIAL_BINDINGS}}", &sim_material_bindings_code)
             .replace(
                 "{{EMIT_EVENT_BUFFER_BINDINGS}}",
                 &emit_event_buffer_bindings_code,
@@ -1336,7 +1655,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             .replace("{{INPUTS}}", &inputs_code)
             .replace("{{PROPERTIES}}", &properties_code)
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
-            .replace("{{MATERIAL_BINDINGS}}", &material_bindings_code)
+            .replace("{{MATERIAL_BINDINGS}}", &render_material_bindings_code)
             .replace("{{VERTEX_MODIFIERS}}", &vertex_code)
             .replace("{{FRAGMENT_MODIFIERS}}", &fragment_code)
             .replace("{{RENDER_EXTRA}}", &render_extra)
@@ -2080,31 +2399,48 @@ else { return c1; }
     fn test_simulation_space_eval() {
         let particle_layout = ParticleLayout::empty();
         let property_layout = PropertyLayout::default();
+        let texture_layout = TextureLayout::default();
         {
             // Local is always available
-            let ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_err());
 
             // Global requires storing the particle's position
             let particle_layout = ParticleLayout::new().append(Attribute::POSITION).build();
-            let ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_ok());
         }
         {
             // Local is always available
-            let ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_err());
 
             // Global requires storing the particle's position
             let particle_layout = ParticleLayout::new().append(Attribute::POSITION).build();
-            let ctx =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let ctx = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             assert!(SimulationSpace::Local.eval(&ctx).is_ok());
             assert!(SimulationSpace::Global.eval(&ctx).is_ok());
         }
@@ -2586,5 +2922,123 @@ else { return c1; }
                 assert!(compiled_particle_effect.effect_shader.is_some());
             }
         }
+    }
+
+    bitflags::bitflags! {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct LayerMatchFlags: u8 {
+            const EXACTLY_ONE = (1u8 << 0);
+            const ONE_OR_MORE = (1u8 << 1);
+            const EXACTLY_SIX = (1u8 << 2);
+            const MULTIPLE_OF_SIX = (1u8 << 3);
+        }
+    }
+
+    impl LayerMatchFlags {
+        pub fn accepts(&self, layer: u32) -> bool {
+            match *self {
+                Self::EXACTLY_ONE => layer == 1,
+                Self::ONE_OR_MORE => layer >= 1,
+                Self::EXACTLY_SIX => layer == 6,
+                Self::MULTIPLE_OF_SIX => layer.is_multiple_of(6),
+                _ => panic!(),
+            }
+        }
+    }
+
+    fn check_texslot(slot: &TextureSlot, accepts: (TextureDimension, LayerMatchFlags, bool)) {
+        for dim in [
+            TextureDimension::D1,
+            TextureDimension::D2,
+            TextureDimension::D3,
+        ] {
+            for layer in [1, 2, 6, 14, 18] {
+                for is_depth in [true, false] {
+                    let is_matching =
+                        (dim == accepts.0) && (is_depth == accepts.2) && accepts.1.accepts(layer);
+                    assert_eq!(
+                        slot.accepts(dim, layer, is_depth),
+                        is_matching,
+                        "Expected slot {slot:?} to accept={is_matching} for dim={dim:?}, layer={layer}, is_depth={is_depth}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn texslot_accepts() {
+        let slot_1d = TextureSlot {
+            name: "D1".to_string(),
+            dimension: SlotDimension::D1,
+        };
+        let accepts = (TextureDimension::D1, LayerMatchFlags::EXACTLY_ONE, false);
+        check_texslot(&slot_1d, accepts);
+
+        let slot_2d = TextureSlot {
+            name: "D2".to_string(),
+            dimension: SlotDimension::D2,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::EXACTLY_ONE, false);
+        check_texslot(&slot_2d, accepts);
+
+        let slot_2d_array = TextureSlot {
+            name: "D2Array".to_string(),
+            dimension: SlotDimension::D2Array,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::ONE_OR_MORE, false);
+        check_texslot(&slot_2d_array, accepts);
+
+        let slot_cube = TextureSlot {
+            name: "Cube".to_string(),
+            dimension: SlotDimension::Cube,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::EXACTLY_SIX, false);
+        check_texslot(&slot_cube, accepts);
+
+        let slot_cube_array = TextureSlot {
+            name: "CubeArray".to_string(),
+            dimension: SlotDimension::CubeArray,
+        };
+        let accepts = (
+            TextureDimension::D2,
+            LayerMatchFlags::MULTIPLE_OF_SIX,
+            false,
+        );
+        check_texslot(&slot_cube_array, accepts);
+
+        let slot_3d = TextureSlot {
+            name: "D3".to_string(),
+            dimension: SlotDimension::D3,
+        };
+        let accepts = (TextureDimension::D3, LayerMatchFlags::EXACTLY_ONE, false);
+        check_texslot(&slot_3d, accepts);
+
+        let slot_depth_2d = TextureSlot {
+            name: "DepthD2".to_string(),
+            dimension: SlotDimension::DepthD2,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::EXACTLY_ONE, true);
+        check_texslot(&slot_depth_2d, accepts);
+
+        let slot_depth_2d_array = TextureSlot {
+            name: "DepthD2Array".to_string(),
+            dimension: SlotDimension::DepthD2Array,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::ONE_OR_MORE, true);
+        check_texslot(&slot_depth_2d_array, accepts);
+
+        let slot_depth_cube = TextureSlot {
+            name: "DepthCube".to_string(),
+            dimension: SlotDimension::DepthCube,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::EXACTLY_SIX, true);
+        check_texslot(&slot_depth_cube, accepts);
+
+        let slot_depth_cube_array = TextureSlot {
+            name: "DepthCubeArray".to_string(),
+            dimension: SlotDimension::DepthCubeArray,
+        };
+        let accepts = (TextureDimension::D2, LayerMatchFlags::MULTIPLE_OF_SIX, true);
+        check_texslot(&slot_depth_cube_array, accepts);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,12 +1041,12 @@ impl TextureLayout {
             entries.push(
                 slot.to_texture_binding_type()
                     .into_bind_group_layout_entry_builder()
-                    .build(tex_index, ShaderStages::COMPUTE | ShaderStages::VERTEX),
+                    .build(tex_index, ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT),
             );
             entries.push(
                 slot.to_sampler_binding_type()
                     .into_bind_group_layout_entry_builder()
-                    .build(sampler_index, ShaderStages::COMPUTE | ShaderStages::VERTEX),
+                    .build(sampler_index, ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT),
             );
             bind_index += 2;
         }
@@ -1299,10 +1299,9 @@ impl EffectShaderSources {
             "@group(2) @binding(3) var<storage, read> properties : array<Properties>;".to_string()
         };
 
-        // Generate the shader code defining the material bindings for the simulation
-        // (init and update) passes. These occupy the @group(2) @binding(4..) range.
+        // Generate the shader code defining the material bindings. These occupy the @group(2) @binding(4..) range.
         let texture_layout = asset.texture_layout();
-        let sim_material_bindings_code = texture_layout.to_wgsl_binding(2, 4);
+        let material_bindings_code = texture_layout.to_wgsl_binding(2, 4);
 
         // Event buffer bindings for the update pass, if the effect emits GPU events to
         // one or more other effects.
@@ -1410,7 +1409,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             .replace("{{INIT_EXTRA}}", &init_extra)
             .replace("{{PROPERTIES}}", &properties_code)
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
-            .replace("{{MATERIAL_BINDINGS}}", &sim_material_bindings_code)
+            .replace("{{MATERIAL_BINDINGS}}", &material_bindings_code)
             .replace(
                 "{{SIMULATION_SPACE_TRANSFORM_PARTICLE}}",
                 &init_sim_space_transform_code,
@@ -1492,7 +1491,6 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             alpha_cutoff_code,
             flipbook_scale_code,
             flipbook_row_count_code,
-            render_material_bindings_code,
         ) = {
             let texture_layout = module.texture_layout();
             let mut render_context =
@@ -1544,12 +1542,6 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
                 (String::new(), String::new())
             };
 
-            trace!(
-                "Generating material bindings code for layout: {:?}",
-                texture_layout
-            );
-            let material_bindings_code = texture_layout.to_wgsl_binding(3, 0);
-
             (
                 render_context.vertex_code,
                 render_context.fragment_code,
@@ -1557,7 +1549,6 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
                 alpha_cutoff_code,
                 flipbook_scale_code,
                 flipbook_row_count_code,
-                material_bindings_code,
             )
         };
 
@@ -1633,7 +1624,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             .replace("{{UPDATE_EXTRA}}", &update_extra)
             .replace("{{PROPERTIES}}", &properties_code)
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
-            .replace("{{MATERIAL_BINDINGS}}", &sim_material_bindings_code)
+            .replace("{{MATERIAL_BINDINGS}}", &material_bindings_code)
             .replace(
                 "{{EMIT_EVENT_BUFFER_BINDINGS}}",
                 &emit_event_buffer_bindings_code,
@@ -1655,7 +1646,7 @@ fn append_spawn_events_{0}(base_child_index: u32, particle_index: u32, count: u3
             .replace("{{INPUTS}}", &inputs_code)
             .replace("{{PROPERTIES}}", &properties_code)
             .replace("{{PROPERTIES_BINDING}}", &properties_binding_code)
-            .replace("{{MATERIAL_BINDINGS}}", &render_material_bindings_code)
+            .replace("{{MATERIAL_BINDINGS}}", &material_bindings_code)
             .replace("{{VERTEX_MODIFIERS}}", &vertex_code)
             .replace("{{FRAGMENT_MODIFIERS}}", &fragment_code)
             .replace("{{RENDER_EXTRA}}", &render_extra)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,12 +1041,18 @@ impl TextureLayout {
             entries.push(
                 slot.to_texture_binding_type()
                     .into_bind_group_layout_entry_builder()
-                    .build(tex_index, ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT),
+                    .build(
+                        tex_index,
+                        ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT,
+                    ),
             );
             entries.push(
                 slot.to_sampler_binding_type()
                     .into_bind_group_layout_entry_builder()
-                    .build(sampler_index, ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT),
+                    .build(
+                        sampler_index,
+                        ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT,
+                    ),
             );
             bind_index += 2;
         }
@@ -1299,7 +1305,8 @@ impl EffectShaderSources {
             "@group(2) @binding(3) var<storage, read> properties : array<Properties>;".to_string()
         };
 
-        // Generate the shader code defining the material bindings. These occupy the @group(2) @binding(4..) range.
+        // Generate the shader code defining the material bindings. These occupy the
+        // @group(2) @binding(4..) range.
         let texture_layout = asset.texture_layout();
         let material_bindings_code = texture_layout.to_wgsl_binding(2, 4);
 

--- a/src/modifier/accel.rs
+++ b/src/modifier/accel.rs
@@ -311,7 +311,7 @@ impl Modifier for TangentAccelModifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ParticleLayout, Property, PropertyLayout, ToWgslString};
+    use crate::{ParticleLayout, Property, PropertyLayout, TextureLayout, ToWgslString};
 
     #[test]
     fn mod_accel() {
@@ -321,8 +321,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(modifier.apply(&mut module, &mut context).is_ok());
 
         assert!(context.main_code.contains(&accel.to_wgsl_string()));
@@ -333,12 +338,17 @@ mod tests {
         let mut module = Module::default();
         let property_layout = PropertyLayout::new(&[Property::new("my_prop", 3.)]);
         let particle_layout = ParticleLayout::default();
+        let texture_layout = TextureLayout::default();
 
         let origin = Vec3::new(-1.2, 5.3, -8.5);
         let accel = 6.;
         let modifier = RadialAccelModifier::constant(&mut module, origin, accel);
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(modifier.apply(&mut module, &mut context).is_ok());
         // TODO: less weak check...
         assert!(context.extra_code.contains(&accel.to_wgsl_string()));
@@ -347,8 +357,12 @@ mod tests {
         let my_prop = module.add_property("my_prop", 3.0.into());
         let accel = module.prop(my_prop);
         let modifier = RadialAccelModifier::new(origin, accel);
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(modifier.apply(&mut module, &mut context).is_ok());
         // TODO: less weak check...
         assert!(context.extra_code.contains(Attribute::POSITION.name()));
@@ -365,8 +379,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(modifier.apply(&mut module, &mut context).is_ok());
 
         // TODO: less weak check...

--- a/src/modifier/attr.rs
+++ b/src/modifier/attr.rs
@@ -209,7 +209,8 @@ impl Modifier for InheritAttributeModifier {
 mod tests {
     use super::SetAttributeModifier;
     use crate::{
-        Attribute, ExprError, ModifierContext, Module, ParticleLayout, PropertyLayout, ShaderWriter,
+        Attribute, ExprError, ModifierContext, Module, ParticleLayout, PropertyLayout,
+        ShaderWriter, TextureLayout,
     };
 
     #[test]
@@ -218,10 +219,15 @@ mod tests {
         let attr = Attribute::POSITION; // vec3<f32>
         let expr = module.lit(3.); // f32
         let attr = SetAttributeModifier::new(attr, expr);
-        let property_layout = PropertyLayout::empty();
-        let particle_layout = ParticleLayout::empty();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Init, &property_layout, &particle_layout);
+        let property_layout = PropertyLayout::default();
+        let particle_layout = ParticleLayout::default();
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(matches!(
             attr.eval(&mut module, &mut context),
             Err(ExprError::TypeError(_))

--- a/src/modifier/force.rs
+++ b/src/modifier/force.rs
@@ -301,7 +301,7 @@ impl Modifier for LinearDragModifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ParticleLayout, PropertyLayout};
+    use crate::{ParticleLayout, PropertyLayout, TextureLayout};
 
     #[test]
     fn mod_drag() {
@@ -310,8 +310,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(modifier.apply(&mut module, &mut context).is_ok());
 
         assert!(context.main_code.contains("3.5")); // TODO - less weak check

--- a/src/modifier/kill.rs
+++ b/src/modifier/kill.rs
@@ -277,7 +277,7 @@ impl Modifier for KillFrustumModifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ParticleLayout, PropertyLayout};
+    use crate::{ParticleLayout, PropertyLayout, TextureLayout};
 
     #[test]
     fn mod_kill_aabb() {
@@ -288,8 +288,13 @@ mod tests {
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
-        let mut context =
-            ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let texture_layout = TextureLayout::default();
+        let mut context = ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         assert!(modifier.apply(&mut module, &mut context).is_ok());
 
         assert!(context.main_code.contains("is_alive = false")); // TODO - less

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -858,9 +858,8 @@ pub fn register_modifiers(type_registry: &AppTypeRegistry) {
     });
 
     // output.rs
-    register_reflect_modifier::<ParticleTextureModifier>(type_registry, |module| {
-        let slot = module.lit(0u32);
-        Box::new(ParticleTextureModifier::new(slot))
+    register_reflect_modifier::<ParticleTextureModifier>(type_registry, |_| {
+        Box::new(ParticleTextureModifier::new(0))
     });
     register_reflect_modifier::<SetColorModifier>(type_registry, |_| {
         Box::new(SetColorModifier::new(Vec4::ONE))
@@ -915,6 +914,13 @@ pub fn register_modifiers(type_registry: &AppTypeRegistry) {
             height: module.lit(1.0),
             base_radius: module.lit(1.0),
             top_radius: module.lit(0.0),
+            dimension: ShapeDimension::Surface,
+        })
+    });
+    register_reflect_modifier::<SetPositionBoxModifier>(type_registry, |module| {
+        Box::new(SetPositionBoxModifier {
+            center: module.lit(Vec3::ZERO),
+            extent: module.lit(Vec3::ONE),
             dimension: ShapeDimension::Surface,
         })
     });
@@ -1319,10 +1325,9 @@ fn main() {{
 
     #[test]
     fn validate_render() {
-        let mut base_module = Module::default();
-        let slot_zero = base_module.lit(0u32);
+        let base_module = Module::default();
         let modifiers: &[&dyn RenderModifier] = &[
-            &ParticleTextureModifier::new(slot_zero),
+            &ParticleTextureModifier::new(0),
             &ColorOverLifetimeModifier::default(),
             &SizeOverLifetimeModifier::default(),
             &OrientModifier::new(OrientMode::ParallelCameraDepthPlane),

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -212,6 +212,8 @@ pub struct ShaderWriter<'a> {
     pub property_layout: &'a PropertyLayout,
     /// Layout of attributes of a particle for the current effect.
     pub particle_layout: &'a ParticleLayout,
+    /// Layout of textures for the current effect.
+    pub texture_layout: &'a TextureLayout,
     /// Modifier context the writer is being used from.
     modifier_context: ModifierContext,
     /// Counter for unique variable names.
@@ -230,12 +232,14 @@ impl<'a> ShaderWriter<'a> {
         modifier_context: ModifierContext,
         property_layout: &'a PropertyLayout,
         particle_layout: &'a ParticleLayout,
+        texture_layout: &'a TextureLayout,
     ) -> Self {
         Self {
             main_code: String::new(),
             extra_code: String::new(),
             property_layout,
             particle_layout,
+            texture_layout,
             modifier_context,
             var_counter: 0,
             expr_cache: Default::default(),
@@ -306,6 +310,10 @@ impl EvalContext for ShaderWriter<'_> {
         self.particle_layout
     }
 
+    fn texture_layout(&self) -> &TextureLayout {
+        self.texture_layout
+    }
+
     fn eval(&mut self, module: &Module, handle: ExprHandle) -> Result<String, ExprError> {
         // On cache hit, don't re-evaluate the expression to prevent any duplicate
         // side-effect.
@@ -343,6 +351,7 @@ impl EvalContext for ShaderWriter<'_> {
             self.modifier_context,
             self.property_layout,
             self.particle_layout,
+            self.texture_layout,
         )
         .with_attribute_pointer();
 
@@ -495,6 +504,10 @@ impl EvalContext for RenderContext<'_> {
         self.particle_layout
     }
 
+    fn texture_layout(&self) -> &TextureLayout {
+        self.texture_layout
+    }
+
     fn eval(&mut self, module: &Module, handle: ExprHandle) -> Result<String, ExprError> {
         // On cache hit, don't re-evaluate the expression to prevent any duplicate
         // side-effect.
@@ -616,6 +629,7 @@ macro_rules! impl_mod_render {
                 Err(ExprError::InvalidModifierContext(
                     context.modifier_context(),
                     ModifierContext::Render,
+                    "",
                 ))
             }
         }
@@ -1113,8 +1127,13 @@ mod tests {
             assert!(modifier.context().contains(ModifierContext::Init));
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut context =
-                ShaderWriter::new(ModifierContext::Init, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut context = ShaderWriter::new(
+                ModifierContext::Init,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             assert!(modifier.apply(&mut module, &mut context).is_ok());
             let main_code = context.main_code;
             let extra_code = context.extra_code;
@@ -1215,8 +1234,13 @@ fn main() {{
             assert!(modifier.context().contains(ModifierContext::Update));
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
-            let mut context =
-                ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+            let texture_layout = TextureLayout::default();
+            let mut context = ShaderWriter::new(
+                ModifierContext::Update,
+                &property_layout,
+                &particle_layout,
+                &texture_layout,
+            );
             assert!(modifier.apply(&mut module, &mut context).is_ok());
             let update_code = context.main_code;
             let update_extra = context.extra_code;
@@ -1421,12 +1445,20 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {{
         let mut module = Module::default();
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();
+        let texture_layout = TextureLayout::default();
         let x = module.builtin(BuiltInOperator::Rand(ScalarType::Float.into()));
-        let texture_layout = module.texture_layout();
-        let init: &mut dyn EvalContext =
-            &mut ShaderWriter::new(ModifierContext::Init, &property_layout, &particle_layout);
-        let update: &mut dyn EvalContext =
-            &mut ShaderWriter::new(ModifierContext::Update, &property_layout, &particle_layout);
+        let init: &mut dyn EvalContext = &mut ShaderWriter::new(
+            ModifierContext::Init,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
+        let update: &mut dyn EvalContext = &mut ShaderWriter::new(
+            ModifierContext::Update,
+            &property_layout,
+            &particle_layout,
+            &texture_layout,
+        );
         let render: &mut dyn EvalContext =
             &mut RenderContext::new(&property_layout, &particle_layout, &texture_layout);
         for ctx in [init, update, render] {

--- a/src/modifier/mod.rs
+++ b/src/modifier/mod.rs
@@ -1336,9 +1336,12 @@ fn main() {{
         ];
         for &modifier in modifiers.iter() {
             let mut module = base_module.clone();
+            module.add_texture_slot("tex", crate::SlotDimension::D2);
             let property_layout = PropertyLayout::default();
             let particle_layout = ParticleLayout::default();
             let texture_layout = module.texture_layout();
+            assert_eq!(texture_layout.layout.len(), 1);
+            let texture_bindinds = texture_layout.to_wgsl_binding(2, 4);
             let mut context =
                 RenderContext::new(&property_layout, &particle_layout, &texture_layout);
             modifier
@@ -1403,6 +1406,7 @@ struct VertexOutput {{
 }};
 
 @group(0) @binding(0) var<uniform> view: View;
+{texture_bindinds}
 
 {render_extra}
 
@@ -1435,11 +1439,10 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {{
             let res = frontend.parse(&code);
             if let Err(err) = &res {
                 println!(
-                    "Modifier: {:?}",
+                    "Modifier: {:?}\n",
                     modifier.get_represented_type_info().unwrap().type_path()
                 );
-                println!("Code: {:?}", code);
-                println!("Err: {:?}", err);
+                println!("Code: {code:?}\n\nError: {err:?}");
             }
             assert!(res.is_ok());
         }

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -725,15 +725,13 @@ axis_z = cross(axis_x, axis_y);
 ///     .expr();
 /// let update_sprite_index = SetAttributeModifier::new(Attribute::SPRITE_INDEX, sprite_index);
 ///
-/// let texture_slot = writer.lit(0u32).expr();
-///
 /// let asset = EffectAsset::new(32768, SpawnerSettings::once(32.0.into()), writer.finish())
 ///     .with_name("flipbook")
 ///     .init(init_age)
 ///     .init(init_lifetime)
 ///     .update(update_sprite_index)
 ///     .render(ParticleTextureModifier {
-///         texture_slot,
+///         texture_slot: 0,
 ///         sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
 ///     })
 ///     .render(FlipbookModifier {

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -952,9 +952,7 @@ mod tests {
     #[test]
     fn mod_particle_texture() {
         let mut module = Module::default();
-        let slot = module.lit(42u32);
-        // let texture = Handle::<Image>::default();
-        let modifier = ParticleTextureModifier::new(slot);
+        let modifier = ParticleTextureModifier::new(42);
 
         let property_layout = PropertyLayout::default();
         let particle_layout = ParticleLayout::default();

--- a/src/modifier/output.rs
+++ b/src/modifier/output.rs
@@ -72,7 +72,7 @@ pub struct ParticleTextureModifier {
     /// [`EffectMaterial`] component.
     ///
     /// [`EffectMaterial`]: crate::EffectMaterial
-    pub texture_slot: ExprHandle,
+    pub texture_slot: u32,
 
     /// The mapping of the texture image samples to the base particle color.
     pub sample_mapping: ImageSampleMapping,
@@ -80,7 +80,7 @@ pub struct ParticleTextureModifier {
 
 impl ParticleTextureModifier {
     /// Create a new modifier with the default [`ImageSampleMapping`].
-    pub fn new(texture_slot: ExprHandle) -> Self {
+    pub fn new(texture_slot: u32) -> Self {
         Self {
             texture_slot,
             sample_mapping: default(),
@@ -115,13 +115,11 @@ impl ParticleTextureModifier {
     /// Evaluate the modifier to generate the shader code.
     pub fn eval(
         &self,
-        module: &Module,
-        context: &mut dyn EvalContext,
+        _module: &Module,
+        _context: &mut dyn EvalContext,
     ) -> Result<String, ExprError> {
-        let texture_slot = module.try_get(self.texture_slot)?;
-        let texture_slot = texture_slot.eval(module, context)?;
-        let sample_mapping = self.sample_mapping.to_shader_code(&texture_slot[..]);
-
+        let texture_slot = self.texture_slot.to_string();
+        let sample_mapping = self.sample_mapping.to_shader_code(&texture_slot);
         let sample_mapping_name = format!("{:?}", self.sample_mapping);
 
         // Build a switch statement to select the texture/sampler.
@@ -131,17 +129,7 @@ impl ParticleTextureModifier {
         let mut code = String::with_capacity(1024);
         code += &format!(
             "    // ParticleTextureModifier
-    var texColor{texture_slot}: vec4<f32>;
-    switch ({texture_slot}) {{\n"
-        );
-        let count = module.texture_layout().layout.len() as u32;
-        for index in 0..count {
-            let wgsl_index = index.to_wgsl_string();
-            code += &format!("      case {wgsl_index}: {{ texColor{texture_slot} = textureSample(material_texture_{index}, material_sampler_{index}, uv); }}\n");
-        }
-        code += &format!("      default: {{ texColor{texture_slot} = vec4<f32>(0.0); }}\n");
-        code += &format!(
-            "    }}
+    var texColor{texture_slot} = textureSample(material_texture_{texture_slot}, material_sampler_{texture_slot}, uv);
     // Sample mapping: {sample_mapping_name}
     {sample_mapping}"
         );

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -168,8 +168,8 @@ pub(crate) struct EffectBatch {
     pub parent_binding_source: Option<BufferBindingSource>,
     /// Event buffers of child effects, if any.
     pub child_event_buffers: Vec<(Entity, BufferBindingSource)>,
-    /// Index of the property buffer, if any.
-    pub property_key: Option<PropertyBindGroupKey>,
+    /// Key for the "property" bind group (including textures).
+    pub property_key: PropertyBindGroupKey,
     /// Index of the first [`GpuSpawnerParams`] entry of the effects in the
     /// batch. Subsequent batched effects have their entries following linearly
     /// after that one.
@@ -745,7 +745,7 @@ impl EffectBatch {
         input: &mut BatchInput,
         draw_indirect_buffer_row_index: BufferTableId,
         metadata_table_id: BufferTableId,
-        property_key: Option<PropertyBindGroupKey>,
+        property_key: PropertyBindGroupKey,
     ) -> EffectBatch {
         assert_eq!(
             input.event_buffer_index.is_some(),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2706,7 +2706,7 @@ pub(crate) fn extract_effects(
                 "Instance of effect '{}' on entity {:?} is missing some textures. Layout expected {} textures, but CompiledParticleEffect got {} instead.",
                 asset.name,
                 main_entity,
-                num_expected_tex, 
+                num_expected_tex,
                 compiled_effect.textures.len()
             );
             continue;
@@ -2716,7 +2716,7 @@ pub(crate) fn extract_effects(
                 "Instance of effect '{}' on entity {:?} has too many textures. Layout expected {} textures, but CompiledParticleEffect got {} instead. Ignoring the extra ones.",
                 asset.name,
                 main_entity,
-                num_expected_tex, 
+                num_expected_tex,
                 compiled_effect.textures.len()
             );
             compiled_effect.textures[..num_expected_tex].to_vec()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2048,48 +2048,6 @@ impl SpecializedComputePipeline for ParticlesUpdatePipeline {
 #[derive(Resource)]
 pub(crate) struct ParticlesRenderPipeline {
     view_layout_desc: BindGroupLayoutDescriptor,
-    material_layout_descs: HashMap<TextureLayout, BindGroupLayoutDescriptor>,
-}
-
-impl ParticlesRenderPipeline {
-    /// Cache a material, creating its bind group layout based on the texture
-    /// layout.
-    pub fn cache_material(&mut self, layout: &TextureLayout) {
-        if layout.layout.is_empty() {
-            return;
-        }
-
-        // FIXME - no current stable API to insert an entry into a HashMap only if it
-        // doesn't exist, and without having to build a key (as opposed to a reference).
-        // So do 2 lookups instead, to avoid having to clone the layout if it's already
-        // cached (which should be the common case).
-        if self.material_layout_descs.contains_key(layout) {
-            return;
-        }
-
-        let mut entries = Vec::with_capacity(layout.layout.len() * 2);
-        layout.append_layout_bindings(0, &mut entries);
-        debug!(
-            "Creating material bind group with {} entries [{:?}] for layout {:?}",
-            entries.len(),
-            entries,
-            layout
-        );
-        let material_bind_group_layout_desc =
-            BindGroupLayoutDescriptor::new("hanabi:material_layout_render", &entries[..]);
-        self.material_layout_descs
-            .insert(layout.clone(), material_bind_group_layout_desc);
-    }
-
-    /// Retrieve a bind group layout for a cached material.
-    pub fn get_material(&self, layout: &TextureLayout) -> Option<&BindGroupLayoutDescriptor> {
-        // Prevent a hash and lookup for the trivial case of an empty layout
-        if layout.layout.is_empty() {
-            return None;
-        }
-
-        self.material_layout_descs.get(layout)
-    }
 }
 
 impl FromWorld for ParticlesRenderPipeline {
@@ -2109,7 +2067,6 @@ impl FromWorld for ParticlesRenderPipeline {
 
         Self {
             view_layout_desc,
-            material_layout_descs: default(),
         }
     }
 }
@@ -2206,19 +2163,15 @@ impl SpecializedRenderPipeline for ParticlesRenderPipeline {
             ),
         );
 
-        let mut layout = vec![
+        let layout = vec![
             self.view_layout_desc.clone(),
             particle_bind_group_layout_desc,
             key.spawner_bind_group_layout_desc.clone(),
         ];
+
         let mut shader_defs = vec![];
         if !key.texture_layout.layout.is_empty() {
             shader_defs.push("HAS_MATERIAL".into());
-            if let Some(material_bind_group_layout) = self.get_material(&key.texture_layout) {
-                layout.push(material_bind_group_layout.clone());
-            } else {
-                panic!("Failed to retrieve material bind group layout, cannot specialize render pipeline.");
-            }
         }
 
         let vertex_buffer_layout = key.mesh_layout.as_ref().and_then(|mesh_layout| {
@@ -2760,6 +2713,7 @@ pub(crate) fn extract_effects(
             compiled_effect.textures.len(),
             layout_flags,
         );
+        assert_eq!(texture_layout.layout.len(), compiled_effect.textures.len());
         let new_extracted_effect = ExtractedEffect {
             handle: compiled_effect.asset.clone(),
             particle_layout: asset.particle_layout().clone(),
@@ -3919,8 +3873,9 @@ pub fn prepare_init_update_pipelines(
             )
             .unwrap_or_else(|| {
                 panic!(
-                    "Failed to find spawner@2 bind group layout for property binding size {:?}",
+                    "Failed to find spawner@2 bind group layout for property binding size {:?} and texture layout {:?}",
                     property_layout_min_binding_size,
+                    extracted_effect.texture_layout,
                 )
             });
         trace!(
@@ -5167,8 +5122,6 @@ pub struct EffectBindGroups {
     /// update pass.
     // FIXME - doesn't work with batching; this should be the instance ID
     update_metadata_bind_groups: HashMap<SlabId, CachedBindGroup<UpdateMetadataBindGroupKey>>,
-    /// Map from an effect material to its bind group.
-    material_bind_groups: HashMap<Material, BindGroup>,
 }
 
 impl EffectBindGroups {
@@ -5496,9 +5449,6 @@ fn emit_sorted_draw<T, F>(
             #[cfg(feature = "trace")]
             _span_check_vis.exit();
 
-            // Create and cache the bind group layout for this texture layout
-            render_pipeline.cache_material(&effect_batch.texture_layout);
-
             // FIXME - We draw the entire batch, but part of it may not be visible in this
             // view! We should re-batch for the current view specifically!
 
@@ -5706,9 +5656,6 @@ fn emit_binned_draw<T, F, G>(
             }
             #[cfg(feature = "trace")]
             _span_check_vis.exit();
-
-            // Create and cache the bind group layout for this texture layout
-            render_pipeline.cache_material(&effect_batch.texture_layout);
 
             // FIXME - We draw the entire batch, but part of it may not be visible in this
             // view! We should re-batch for the current view specifically!
@@ -6430,7 +6377,6 @@ pub struct PipelineParams<'w, 's> {
     utils_pipeline: Res<'w, UtilsPipeline>,
     init_pipeline: Res<'w, ParticlesInitPipeline>,
     update_pipeline: Res<'w, ParticlesUpdatePipeline>,
-    render_pipeline: ResMut<'w, ParticlesRenderPipeline>,
     marker: PhantomData<&'s usize>,
 }
 
@@ -6478,7 +6424,6 @@ pub(crate) fn prepare_bind_groups(
     let utils_pipeline = pipelines.utils_pipeline.into_inner();
     let init_pipeline = pipelines.init_pipeline.into_inner();
     let update_pipeline = pipelines.update_pipeline.into_inner();
-    let render_pipeline = pipelines.render_pipeline.into_inner();
 
     // Ensure child_infos@3 bind group for the indirect pass is available if needed.
     // This returns `None` if the buffer is not ready, either because it's not
@@ -6655,27 +6600,6 @@ pub(crate) fn prepare_bind_groups(
             continue;
         }
 
-        // Also create a texture-less bind group for the render pass; in the render
-        // pass, textures from the effect's material are bound separately.
-        if effect_batch.property_key.has_textures() {
-            let property_key = effect_batch.property_key.for_render();
-            if let Err(err) = property_bind_groups.ensure_exists(
-                &property_key,
-                &property_cache,
-                &spawner_buffer,
-                &prefix_sum_buffer,
-                &effect_batch.texture_layout,
-                &effect_batch.textures[..],
-                &batch_info_buffer,
-                &render_device,
-                &pipeline_cache,
-                &gpu_images,
-            ) {
-                error!("Failed to create property bind group for effect batch: {err:?}");
-                continue;
-            }
-        }
-
         // Bind group particle@1 for the simulate compute shaders (init and udpate) to
         // simulate particles.
         if effect_cache
@@ -6806,54 +6730,6 @@ pub(crate) fn prepare_bind_groups(
                 continue;
             }
         }
-
-        // Ensure the particle texture(s) are available as GPU resources and that a bind
-        // group for them exists
-        // FIXME fix this insert+get below
-        if !effect_batch.texture_layout.layout.is_empty() {
-            // This should always be available, as this is cached into the render pipeline
-            // just before we start specializing it.
-            let Some(material_bind_group_layout_desc) =
-                render_pipeline.get_material(&effect_batch.texture_layout)
-            else {
-                error!(
-                    "Failed to find material bind group layout for particle slab #{}",
-                    effect_batch.slab_id.index()
-                );
-                continue;
-            };
-
-            // TODO = move
-            let material = Material {
-                layout: effect_batch.texture_layout.clone(),
-                textures: effect_batch.textures.iter().map(|h| h.id()).collect(),
-            };
-            assert_eq!(material.layout.layout.len(), material.textures.len());
-
-            let mut bind_group_entries = vec![];
-            if !material.append_binding_entries(0, &gpu_images, &mut bind_group_entries) {
-                trace!(
-                    "Temporarily ignoring material {:?} due to missing image(s)",
-                    material
-                );
-                continue;
-            };
-
-            effect_bind_groups
-                .material_bind_groups
-                .entry(material.clone())
-                .or_insert_with(|| {
-                    debug!("Creating material bind group for material {:?}", material);
-                    render_device.create_bind_group(
-                        &format!(
-                            "hanabi:material_bind_group_{}",
-                            material.layout.layout.len()
-                        )[..],
-                        &pipeline_cache.get_bind_group_layout(material_bind_group_layout_desc),
-                        &bind_group_entries[..],
-                    )
-                });
-        }
     }
 }
 
@@ -6955,26 +6831,6 @@ fn draw<'w>(
         &[],
     );
 
-    // Effect materials (textures and samplers)
-    // TODO = move
-    let material = Material {
-        layout: effect_batch.texture_layout.clone(),
-        textures: effect_batch.textures.iter().map(|h| h.id()).collect(),
-    };
-    let has_material = !effect_batch.texture_layout.layout.is_empty();
-    if has_material {
-        if let Some(bind_group) = effect_bind_groups.material_bind_groups.get(&material) {
-            pass.set_bind_group(3, bind_group, &[]);
-        } else {
-            // Texture(s) not ready; skip this drawing for now
-            trace!(
-                "Particle material bind group not available for batch slab_id={}. Skipping draw call.",
-                effect_batch.slab_id.index(),
-            );
-            return;
-        }
-    }
-
     let Some(indirect_buffer) = effects_meta.draw_indirect_args_buffer.buffer() else {
         trace!(
             "The draw indirect buffer containing the indirect draw args is not ready for batch slab_id=#{}. Skipping draw call.",
@@ -7013,12 +6869,9 @@ fn draw<'w>(
                 effect_batch.effect_data.len()
             );
             for effect_data in &effect_batch.effect_data {
-                // Get the key without any texture; for the render pass, textures are bound
-                // separately.
-                let key = effect_batch.property_key.for_render();
                 pass.set_bind_group(
                     2,
-                    property_bind_groups.get(&key, with_prefix_sum).unwrap(),
+                    property_bind_groups.get(&effect_batch.property_key, with_prefix_sum).unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
                 let draw_indirect_index = effect_data.draw_indirect_buffer_row_index.0;
@@ -7051,12 +6904,9 @@ fn draw<'w>(
                 effect_batch.effect_data.len()
             );
             for effect_data in &effect_batch.effect_data {
-                // Get the key without any texture; for the render pass, textures are bound
-                // separately.
-                let key = effect_batch.property_key.for_render();
                 pass.set_bind_group(
                     2,
-                    property_bind_groups.get(&key, with_prefix_sum).unwrap(),
+                    property_bind_groups.get(&effect_batch.property_key, with_prefix_sum).unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
                 let draw_indirect_index = effect_data.draw_indirect_buffer_row_index.0;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2068,26 +2068,7 @@ impl ParticlesRenderPipeline {
         }
 
         let mut entries = Vec::with_capacity(layout.layout.len() * 2);
-        let mut index = 0;
-        for _slot in &layout.layout {
-            entries.push(BindGroupLayoutEntry {
-                binding: index,
-                visibility: ShaderStages::FRAGMENT,
-                ty: BindingType::Texture {
-                    multisampled: false,
-                    sample_type: TextureSampleType::Float { filterable: true },
-                    view_dimension: TextureViewDimension::D2,
-                },
-                count: None,
-            });
-            entries.push(BindGroupLayoutEntry {
-                binding: index + 1,
-                visibility: ShaderStages::FRAGMENT,
-                ty: BindingType::Sampler(SamplerBindingType::Filtering),
-                count: None,
-            });
-            index += 2;
-        }
+        layout.append_layout_bindings(0, &mut entries);
         debug!(
             "Creating material bind group with {} entries [{:?}] for layout {:?}",
             entries.len(),
@@ -3931,7 +3912,11 @@ pub fn prepare_init_update_pipelines(
         let property_layout_min_binding_size =
             maybe_cached_properties.map(|cp| cp.property_layout.min_binding_size());
         let spawner_bind_group_layout_desc = property_cache
-            .bind_group_layout_desc(property_layout_min_binding_size, true)
+            .bind_group_layout_desc(
+                property_layout_min_binding_size,
+                true,
+                &extracted_effect.texture_layout,
+            )
             .unwrap_or_else(|| {
                 panic!(
                     "Failed to find spawner@2 bind group layout for property binding size {:?}",
@@ -4794,6 +4779,13 @@ pub(crate) fn batch_effects(
         // batch.
         let spawner_index = effects_meta.allocate_spawner(input.gpu_spawner_params);
 
+        let texture_layout = extracted_effect.texture_layout.clone();
+        let property_key = if let Some(cp) = cached_properties.as_ref() {
+            PropertyBindGroupKey::new(cp, texture_layout)
+        } else {
+            PropertyBindGroupKey::texture_only(texture_layout)
+        };
+
         // Create a single-effect batch candidate. It can be merged with the previous
         // batch if fully compatible.
         let mut effect_batch = EffectBatch::from_input(
@@ -4807,7 +4799,7 @@ pub(crate) fn batch_effects(
             &mut input,
             cached_draw_indirect_args.row,
             cached_effect_metadata.table_id,
-            cached_properties.map(Into::into),
+            property_key,
         );
 
         // If the batch has ribbons, we need to sort the particles by RIBBON_ID and AGE
@@ -4915,7 +4907,7 @@ pub(crate) fn batch_effects(
     {
         // Buffer was reallocated; clear all bind groups referencing the old buffer
         effect_bind_groups.particle_slabs.clear();
-        property_bind_groups.clear(true);
+        property_bind_groups.clear();
         effects_meta.indirect_spawner_bind_group = None;
     }
 
@@ -4923,7 +4915,7 @@ pub(crate) fn batch_effects(
     if batcher.write_batch_info_buffer(&render_device, &render_queue) {
         // Buffer was reallocated; clear all bind groups referencing the old buffer
         effect_bind_groups.particle_slabs.clear();
-        property_bind_groups.clear(true);
+        property_bind_groups.clear();
         effects_meta.indirect_spawner_bind_group = None;
         effects_meta.prefix_sum_bind_group = None;
     }
@@ -4932,7 +4924,7 @@ pub(crate) fn batch_effects(
     if batcher.write_prefix_sum_buffer(&render_device, &render_queue) {
         // Buffer was reallocated; clear all bind groups referencing the old buffer
         effect_bind_groups.particle_slabs.clear();
-        property_bind_groups.clear(true);
+        property_bind_groups.clear();
         effects_meta.indirect_spawner_bind_group = None;
         effects_meta.prefix_sum_bind_group = None;
     }
@@ -4985,40 +4977,49 @@ struct Material {
 
 impl Material {
     /// Get the bind group entries to create a bind group.
-    pub fn make_entries<'a>(
-        &self,
+    pub fn append_binding_entries<'a, 'b>(
+        &'b self,
+        binding_start: u32,
         gpu_images: &'a RenderAssets<GpuImage>,
-    ) -> Result<Vec<BindGroupEntry<'a>>, ()> {
-        if self.textures.is_empty() {
-            return Ok(vec![]);
+        entries: &'b mut Vec<BindGroupEntry<'a>>,
+    ) -> bool {
+        if self.layout.layout.len() != self.textures.len() {
+            return false;
         }
 
-        let entries: Vec<BindGroupEntry<'a>> = self
-            .textures
-            .iter()
-            .enumerate()
-            .flat_map(|(index, id)| {
-                let base_binding = index as u32 * 2;
-                if let Some(gpu_image) = gpu_images.get(*id) {
-                    vec![
-                        BindGroupEntry {
-                            binding: base_binding,
-                            resource: BindingResource::TextureView(&gpu_image.texture_view),
-                        },
-                        BindGroupEntry {
-                            binding: base_binding + 1,
-                            resource: BindingResource::Sampler(&gpu_image.sampler),
-                        },
-                    ]
-                } else {
-                    vec![]
-                }
-            })
-            .collect();
-        if entries.len() == self.textures.len() * 2 {
-            return Ok(entries);
+        if self.textures.is_empty() {
+            return true;
         }
-        Err(())
+
+        let mut index = binding_start;
+        for (slot, asset_id) in self.layout.layout.iter().zip(self.textures.iter()) {
+            let Some(gpu_image) = gpu_images.get(*asset_id) else {
+                return false;
+            };
+            if gpu_image.texture_descriptor.sample_count > 1 {
+                return false;
+            }
+            if !slot.accepts(
+                gpu_image.texture_descriptor.dimension,
+                gpu_image.texture_descriptor.array_layer_count(),
+                gpu_image
+                    .texture_descriptor
+                    .format
+                    .is_depth_stencil_format(),
+            ) {
+                return false;
+            }
+            entries.push(BindGroupEntry {
+                binding: index,
+                resource: BindingResource::TextureView(&gpu_image.texture_view),
+            });
+            entries.push(BindGroupEntry {
+                binding: index + 1,
+                resource: BindingResource::Sampler(&gpu_image.sampler),
+            });
+            index += 2;
+        }
+        true
     }
 }
 
@@ -5543,11 +5544,14 @@ fn emit_sorted_draw<T, F>(
             // have inserted any property in the cache, which would have allocated the
             // proper bind group layout (or the default no-property one).
             let has_multi_draw = false; // TODO?
-            let property_layout_min_binding_size = effect_batch
-                .property_key
-                .map(|key| NonZeroU64::new(key.binding_size as u64).unwrap());
+            let property_layout_min_binding_size =
+                NonZeroU64::new(effect_batch.property_key.binding_size as u64);
             let spawner_bind_group_layout_desc = property_cache
-                .bind_group_layout_desc(property_layout_min_binding_size, has_multi_draw)
+                .bind_group_layout_desc(
+                    property_layout_min_binding_size,
+                    has_multi_draw,
+                    &effect_batch.texture_layout,
+                )
                 .unwrap_or_else(|| {
                     panic!(
                         "Failed to find spawner@2 bind group layout for property binding size {:?}",
@@ -5749,11 +5753,14 @@ fn emit_binned_draw<T, F, G>(
             // have inserted any property in the cache, which would have allocated the
             // proper bind group layout (or the default no-property one).
             let has_multi_draw = false; // TODO?
-            let property_layout_min_binding_size = effect_batch
-                .property_key
-                .map(|key| NonZeroU64::new(key.binding_size as u64).unwrap());
+            let property_layout_min_binding_size =
+                NonZeroU64::new(effect_batch.property_key.binding_size as u64);
             let spawner_bind_group_layout_desc = property_cache
-                .bind_group_layout_desc(property_layout_min_binding_size, has_multi_draw)
+                .bind_group_layout_desc(
+                    property_layout_min_binding_size,
+                    has_multi_draw,
+                    &effect_batch.texture_layout,
+                )
                 .unwrap_or_else(|| {
                     panic!(
                         "Failed to find spawner@2 bind group layout for property binding size {:?}",
@@ -6632,29 +6639,41 @@ pub(crate) fn prepare_bind_groups(
         let _span_buffer = bevy::log::info_span!("create_batch_bind_groups").entered();
 
         // Create the property bind group @2 if needed
-        if let Some(property_key) = &effect_batch.property_key {
+        if let Err(err) = property_bind_groups.ensure_exists(
+            &effect_batch.property_key,
+            &property_cache,
+            &spawner_buffer,
+            &prefix_sum_buffer,
+            &effect_batch.texture_layout,
+            &effect_batch.textures[..],
+            &batch_info_buffer,
+            &render_device,
+            &pipeline_cache,
+            &gpu_images,
+        ) {
+            error!("Failed to create property bind group for effect batch: {err:?}");
+            continue;
+        }
+
+        // Also create a texture-less bind group for the render pass; in the render
+        // pass, textures from the effect's material are bound separately.
+        if effect_batch.property_key.has_textures() {
+            let property_key = effect_batch.property_key.for_render();
             if let Err(err) = property_bind_groups.ensure_exists(
-                property_key,
+                &property_key,
                 &property_cache,
                 &spawner_buffer,
                 &prefix_sum_buffer,
+                &effect_batch.texture_layout,
+                &effect_batch.textures[..],
                 &batch_info_buffer,
                 &render_device,
                 &pipeline_cache,
+                &gpu_images,
             ) {
                 error!("Failed to create property bind group for effect batch: {err:?}");
                 continue;
             }
-        } else if let Err(err) = property_bind_groups.ensure_exists_no_property(
-            &property_cache,
-            &spawner_buffer,
-            &prefix_sum_buffer,
-            &batch_info_buffer,
-            &render_device,
-            &pipeline_cache,
-        ) {
-            error!("Failed to create property bind group for effect batch: {err:?}");
-            continue;
         }
 
         // Bind group particle@1 for the simulate compute shaders (init and udpate) to
@@ -6811,8 +6830,8 @@ pub(crate) fn prepare_bind_groups(
             };
             assert_eq!(material.layout.layout.len(), material.textures.len());
 
-            //let bind_group_entries = material.make_entries(&gpu_images).unwrap();
-            let Ok(bind_group_entries) = material.make_entries(&gpu_images) else {
+            let mut bind_group_entries = vec![];
+            if !material.append_binding_entries(0, &gpu_images, &mut bind_group_entries) {
                 trace!(
                     "Temporarily ignoring material {:?} due to missing image(s)",
                     material
@@ -6994,11 +7013,12 @@ fn draw<'w>(
                 effect_batch.effect_data.len()
             );
             for effect_data in &effect_batch.effect_data {
+                // Get the key without any texture; for the render pass, textures are bound
+                // separately.
+                let key = effect_batch.property_key.for_render();
                 pass.set_bind_group(
                     2,
-                    property_bind_groups
-                        .get(effect_batch.property_key.as_ref(), with_prefix_sum)
-                        .unwrap(),
+                    property_bind_groups.get(&key, with_prefix_sum).unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
                 let draw_indirect_index = effect_data.draw_indirect_buffer_row_index.0;
@@ -7031,11 +7051,12 @@ fn draw<'w>(
                 effect_batch.effect_data.len()
             );
             for effect_data in &effect_batch.effect_data {
+                // Get the key without any texture; for the render pass, textures are bound
+                // separately.
+                let key = effect_batch.property_key.for_render();
                 pass.set_bind_group(
                     2,
-                    property_bind_groups
-                        .get(effect_batch.property_key.as_ref(), with_prefix_sum)
-                        .unwrap(),
+                    property_bind_groups.get(&key, with_prefix_sum).unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
                 let draw_indirect_index = effect_data.draw_indirect_buffer_row_index.0;
@@ -7395,7 +7416,7 @@ fn simulate(
             compute_pass.set_bind_group(
                 2,
                 property_bind_groups
-                    .get(effect_batch.property_key.as_ref(), true)
+                    .get(&effect_batch.property_key, true)
                     .unwrap(),
                 &[batch_info_offset],
             );
@@ -7636,7 +7657,7 @@ fn simulate(
             compute_pass.set_bind_group(
                 2,
                 property_bind_groups
-                    .get(effect_batch.property_key.as_ref(), true)
+                    .get(&effect_batch.property_key, true)
                     .unwrap(),
                 &[batch_info_offset],
             );

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2065,9 +2065,7 @@ impl FromWorld for ParticlesRenderPipeline {
             ),
         );
 
-        Self {
-            view_layout_desc,
-        }
+        Self { view_layout_desc }
     }
 }
 
@@ -2700,8 +2698,33 @@ pub(crate) fn extract_effects(
             .map(|(extracted_effect, b, c, d, e)| (Some(extracted_effect), b, c, d, e))
             .unwrap_or((None, None, None, None, None));
 
-        // Extract general effect data
+        // Validate material
         let texture_layout = asset.module().texture_layout();
+        let num_expected_tex = texture_layout.layout.len();
+        if compiled_effect.textures.len() < num_expected_tex {
+            error!(
+                "Instance of effect '{}' on entity {:?} is missing some textures. Layout expected {} textures, but CompiledParticleEffect got {} instead.",
+                asset.name,
+                main_entity,
+                num_expected_tex, 
+                compiled_effect.textures.len()
+            );
+            continue;
+        }
+        let textures = if compiled_effect.textures.len() > num_expected_tex {
+            trace!(
+                "Instance of effect '{}' on entity {:?} has too many textures. Layout expected {} textures, but CompiledParticleEffect got {} instead. Ignoring the extra ones.",
+                asset.name,
+                main_entity,
+                num_expected_tex, 
+                compiled_effect.textures.len()
+            );
+            compiled_effect.textures[..num_expected_tex].to_vec()
+        } else {
+            compiled_effect.textures.clone()
+        };
+
+        // Extract general effect data
         let layout_flags = compiled_effect.layout_flags;
         let alpha_mode = compiled_effect.alpha_mode;
         trace!(
@@ -2710,17 +2733,16 @@ pub(crate) fn extract_effects(
             main_entity,
             render_entity,
             texture_layout.layout.len(),
-            compiled_effect.textures.len(),
+            textures.len(),
             layout_flags,
         );
-        assert_eq!(texture_layout.layout.len(), compiled_effect.textures.len());
         let new_extracted_effect = ExtractedEffect {
             handle: compiled_effect.asset.clone(),
             particle_layout: asset.particle_layout().clone(),
             capacity: asset.capacity(),
             layout_flags,
             texture_layout,
-            textures: compiled_effect.textures.clone(),
+            textures,
             alpha_mode,
             effect_shaders: effect_shaders.clone(),
             simulation_condition: asset.simulation_condition,
@@ -6871,7 +6893,9 @@ fn draw<'w>(
             for effect_data in &effect_batch.effect_data {
                 pass.set_bind_group(
                     2,
-                    property_bind_groups.get(&effect_batch.property_key, with_prefix_sum).unwrap(),
+                    property_bind_groups
+                        .get(&effect_batch.property_key, with_prefix_sum)
+                        .unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
                 let draw_indirect_index = effect_data.draw_indirect_buffer_row_index.0;
@@ -6906,7 +6930,9 @@ fn draw<'w>(
             for effect_data in &effect_batch.effect_data {
                 pass.set_bind_group(
                     2,
-                    property_bind_groups.get(&effect_batch.property_key, with_prefix_sum).unwrap(),
+                    property_bind_groups
+                        .get(&effect_batch.property_key, with_prefix_sum)
+                        .unwrap(),
                     &[effect_data.render_batch_info_offset],
                 );
                 let draw_indirect_index = effect_data.draw_indirect_buffer_row_index.0;

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -4,28 +4,37 @@ use std::{
 };
 
 use bevy::{
+    asset::Handle,
     ecs::{lifecycle::Remove, observer::On, system::Commands, world::Mut},
+    image::Image,
     log::{error, trace},
-    platform::collections::{hash_map::Entry, HashMap},
+    platform::collections::{hash_map::EntryRef, HashMap},
     prelude::{Component, Entity, Query, Res, ResMut, Resource},
     render::{
+        render_asset::RenderAssets,
         render_resource::{
             binding_types::{storage_buffer_read_only, storage_buffer_read_only_sized},
             BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries, Buffer,
             PipelineCache, ShaderSize,
         },
         renderer::{RenderDevice, RenderQueue},
+        texture::GpuImage,
     },
+    utils::default,
 };
 use bytemuck::{cast_slice, Pod};
 use wgpu::{
-    BindingResource, BufferAddress, BufferBinding, BufferDescriptor, BufferUsages, ShaderStages,
+    BindGroupEntry, BindingResource, BufferAddress, BufferBinding, BufferDescriptor, BufferUsages,
+    ShaderStages,
 };
 
 use super::effect_cache::SlabState;
 use crate::{
-    render::{ExtractedProperties, GpuBatchInfo, GpuSpawnerParams, StorageType as _},
-    PropertyLayout,
+    render::{
+        ExtractedEffect, ExtractedProperties, GpuBatchInfo, GpuSpawnerParams, Material,
+        StorageType as _,
+    },
+    PropertyLayout, TextureLayout,
 };
 
 /// Allocation into the [`PropertyCache`] for an effect instance. This component
@@ -49,6 +58,7 @@ impl CachedEffectProperties {
         PropertyBindGroupKey {
             buffer_index: self.buffer_index,
             binding_size,
+            ..default()
         }
     }
 }
@@ -509,12 +519,25 @@ impl PropertyBuffer {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BindGroupLayoutKey {
     /// Binding size, in bytes, of the property block.
     pub binding_byte_size: u32,
     /// Is this binding using the prefix sum buffer?
     pub with_prefix_sum: bool,
+    /// Texture layout for the material bindings.
+    pub texture_layout: TextureLayout,
+}
+
+impl BindGroupLayoutKey {
+    /// Get the base variant, without any property nor texture.
+    fn base(with_prefix_sum: bool) -> Self {
+        Self {
+            binding_byte_size: 0,
+            with_prefix_sum,
+            texture_layout: TextureLayout::default(),
+        }
+    }
 }
 
 /// Cache for effect properties.
@@ -524,10 +547,11 @@ pub struct PropertyCache {
     /// be `None` if the entry is not used. Since the buffers are referenced
     /// by index, we cannot move them once they're allocated.
     buffers: Vec<Option<PropertyBuffer>>,
-    /// Map from a binding size in bytes to its bind group layout. The binding
-    /// size zero is valid, and corresponds to the variant without properties,
-    /// which by abuse is stored here even though it's not related to properties
-    /// (contains only the spawner binding).
+    /// Map from an effect layout (properties and material textures) to its bind
+    /// group layout. The binding size zero is valid, and corresponds to the
+    /// variant without properties, which by abuse is stored here even
+    /// though it's not related to properties (contains only the spawner
+    /// binding).
     bind_group_layout_descs: HashMap<BindGroupLayoutKey, BindGroupLayoutDescriptor>,
 }
 
@@ -551,7 +575,8 @@ impl PropertyCache {
         // the other depending on multi-draw availability. Technically we could skip the
         // no-prefix-sum variant if we're sure we always use multi-draw though.
 
-        // Create the default bind group layout when no properties are present
+        // Create the default bind group layout when no properties and no material
+        // textures are present.
         let bgl_prefix = BindGroupLayoutDescriptor::new(
             "hanabi:bgl:no_property",
             &BindGroupLayoutEntries::sequential(
@@ -587,20 +612,8 @@ impl PropertyCache {
             bgl_noprefix
         );
         let mut bind_group_layout_descs = HashMap::with_capacity_and_hasher(16, Default::default());
-        bind_group_layout_descs.insert(
-            BindGroupLayoutKey {
-                binding_byte_size: 0,
-                with_prefix_sum: true,
-            },
-            bgl_prefix,
-        );
-        bind_group_layout_descs.insert(
-            BindGroupLayoutKey {
-                binding_byte_size: 0,
-                with_prefix_sum: false,
-            },
-            bgl_noprefix,
-        );
+        bind_group_layout_descs.insert(BindGroupLayoutKey::base(true), bgl_prefix);
+        bind_group_layout_descs.insert(BindGroupLayoutKey::base(false), bgl_noprefix);
 
         Self {
             buffers: vec![],
@@ -624,51 +637,72 @@ impl PropertyCache {
         &self,
         min_binding_size: Option<NonZeroU64>,
         with_prefix_sum: bool,
+        texture_layout: &TextureLayout,
     ) -> Option<&BindGroupLayoutDescriptor> {
         let binding_byte_size = min_binding_size.map(NonZeroU64::get).unwrap_or(0) as u32;
         let key = BindGroupLayoutKey {
             binding_byte_size,
             with_prefix_sum,
+            texture_layout: texture_layout.clone(), // TODO - Q: Equivalent<K> to avoid clone
         };
         self.bind_group_layout_descs.get(&key)
     }
 
-    pub fn allocate(&mut self, property_layout: &PropertyLayout) -> CachedEffectProperties {
-        assert!(!property_layout.is_empty());
-
+    pub fn allocate(
+        &mut self,
+        property_layout: &PropertyLayout,
+        texture_layout: &TextureLayout,
+    ) -> CachedEffectProperties {
         // Ensure there's a bind group layout for the property variant with that binding
         // size.
-        let properties_min_binding_size = property_layout.min_binding_size();
+        let properties_min_binding_size = if property_layout.is_empty() {
+            0
+        } else {
+            property_layout.min_binding_size().get() as u32
+        };
         for with_prefix_sum in [false, true] {
-            // Get base layout that we will clone and modify
-            let mut key = BindGroupLayoutKey {
-                binding_byte_size: 0,
-                with_prefix_sum,
-            };
-            let mut bgl = self.bind_group_layout_descs.get(&key).unwrap().clone();
+            // Get the base layout that we will clone and modify
+            let base_key = BindGroupLayoutKey::base(with_prefix_sum);
+            let mut bgl = self.bind_group_layout_descs.get(&base_key).unwrap().clone();
 
-            // Make a layout for the given binding size if needed
-            key.binding_byte_size = properties_min_binding_size.get() as u32;
+            // Make a layout for the given binding size and texture layout if needed
+            let key = BindGroupLayoutKey {
+                binding_byte_size: properties_min_binding_size,
+                with_prefix_sum,
+                texture_layout: texture_layout.clone(), // TODO - Q: Equivalent<K> to avoid clone
+            };
             self.bind_group_layout_descs.entry(key).or_insert_with(|| {
                 let label = format!(
-                    "hanabi:bgl:property_size{}",
-                    properties_min_binding_size.get()
+                    "hanabi:bgl:property_size{}_tex{}",
+                    properties_min_binding_size,
+                    texture_layout.layout.len(),
                 );
                 trace!(
-                    "Create new property bind group layout '{}' for binding size {} bytes.",
+                    "Create new property bind group layout '{}' for binding size {} bytes with {} textures.",
                     label,
-                    properties_min_binding_size.get()
+                    properties_min_binding_size,
+                    texture_layout.layout.len(),
                 );
-                // Append the Properties array binding
                 bgl.label = label.into();
-                bgl.entries.push(
-                    storage_buffer_read_only_sized(false, Some(properties_min_binding_size))
-                        .build(3, ShaderStages::COMPUTE | ShaderStages::VERTEX),
-                );
+
+                // Append the Properties array binding
+                let mut start_binding = 3;
+                if properties_min_binding_size > 0 {
+                    bgl.entries.push(
+                        storage_buffer_read_only_sized(false, Some(NonZeroU64::new(properties_min_binding_size as u64).unwrap()))
+                            .build(start_binding, ShaderStages::COMPUTE | ShaderStages::VERTEX),
+                    );
+                    start_binding += 1;
+                }
+
+                // Append the texture bindings, if any
+                texture_layout.append_layout_bindings(start_binding, &mut bgl.entries);
+
                 trace!(
-                    "-> created bind group layout desc for size {}: {:?}",
-                    properties_min_binding_size.get(),
-                    bgl
+                    "-> created bind group layout desc for size {} with {} textures: {:?}",
+                    properties_min_binding_size,
+                    texture_layout.layout.len(),
+                    bgl,
                 );
                 bgl
             });
@@ -750,17 +784,58 @@ impl PropertyCache {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Bind group key for the effect batch "property" binding.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct PropertyBindGroupKey {
+    /// Index of the property buffer.
     pub buffer_index: u32,
+    /// Binding size, in bytes, of the property block. 0 means no property use.
     pub binding_size: u32,
+    /// Texture layout for the material binding points.
+    pub texture_layout: TextureLayout,
 }
 
-impl From<&CachedEffectProperties> for PropertyBindGroupKey {
-    fn from(value: &CachedEffectProperties) -> Self {
+// Note: use by HashMap to turn a key reference into an owned key when inserting
+// an entry. We use the same struct (even if we shouldn't, to avoid
+// TextureLayout cloning) for both.
+impl Into<PropertyBindGroupKey> for &PropertyBindGroupKey {
+    fn into(self) -> PropertyBindGroupKey {
+        self.clone()
+    }
+}
+
+impl PropertyBindGroupKey {
+    pub fn new(properties: &CachedEffectProperties, texture_layout: TextureLayout) -> Self {
         Self {
-            buffer_index: value.buffer_index,
-            binding_size: value.property_layout.min_binding_size().get() as u32,
+            buffer_index: properties.buffer_index,
+            binding_size: properties.property_layout.min_binding_size().get() as u32,
+            texture_layout,
+        }
+    }
+
+    /// Get a key for an effect without property.
+    pub fn texture_only(texture_layout: TextureLayout) -> Self {
+        Self {
+            buffer_index: 0,
+            binding_size: 0,
+            texture_layout,
+        }
+    }
+
+    pub fn has_properties(&self) -> bool {
+        self.binding_size > 0
+    }
+
+    pub fn has_textures(&self) -> bool {
+        !self.texture_layout.layout.is_empty()
+    }
+
+    /// Get the key without any texture; for the render pass, textures are bound
+    /// separately.
+    pub fn for_render(&self) -> Self {
+        Self {
+            texture_layout: default(),
+            ..*self
         }
     }
 }
@@ -770,33 +845,27 @@ pub struct PropertyBindGroups {
     /// Map from a [`PropertyBuffer`] index and a binding size to the
     /// corresponding bind group.
     property_bind_groups: HashMap<PropertyBindGroupKey, [BindGroup; 2]>,
-    /// Bind group for the variant without any property (without and with prefix
-    /// sum).
-    no_property_bind_groups: Option<[BindGroup; 2]>,
 }
 
 impl PropertyBindGroups {
-    /// Clear all bind groups.
-    ///
-    /// If `with_no_property` is `true`, also clear the no-property bind group,
-    /// which doesn't depend on any property buffer.
-    pub fn clear(&mut self, with_no_property: bool) {
+    /// Clear all cached bind groups.
+    pub fn clear(&mut self) {
         self.property_bind_groups.clear();
-        if with_no_property {
-            self.no_property_bind_groups = None;
-        }
     }
 
     fn make_bind_group(
         property_key: &PropertyBindGroupKey,
         property_cache: &PropertyCache,
         with_prefix_sum: bool,
+        texture_layout: &TextureLayout,
+        textures: &[Handle<Image>],
         spawner_buffer: &Buffer,
         prefix_sum_buffer: &Buffer,
         batch_info_buffer: &Buffer,
-        property_buffer: &Buffer,
+        property_buffer: Option<&Buffer>,
         render_device: &RenderDevice,
         pipeline_cache: &PipelineCache,
+        gpu_images: &RenderAssets<GpuImage>,
     ) -> Result<BindGroup, ()> {
         trace!(
             "Creating new spawner@2 bind group for property buffer #{} and binding size {} (w/ prefix sum: {})",
@@ -806,18 +875,70 @@ impl PropertyBindGroups {
         );
 
         // This should always be non-zero if the property key is Some().
-        let property_binding_size = NonZeroU64::new(property_key.binding_size as u64).unwrap();
-        let Some(layout_desc) =
-            property_cache.bind_group_layout_desc(Some(property_binding_size), with_prefix_sum)
-        else {
+        let property_binding_size = if property_key.has_properties() {
+            Some(NonZeroU64::new(property_key.binding_size as u64).unwrap())
+        } else {
+            None
+        };
+        let Some(layout_desc) = property_cache.bind_group_layout_desc(
+            property_binding_size,
+            with_prefix_sum,
+            texture_layout,
+        ) else {
             error!(
-                "Missing property bind group layout for binding size {}, referenced by effect batch.",
-                property_binding_size.get(),
+                "Missing property bind group layout for binding size {:?}, referenced by effect batch.",
+                property_binding_size,
             );
             return Err(());
         };
 
         let align = render_device.limits().min_storage_buffer_offset_alignment;
+
+        let mut entries;
+        if with_prefix_sum {
+            entries = (*BindGroupEntries::sequential((
+                spawner_buffer.as_entire_binding(),
+                prefix_sum_buffer.as_entire_binding(),
+                BufferBinding {
+                    buffer: batch_info_buffer,
+                    offset: 0,
+                    size: Some(GpuBatchInfo::aligned_size(align)),
+                },
+            )))
+            .to_vec();
+        } else {
+            entries = (*BindGroupEntries::with_indices((
+                (0, spawner_buffer.as_entire_binding()),
+                (
+                    1,
+                    BufferBinding {
+                        buffer: batch_info_buffer,
+                        offset: 0,
+                        size: Some(GpuBatchInfo::aligned_size(align)),
+                    },
+                ),
+            )))
+            .to_vec();
+        }
+        if let Some(property_buffer) = property_buffer {
+            // @group(2) @binding(3) var<storage, read> properties : array<Properties>
+            entries.push(BindGroupEntry {
+                binding: 3,
+                resource: property_buffer.as_entire_binding(),
+            });
+        }
+        // TODO = move
+        let material = Material {
+            layout: texture_layout.clone(),
+            textures: textures.iter().map(|h| h.id()).collect(),
+        };
+        assert_eq!(material.layout.layout.len(), material.textures.len());
+        material.append_binding_entries(4, &gpu_images, &mut entries);
+
+        trace!("Creating @2 bind group with {} entries:", entries.len());
+        for e in &entries {
+            trace!("+ {}: {:?}", e.binding, e.resource);
+        }
 
         let bind_group = if with_prefix_sum {
             render_device.create_bind_group(
@@ -828,16 +949,7 @@ impl PropertyBindGroups {
                     )[..],
                 ),
                 &pipeline_cache.get_bind_group_layout(layout_desc),
-                &BindGroupEntries::sequential((
-                    spawner_buffer.as_entire_binding(),
-                    prefix_sum_buffer.as_entire_binding(),
-                    BufferBinding {
-                        buffer: batch_info_buffer,
-                        offset: 0,
-                        size: Some(GpuBatchInfo::aligned_size(align)),
-                    },
-                    property_buffer.as_entire_binding(),
-                )),
+                &entries[..],
             )
         } else {
             render_device.create_bind_group(
@@ -848,18 +960,7 @@ impl PropertyBindGroups {
                     )[..],
                 ),
                 &pipeline_cache.get_bind_group_layout(layout_desc),
-                &BindGroupEntries::with_indices((
-                    (0, spawner_buffer.as_entire_binding()),
-                    (
-                        1,
-                        BufferBinding {
-                            buffer: batch_info_buffer,
-                            offset: 0,
-                            size: Some(GpuBatchInfo::aligned_size(align)),
-                        },
-                    ),
-                    (3, property_buffer.as_entire_binding()),
-                )),
+                &entries[..],
             )
         };
         Ok(bind_group)
@@ -872,127 +973,68 @@ impl PropertyBindGroups {
         property_cache: &PropertyCache,
         spawner_buffer: &Buffer,
         prefix_sum_buffer: &Buffer,
+        texture_layout: &TextureLayout,
+        textures: &[Handle<Image>],
         batch_info_buffer: &Buffer,
         render_device: &RenderDevice,
         pipeline_cache: &PipelineCache,
+        gpu_images: &RenderAssets<GpuImage>,
     ) -> Result<(), ()> {
-        let Some(property_buffer) = property_cache.get_buffer(property_key.buffer_index) else {
-            error!(
-                "Missing property buffer #{}, referenced by effect batch.",
-                property_key.buffer_index,
-            );
-            return Err(());
+        let property_buffer = if property_key.has_properties() {
+            let Some(property_buffer) = property_cache.get_buffer(property_key.buffer_index) else {
+                error!(
+                    "Missing property buffer #{}, referenced by effect batch.",
+                    property_key.buffer_index,
+                );
+                return Err(());
+            };
+            Some(property_buffer)
+        } else {
+            None
         };
 
-        match self.property_bind_groups.entry(*property_key) {
-            Entry::Vacant(entry) => {
+        match self.property_bind_groups.entry_ref(property_key) {
+            EntryRef::Vacant(entry) => {
                 let without = Self::make_bind_group(
                     property_key,
                     property_cache,
                     false,
+                    texture_layout,
+                    textures,
                     spawner_buffer,
                     prefix_sum_buffer,
                     batch_info_buffer,
                     property_buffer,
                     render_device,
                     pipeline_cache,
+                    gpu_images,
                 )?;
                 let with = Self::make_bind_group(
                     property_key,
                     property_cache,
                     true,
+                    texture_layout,
+                    textures,
                     spawner_buffer,
                     prefix_sum_buffer,
                     batch_info_buffer,
                     property_buffer,
                     render_device,
                     pipeline_cache,
+                    gpu_images,
                 )?;
                 entry.insert([without, with]);
             }
-            Entry::Occupied(_) => (),
+            EntryRef::Occupied(_) => (),
         };
-        Ok(())
-    }
-
-    /// Ensure the bind group for the given key exists, creating it if needed.
-    pub fn ensure_exists_no_property(
-        &mut self,
-        property_cache: &PropertyCache,
-        spawner_buffer: &Buffer,
-        prefix_sum_buffer: &Buffer,
-        batch_info_buffer: &Buffer,
-        render_device: &RenderDevice,
-        pipeline_cache: &PipelineCache,
-    ) -> Result<(), ()> {
-        if self.no_property_bind_groups.is_some() {
-            return Ok(());
-        }
-
-        let align = render_device.limits().min_storage_buffer_offset_alignment;
-        trace!("Creating new spawner@2 bind group for no-property variant");
-
-        // Variant with prefix sum (for init/update batched passes, and multi-draw
-        // rendering)
-        let Some(layout_desc) = property_cache.bind_group_layout_desc(None, true) else {
-            error!(
-                "Missing property bind group layout for no-property variant (w/ prefix), referenced by effect batch.",
-            );
-            return Err(());
-        };
-        let with = render_device.create_bind_group(
-            Some("hanabi:bg:spawner@2:no-property_md"),
-            &pipeline_cache.get_bind_group_layout(layout_desc),
-            &BindGroupEntries::sequential((
-                spawner_buffer.as_entire_binding(),
-                prefix_sum_buffer.as_entire_binding(),
-                BufferBinding {
-                    buffer: batch_info_buffer,
-                    offset: 0,
-                    size: Some(GpuBatchInfo::aligned_size(align)),
-                },
-            )),
-        );
-
-        // Variant without prefix sum (for single-draw rendering)
-        let Some(layout_desc) = property_cache.bind_group_layout_desc(None, false) else {
-            error!(
-                "Missing property bind group layout for no-property variant (w/o prefix), referenced by effect batch.",
-            );
-            return Err(());
-        };
-        let without = render_device.create_bind_group(
-            Some("hanabi:bg:spawner@2:no-property"),
-            &pipeline_cache.get_bind_group_layout(layout_desc),
-            &BindGroupEntries::sequential((
-                spawner_buffer.as_entire_binding(),
-                BufferBinding {
-                    buffer: batch_info_buffer,
-                    offset: 0,
-                    size: Some(GpuBatchInfo::aligned_size(align)),
-                },
-            )),
-        );
-
-        self.no_property_bind_groups = Some([without, with]);
         Ok(())
     }
 
     /// Get the bind group for the given key.
-    pub fn get(
-        &self,
-        key: Option<&PropertyBindGroupKey>,
-        with_prefix_sum: bool,
-    ) -> Option<&BindGroup> {
-        if let Some(key) = key {
-            self.property_bind_groups
-                .get(key)
-                .map(|arr| &arr[with_prefix_sum as usize])
-        } else {
-            self.no_property_bind_groups
-                .as_ref()
-                .map(|arr| &arr[with_prefix_sum as usize])
-        }
+    pub fn get(&self, key: &PropertyBindGroupKey, with_prefix_sum: bool) -> Option<&BindGroup> {
+        self.property_bind_groups
+            .get(key)
+            .map(|arr| &arr[with_prefix_sum as usize])
     }
 }
 
@@ -1037,6 +1079,7 @@ pub(crate) fn allocate_properties(
     mut property_cache: ResMut<PropertyCache>,
     mut q_effects: Query<(
         Entity,
+        &ExtractedEffect,
         &ExtractedProperties,
         Option<&mut CachedEffectProperties>,
     )>,
@@ -1045,7 +1088,9 @@ pub(crate) fn allocate_properties(
     let _span = bevy::log::info_span!("allocate_properties").entered();
     trace!("allocate_properties");
 
-    for (entity, extracted_properties, maybe_cached_effect_properties) in &mut q_effects {
+    for (entity, extracted_effect, extracted_properties, maybe_cached_effect_properties) in
+        &mut q_effects
+    {
         if let Some(mut cached_effect_properties) = maybe_cached_effect_properties {
             // Note: Technically we should compare the entire layout, but in practice the
             // allocation only cares about the size of the layout to store all properties,
@@ -1066,8 +1111,10 @@ pub(crate) fn allocate_properties(
                 if extracted_properties.property_layout.is_empty() {
                     commands.entity(entity).remove::<CachedEffectProperties>();
                 } else {
-                    *cached_effect_properties =
-                        property_cache.allocate(&extracted_properties.property_layout);
+                    *cached_effect_properties = property_cache.allocate(
+                        &extracted_properties.property_layout,
+                        &extracted_effect.texture_layout,
+                    );
                 }
             }
 
@@ -1084,8 +1131,10 @@ pub(crate) fn allocate_properties(
                 );
             }
         } else {
-            let cached_effect_properties =
-                property_cache.allocate(&extracted_properties.property_layout);
+            let cached_effect_properties = property_cache.allocate(
+                &extracted_properties.property_layout,
+                &extracted_effect.texture_layout,
+            );
             trace!("First-time properties, allocated a new CachedEffectProperties : {cached_effect_properties:?}");
             upload_properties(
                 extracted_properties,
@@ -1126,7 +1175,7 @@ pub(crate) fn on_remove_cached_properties(
             trace!("Destroying property bind group for key {key:?} due to property buffer deallocated.");
             property_bind_groups
                 .property_bind_groups
-                .retain(|&k, _| k.buffer_index != key.buffer_index);
+                .retain(|k, _| k.buffer_index != key.buffer_index);
         }
     }
 }
@@ -1149,7 +1198,7 @@ pub(crate) fn prepare_property_buffers(
             trace!("Destroying all bind groups for property buffer #{buffer_index}");
             bind_groups
                 .property_bind_groups
-                .retain(|&k, _| k.buffer_index != buffer_index as u32);
+                .retain(|k, _| k.buffer_index != buffer_index as u32);
         }
     }
 }

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -805,9 +805,9 @@ pub struct PropertyBindGroupKey {
 // Note: use by HashMap to turn a key reference into an owned key when inserting
 // an entry. We use the same struct (even if we shouldn't, to avoid
 // TextureLayout cloning) for both.
-impl Into<PropertyBindGroupKey> for &PropertyBindGroupKey {
-    fn into(self) -> PropertyBindGroupKey {
-        self.clone()
+impl From<&PropertyBindGroupKey> for PropertyBindGroupKey {
+    fn from(value: &PropertyBindGroupKey) -> Self {
+        value.clone()
     }
 }
 
@@ -833,6 +833,7 @@ impl PropertyBindGroupKey {
         self.binding_size > 0
     }
 
+    #[allow(dead_code)]
     pub fn has_textures(&self) -> bool {
         !self.texture_layout.layout.is_empty()
     }
@@ -892,9 +893,8 @@ impl PropertyBindGroups {
 
         let align = render_device.limits().min_storage_buffer_offset_alignment;
 
-        let mut entries;
-        if with_prefix_sum {
-            entries = (*BindGroupEntries::sequential((
+        let mut entries = if with_prefix_sum {
+            (*BindGroupEntries::sequential((
                 spawner_buffer.as_entire_binding(),
                 prefix_sum_buffer.as_entire_binding(),
                 BufferBinding {
@@ -903,9 +903,9 @@ impl PropertyBindGroups {
                     size: Some(GpuBatchInfo::aligned_size(align)),
                 },
             )))
-            .to_vec();
+            .to_vec()
         } else {
-            entries = (*BindGroupEntries::with_indices((
+            (*BindGroupEntries::with_indices((
                 (0, spawner_buffer.as_entire_binding()),
                 (
                     1,
@@ -916,8 +916,8 @@ impl PropertyBindGroups {
                     },
                 ),
             )))
-            .to_vec();
-        }
+            .to_vec()
+        };
         if let Some(property_buffer) = property_buffer {
             // @group(2) @binding(3) var<storage, read> properties : array<Properties>
             entries.push(BindGroupEntry {
@@ -931,7 +931,7 @@ impl PropertyBindGroups {
             textures: textures.iter().map(|h| h.id()).collect(),
         };
         assert_eq!(material.layout.layout.len(), material.textures.len());
-        material.append_binding_entries(4, &gpu_images, &mut entries);
+        material.append_binding_entries(4, gpu_images, &mut entries);
 
         trace!("Creating @2 bind group with {} entries:", entries.len());
         for e in &entries {

--- a/src/render/property.rs
+++ b/src/render/property.rs
@@ -5,7 +5,7 @@ use std::{
 
 use bevy::{
     asset::Handle,
-    ecs::{lifecycle::Remove, observer::On, system::Commands, world::Mut},
+    ecs::{lifecycle::Remove, observer::On, query::Without, system::Commands, world::Mut},
     image::Image,
     log::{error, trace},
     platform::collections::{hash_map::EntryRef, HashMap},
@@ -473,6 +473,7 @@ impl PropertyBuffer {
         // needs to be large enough to host at least one struct when bound to a shader,
         // and in WGSL the struct is padded to its align size.
         let size = layout.min_binding_size().get() as u32;
+        assert!(size > 0);
 
         // For now, we expand a single buffer infinitely. TODO to add a limit...
         let offset = self.alloc_aligned(size);
@@ -648,13 +649,13 @@ impl PropertyCache {
         self.bind_group_layout_descs.get(&key)
     }
 
-    pub fn allocate(
+    /// Ensure there's a bind group layout for the property variant with that
+    /// binding size and the given texture layout.
+    pub fn ensure_layout_exists(
         &mut self,
         property_layout: &PropertyLayout,
         texture_layout: &TextureLayout,
-    ) -> CachedEffectProperties {
-        // Ensure there's a bind group layout for the property variant with that binding
-        // size.
+    ) {
         let properties_min_binding_size = if property_layout.is_empty() {
             0
         } else {
@@ -686,17 +687,15 @@ impl PropertyCache {
                 bgl.label = label.into();
 
                 // Append the Properties array binding
-                let mut start_binding = 3;
                 if properties_min_binding_size > 0 {
                     bgl.entries.push(
                         storage_buffer_read_only_sized(false, Some(NonZeroU64::new(properties_min_binding_size as u64).unwrap()))
-                            .build(start_binding, ShaderStages::COMPUTE | ShaderStages::VERTEX),
+                            .build(3, ShaderStages::COMPUTE | ShaderStages::VERTEX | ShaderStages::FRAGMENT),
                     );
-                    start_binding += 1;
                 }
 
                 // Append the texture bindings, if any
-                texture_layout.append_layout_bindings(start_binding, &mut bgl.entries);
+                texture_layout.append_layout_bindings(4, &mut bgl.entries);
 
                 trace!(
                     "-> created bind group layout desc for size {} with {} textures: {:?}",
@@ -707,6 +706,14 @@ impl PropertyCache {
                 bgl
             });
         }
+    }
+
+    pub fn allocate(
+        &mut self,
+        property_layout: &PropertyLayout,
+        texture_layout: &TextureLayout,
+    ) -> CachedEffectProperties {
+        self.ensure_layout_exists(property_layout, texture_layout);
 
         self.buffers
             .iter_mut()
@@ -828,15 +835,6 @@ impl PropertyBindGroupKey {
 
     pub fn has_textures(&self) -> bool {
         !self.texture_layout.layout.is_empty()
-    }
-
-    /// Get the key without any texture; for the render pass, textures are bound
-    /// separately.
-    pub fn for_render(&self) -> Self {
-        Self {
-            texture_layout: default(),
-            ..*self
-        }
     }
 }
 
@@ -980,6 +978,8 @@ impl PropertyBindGroups {
         pipeline_cache: &PipelineCache,
         gpu_images: &RenderAssets<GpuImage>,
     ) -> Result<(), ()> {
+        trace!("PropertyBindGroups::ensure_exists() key={property_key:?}");
+
         let property_buffer = if property_key.has_properties() {
             let Some(property_buffer) = property_cache.get_buffer(property_key.buffer_index) else {
                 error!(
@@ -1083,6 +1083,7 @@ pub(crate) fn allocate_properties(
         &ExtractedProperties,
         Option<&mut CachedEffectProperties>,
     )>,
+    q_noprop_effects: Query<&ExtractedEffect, Without<ExtractedProperties>>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("allocate_properties").entered();
@@ -1143,6 +1144,14 @@ pub(crate) fn allocate_properties(
             );
             commands.entity(entity).insert(cached_effect_properties);
         }
+    }
+
+    // For no-property bind groups, just ensure the layout exists because we will
+    // need it when creating the pipelines.
+    let empty_propert_layout = PropertyLayout::default();
+    for extracted_effect in &q_noprop_effects {
+        property_cache
+            .ensure_layout_exists(&empty_propert_layout, &extracted_effect.texture_layout);
     }
 }
 

--- a/src/render/vfx_init.wgsl
+++ b/src/render/vfx_init.wgsl
@@ -86,6 +86,7 @@ fn find_location_from_particle(update_particle_index: u32) -> EffectLocation {
 @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
 @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
 {{PROPERTIES_BINDING}}
+{{MATERIAL_BINDINGS}}
 
 // "metadata" group @3
 @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>;

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -50,11 +50,7 @@ struct VertexOutput {
 @group(2) @binding(1) var<storage, read> batch_info : BatchInfo;
 #endif
 {{PROPERTIES_BINDING}}
-
-// Per-effect bindings
-#ifdef HAS_MATERIAL
 {{MATERIAL_BINDINGS}}
-#endif
 
 /// The resolved effect and particle location.
 ///

--- a/src/render/vfx_render.wgsl
+++ b/src/render/vfx_render.wgsl
@@ -41,7 +41,6 @@ struct VertexOutput {
 
 #ifdef HAS_BATCHED_DRAW
 // Per-batch bindings
-// "spawner" group @2
 @group(2) @binding(0) var<storage, read> spawners : array<Spawner>;
 @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
 @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;

--- a/src/render/vfx_update.wgsl
+++ b/src/render/vfx_update.wgsl
@@ -113,6 +113,7 @@ fn transform_normal_simulation_to_world(sim_normal: vec3<f32>) -> vec3<f32> {
 @group(2) @binding(1) var<storage, read> prefix_sum : array<u32>;
 @group(2) @binding(2) var<storage, read> batch_info : BatchInfo;
 {{PROPERTIES_BINDING}}
+{{MATERIAL_BINDINGS}}
 
 // "metadata" group @3
 @group(3) @binding(0) var<storage, read_write> effect_metadatas : array<EffectMetadata>;


### PR DESCRIPTION
Add support for accessing most types of WGSL textures, both with filtering
(sampler in fragment shader) and without (direct value loading). The former
extends the existing `TextureSampleExpr` while the latter adds a new
`TextureLoadExpr`.

This change forces the `TextureSampleExpr` slot back into a CPU constant. To dynamically switch between texture, use an array texture with a `layer_index` expression instead.

Add a new `lut.rs` example showing how to use a `TextureLoadExpr` inside the
Update pass to read a 2D array texture used as a look-up table (LUT).