### PR TITLE
Fix stale opaque draw batch panic

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6779,7 +6779,10 @@ fn draw<'w>(
     let property_bind_groups = property_bind_groups.into_inner();
     let meshes = meshes.into_inner();
     let mesh_allocator = mesh_allocator.into_inner();
-    let effect_draw_batch = effect_draw_batches.get(entity.0).unwrap();
+    let Ok(effect_draw_batch) = effect_draw_batches.get(entity.0) else {
+        trace!("Effect draw batch no longer exists. Skipping draw call.");
+        return;
+    };
     let effect_batch = batcher.get(effect_draw_batch.effect_batch_index).unwrap();
 
     let Some(pipeline) = pipeline_cache.into_inner().get_render_pipeline(pipeline_id) else {


### PR DESCRIPTION
## Problem

An `Opaque3d` phase item can outlive its temporary effect draw-batch entity after an effect is despawned. `draw()` unwraps that stale entity lookup and panics in the render thread.

## Fix

Skip the draw call when its effect draw batch no longer exists. Live batches continue through the existing draw path.

## Testing

- `cargo test --lib render::tests --all-features`
- `cargo test --lib --all-features`

Fixes #557
