### PR TITLE
Reduce the per-frame cost of compile_effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reduced the per-frame CPU cost of `compile_effects`. `EffectAsset::particle_layout()`
+  is no longer called for every effect each frame, only for those used as a parent, and
+  the maps resolving parents are skipped when none is declared. Advancing the per-effect
+  PRNG seed no longer builds a `StdRng`.
 - Batch same-effect instances. This greatly improves performance when using many instances
   of the same effect, by reducing the number of compute jobs dispatched to the GPU, and instead
   taking full advantage of all GPU threads to process the init/update of all particles in parallel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,6 @@ use bevy::{
         sync_world::SyncToRenderWorld,
     },
 };
-use rand::{RngExt as _, SeedableRng as _};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -2057,18 +2056,38 @@ fn compile_effects(
 ) {
     trace!("compile_effects: {} effect(s)", q_effects.iter().len());
 
+    // Which effects are declared as a parent by another one. Only a parent's
+    // layout is read below, and `EffectAsset::particle_layout()` allocates a
+    // new layout by walking every modifier and every expression of the asset.
+    let parents: HashSet<Entity> = q_effects
+        .iter()
+        .filter_map(|(_, _, _, _, parent, _)| parent.map(|p| p.entity))
+        .collect();
+
     // Loop over all existing effects and collect the valid ones. We do a separate
     // pass because we can't borrow mutably while doing a double lookup on the
     // query. This map is used to lookup valid parents, and filter out effects with
-    // a declared parent but unresolved parent asset.
-    let particle_layouts_and_parents: HashMap<Entity, (ParticleLayout, Option<Entity>)> = q_effects
-        .iter()
-        .filter_map(|(entity, effect, _, _, parent, _)| {
-            effects
-                .get(&effect.handle)
-                .map(|asset| (entity, (asset.particle_layout(), parent.map(|p| p.entity))))
-        })
-        .collect();
+    // a declared parent but unresolved parent asset. With no parent declared
+    // anywhere, neither this map nor the child map below is ever read.
+    let particle_layouts_and_parents: HashMap<Entity, (Option<ParticleLayout>, Option<Entity>)> =
+        if parents.is_empty() {
+            HashMap::default()
+        } else {
+            q_effects
+                .iter()
+                .filter_map(|(entity, effect, _, _, parent, _)| {
+                    effects.get(&effect.handle).map(|asset| {
+                        (
+                            entity,
+                            (
+                                parents.contains(&entity).then(|| asset.particle_layout()),
+                                parent.map(|p| p.entity),
+                            ),
+                        )
+                    })
+                })
+                .collect()
+        };
 
     // Count children
     let mut children: HashMap<Entity, Vec<Entity>> =
@@ -2098,7 +2117,8 @@ fn compile_effects(
 
             // Same for the parent asset, if any.
             let (parent_entity, parent_layout) = if let Some(parent) = &parent {
-                let Some((parent_layout, _)) = particle_layouts_and_parents.get(&parent.entity)
+                let Some((Some(parent_layout), _)) =
+                    particle_layouts_and_parents.get(&parent.entity)
                 else {
                     // There's a parent declared, but not found. Skip the current asset.
                     return None;
@@ -2156,8 +2176,12 @@ fn compile_effects(
             // is re-uploaded each frame, so if it's not changed every frame then
             // there's no randomness anymore, because the uses of the previous frame
             // are "forgotten".
-            let mut rng = rand::rngs::StdRng::seed_from_u64(compiled_effect.prng_seed as u64);
-            compiled_effect.prng_seed = rng.random();
+            // splitmix64, one step. The seed has to differ each frame; it does
+            // not have to be cryptographic.
+            let mut z = (compiled_effect.prng_seed as u64).wrapping_add(0x9E37_79B9_7F4A_7C15);
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            compiled_effect.prng_seed = (z ^ (z >> 31)) as u32;
         }
     }
 


### PR DESCRIPTION
## What
`compile_effects` runs over every effect every frame and does two things per
effect that it does not need to. Neither changes behaviour.

**`EffectAsset::particle_layout()` for every effect.** That method allocates a
`HashSet`, walks every modifier and its attributes, gathers attributes from the
expression graph, and builds a new `ParticleLayout`. The result is only read for
an effect that another declares as its parent, so it is now built only for
those. The two maps that resolve parents are skipped entirely when no effect
declares one.

**A `StdRng` per effect to advance the PRNG seed.** The seed has to change every
frame because it is not cached on the GPU, but it does not have to be
cryptographic. One splitmix64 step gives the same property.

`prng_seed` remains a `u32` that differs each frame per effect. Only how the
next value is derived has changed.

## Measurements
Timings are for the `compile_effects` system alone, from per-system tracing
spans, on a scene of ~2,100 live effect instances of 22 distinct assets, none
declaring an `EffectParent`. Release build, Windows 11, Ryzen 9 7950X, RTX 5090.
Median over ~425 frames.

| | `compile_effects` |
|---|---|
| before | 7.10 ms |
| after | 3.08 ms |

The whole-frame median moved 25.8 ms to 20.5 ms in that scene, though that
figure includes the rest of the application and is only indicative.

The saving scales with instance count and with how much work an asset's layout
costs to build, so a scene with few instances will see little. A scene where
effects do declare parents keeps paying for those parents, which is the case the
layout is needed for.

## What I have not tested
- Effects that declare an `EffectParent`. None exist in the scene measured, so
  the parent path is exercised only by the existing unit tests.
- GPU spawn events and ribbons, for the same reason.
- One adapter only (Vulkan / RTX 5090).