### PR TITLE
Fix double-free of GPU event buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where some GPU operations queued with a buffer reference could be reused
   after the buffer was reallocated, leading to use-after-free (stale data) on GPU.
+- Fixed a double-free of a GPU buffer when despawning a particle effect with a child effect. (#510)
 
 ## [0.19.0] 2026-06-27
 

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,16 @@ deny = [
     { name = "parley", deny-multiple-versions = true },
     { name = "glam", deny-multiple-versions = true },
     { name = "raw-window-handle", deny-multiple-versions = true },
+    # CVE-2026-77651
+    { name = "append-only-vec", version = ">=0.1.9, <0.1.10" },
+    { name = "arrayref", version = ">=0.3.10, <0.3.11" },
+    { name = "internment", version = ">=0.8.7, <0.8.8" },
+    { name = "proc-macro1" },
+    { name = "proc-macro-en" },
+    { name = "aovine" },
+    { name = "arone" },
+    { name = "aronenao" },
+    { name = "tinymember" },
 ]
 
 [sources]

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -773,10 +773,9 @@ equal to one."
 mod tests {
     use bevy::prelude::*;
 
-    use super::*;
+    use super::{Node as _, *};
     use crate::{
-        node::Node as _, EvalContext, ModifierContext, ParticleLayout, PropertyLayout,
-        ShaderWriter, TextureLayout,
+        EvalContext, ModifierContext, ParticleLayout, PropertyLayout, ShaderWriter, TextureLayout,
     };
 
     #[test]

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -773,7 +773,7 @@ equal to one."
 mod tests {
     use bevy::prelude::*;
 
-    use super::{Node as _, *};
+    use super::{Node, *};
     use crate::{
         EvalContext, ModifierContext, ParticleLayout, PropertyLayout, ShaderWriter, TextureLayout,
     };

--- a/src/render/event.rs
+++ b/src/render/event.rs
@@ -282,15 +282,24 @@ pub(crate) fn on_remove_cached_effect_events(
     trigger: On<Remove, CachedEffectEvents>,
     query: Query<(Entity, &CachedEffectEvents)>,
     mut event_cache: ResMut<EventCache>,
+    mut effect_bind_groups: ResMut<EffectBindGroups>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("on_remove_cached_effect_events").entered();
     trace!("on_remove_cached_effect_events");
 
-    if let Ok((entity, cached_effect_event)) = query.get(trigger.event().entity) {
-        // TODO - handle SlabState return value to invalidate property bind groups!!
-        if let Err(err) = event_cache.free(cached_effect_event) {
-            error!("Error while freeing cached events for effect {entity:?}: {err:?}");
+    if let Ok((entity, cached_effect_events)) = query.get(trigger.event().entity) {
+        match event_cache.free(cached_effect_events) {
+            Err(err) => {
+                error!("Error while freeing cached events for effect {entity:?}: {err:?}");
+            }
+            Ok(buffer_state) => {
+                if buffer_state != SlabState::Used {
+                    // Clear bind groups associated with the old buffer
+                    effect_bind_groups.init_metadata_bind_groups.clear();
+                    effect_bind_groups.update_metadata_bind_groups.clear();
+                }
+            }
         }
     };
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3223,17 +3223,9 @@ impl Default for LayoutFlags {
 /// indicates that the effect instance was despawned.
 pub(crate) fn on_remove_cached_effect(
     trigger: On<Remove, CachedEffect>,
-    query: Query<(
-        Entity,
-        &MainEntity,
-        &CachedEffect,
-        Option<&CachedEffectProperties>,
-        Option<&CachedParentInfo>,
-        Option<&CachedEffectEvents>,
-    )>,
+    query: Query<(Entity, &MainEntity, &CachedEffect)>,
     mut effect_cache: ResMut<EffectCache>,
     mut effect_bind_groups: ResMut<EffectBindGroups>,
-    mut event_cache: ResMut<EventCache>,
 ) {
     #[cfg(feature = "trace")]
     let _span = bevy::log::info_span!("on_remove_cached_effect").entered();
@@ -3243,33 +3235,9 @@ pub(crate) fn on_remove_cached_effect(
 
     // Fecth the components of the effect being destroyed. Note that the despawn
     // command above is not yet applied, so this query should always succeed.
-    let Ok((
-        render_entity,
-        main_entity,
-        cached_effect,
-        _opt_props,
-        _opt_parent,
-        opt_cached_effect_events,
-    )) = query.get(trigger.event().entity)
-    else {
+    let Ok((render_entity, main_entity, cached_effect)) = query.get(trigger.event().entity) else {
         return;
     };
-
-    // Dealllocate the effect slice in the event buffer, if any.
-    if let Some(cached_effect_events) = opt_cached_effect_events {
-        match event_cache.free(cached_effect_events) {
-            Err(err) => {
-                error!("Error while freeing effect event slice: {err:?}");
-            }
-            Ok(buffer_state) => {
-                if buffer_state != SlabState::Used {
-                    // Clear bind groups associated with the old buffer
-                    effect_bind_groups.init_metadata_bind_groups.clear();
-                    effect_bind_groups.update_metadata_bind_groups.clear();
-                }
-            }
-        }
-    }
 
     // Deallocate the effect slice in the GPU effect buffer, and if this was the
     // last slice, also deallocate the GPU buffer itself.

--- a/src/render/shader_contract_tests.rs
+++ b/src/render/shader_contract_tests.rs
@@ -1,9 +1,6 @@
 use std::{borrow::Cow, num::NonZeroU64};
 
-use bevy::{
-    prelude::Vec3,
-    render::{render_resource::*, renderer::RenderQueue},
-};
+use bevy::{prelude::Vec3, render::renderer::RenderQueue};
 use bytemuck::{cast_slice, Pod, Zeroable};
 use futures::channel::oneshot;
 use naga_oil::compose::{ComposableModuleDescriptor, Composer, NagaModuleDescriptor};


### PR DESCRIPTION
Fix a double-free when a particle effect emitting GPU spawn events is despawned. Both the observer for `On<Remove, CachedEffect>` and `On<Remove, CachedEffectEvent>` where freeing the entry from the event cache, even though only the second should have been. Removing the first invalid free fixes the double-free.

Fixes #510